### PR TITLE
Fix worktree dev status routing

### DIFF
--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -63,7 +63,7 @@ checkout.
 | Path | Contents |
 |------|----------|
 | `.env` | Allocated port, service URL, generated dev token |
-| `.pc_env` | The same values plus `PC_SOCKET_PATH`, read by process-compose at startup |
+| `.pc_env` | The same values plus `PC_SOCKET_PATH`, loaded by `bin/dev` before every process-compose command |
 | `.gander/config.json` | Repo-local app config — registered repos |
 | `.gander/gander.db` | Review state (checkoffs, snapshots) |
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,20 +1,56 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# process-compose reads .pc_env at startup and picks up PC_SOCKET_PATH, which
-# outport writes with a per-instance value. That auto-enables UDS mode with a
-# unique socket per worktree — no flags needed here.
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+PC_ENV_FILE="$SCRIPT_ROOT/.pc_env"
 
-cd "$(dirname "$0")/.."
+main() {
+  cd "$SCRIPT_ROOT"
+  load_worktree_env
 
-case "${1:-}" in
-  -D)        shift; process-compose up -D "$@" ;;
-  stop)      process-compose down ;;
-  status)
-    fmt="--output wide"; [[ "${2:-}" == "--json" ]] && fmt="--output json"
-    process-compose process list $fmt 2>/dev/null || { echo "Dev environment is not running. Start it with: bin/dev"; exit 1; }
-    ;;
-  logs)      process-compose process logs "${2:?specify a service}" ;;
-  restart)   process-compose process restart "${2:?specify a service}" ;;
-  *)         process-compose up "$@" ;;
-esac
+  case "${1:-}" in
+    -D)        shift; process-compose up -D "$@" ;;
+    stop)      process-compose down ;;
+    status)    show_status "${2:-}" ;;
+    logs)      process-compose process logs "${2:?specify a service}" ;;
+    restart)   process-compose process restart "${2:?specify a service}" ;;
+    *)         process-compose up "$@" ;;
+  esac
+}
+
+fail() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+load_worktree_env() {
+  [[ -f "$PC_ENV_FILE" ]] || fail "$PC_ENV_FILE is missing. Run bin/setup first."
+
+  # Load the generated environment ourselves instead of relying on
+  # process-compose's implicit dotenv discovery. This makes every command use
+  # the socket belonging to this worktree, regardless of its caller's cwd or
+  # environment.
+  set -a
+  # shellcheck disable=SC1090
+  source "$PC_ENV_FILE"
+  set +a
+
+  [[ -n "${PC_SOCKET_PATH:-}" ]] || fail "PC_SOCKET_PATH is missing from $PC_ENV_FILE. Run bin/setup first."
+}
+
+show_status() {
+  local format="${1:-}"
+  local -a output_args=(--output wide)
+  [[ "$format" == "--json" ]] && output_args=(--output json)
+
+  local output
+  if ! output="$(process-compose process list "${output_args[@]}")"; then
+    printf 'Dev environment is not running or could not be reached. Start it with: bin/dev\n' >&2
+    return 1
+  fi
+
+  [[ -n "$output" ]] || fail "process-compose returned no process status. Check the worktree socket and restart with bin/dev."
+  printf '%s\n' "$output"
+}
+
+main "$@"

--- a/bin/dev.test.ts
+++ b/bin/dev.test.ts
@@ -1,0 +1,144 @@
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { platform } from "node:process";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const appRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+
+let tmpRoot: string;
+let repo: string;
+let fakeBin: string;
+let argsFile: string;
+let envFile: string;
+let env: NodeJS.ProcessEnv;
+
+type CommandResult = { status: number | null; output: string };
+
+function run(...args: string[]): CommandResult {
+  const result = spawnSync(join(repo, "bin/dev"), args, {
+    cwd: join(repo, "nested/directory"), env, encoding: "utf8",
+  });
+  return { status: result.status, output: `${result.stdout}${result.stderr}` };
+}
+
+function writeExecutable(path: string, contents: string): void {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "gander-dev-cli-test-"));
+  repo = join(tmpRoot, "gander");
+  fakeBin = join(tmpRoot, "bin");
+  argsFile = join(tmpRoot, "args");
+  envFile = join(tmpRoot, "env");
+
+  mkdirSync(join(repo, "bin"), { recursive: true });
+  mkdirSync(join(repo, "nested/directory"), { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
+  copyFileSync(join(appRoot, "bin/dev"), join(repo, "bin/dev"));
+  chmodSync(join(repo, "bin/dev"), 0o755);
+
+  writeFileSync(join(repo, ".pc_env"), [
+    "GANDER_PORT=4321",
+    "PC_SOCKET_PATH=/tmp/process-compose-gander-test.sock",
+    "",
+  ].join("\n"));
+
+  writeExecutable(join(fakeBin, "process-compose"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$DEV_TEST_ARGS_FILE"
+printf 'GANDER_PORT=%s\nPC_SOCKET_PATH=%s\n' \
+  "\${GANDER_PORT:-}" "\${PC_SOCKET_PATH:-}" > "$DEV_TEST_ENV_FILE"
+
+case "\${DEV_TEST_MODE:-success}" in
+  success)
+    if [[ " $* " == *" --output json "* ]]; then
+      printf '%s\n' '[{"name":"service","status":"Running"}]'
+    else
+      printf '%s\n' 'PID NAME STATUS' '123 service Running'
+    fi
+    ;;
+  empty) exit 0 ;;
+  error)
+    printf '%s\n' 'dial unix: connection refused' >&2
+    exit 7
+    ;;
+esac
+`);
+
+  env = {
+    ...process.env,
+    PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+    DEV_TEST_ARGS_FILE: argsFile,
+    DEV_TEST_ENV_FILE: envFile,
+    GANDER_PORT: "",
+    PC_SOCKET_PATH: "",
+  };
+});
+
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+describe.skipIf(platform === "win32")("bin/dev", () => {
+  it("loads the worktree environment and returns JSON status", () => {
+    const result = run("status", "--json");
+
+    expect(result.status, result.output).toBe(0);
+    expect(JSON.parse(result.output)).toEqual([{ name: "service", status: "Running" }]);
+    expect(readFileSync(argsFile, "utf8")).toBe("process\nlist\n--output\njson\n");
+    expect(readFileSync(envFile, "utf8")).toBe([
+      "GANDER_PORT=4321",
+      "PC_SOCKET_PATH=/tmp/process-compose-gander-test.sock",
+      "",
+    ].join("\n"));
+  });
+
+  it("returns the human-readable status by default", () => {
+    const result = run("status");
+
+    expect(result.status, result.output).toBe(0);
+    expect(result.output).toContain("123 service Running");
+    expect(readFileSync(argsFile, "utf8")).toBe("process\nlist\n--output\nwide\n");
+  });
+
+  it("preserves process-compose connection errors", () => {
+    env = { ...env, DEV_TEST_MODE: "error" };
+
+    const result = run("status", "--json");
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("dial unix: connection refused");
+    expect(result.output).toContain("Dev environment is not running or could not be reached");
+  });
+
+  it("rejects an empty successful status response", () => {
+    env = { ...env, DEV_TEST_MODE: "empty" };
+
+    const result = run("status", "--json");
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("process-compose returned no process status");
+  });
+
+  it("requires setup before contacting process-compose", () => {
+    unlinkSync(join(repo, ".pc_env"));
+
+    const result = run("status", "--json");
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("Run bin/setup first");
+  });
+
+  it("refuses to use process-compose without a worktree socket", () => {
+    writeFileSync(join(repo, ".pc_env"), "GANDER_PORT=4321\n");
+
+    const result = run("status", "--json");
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("PC_SOCKET_PATH is missing");
+    expect(existsSync(argsFile)).toBe(false);
+  });
+});

--- a/bin/setup
+++ b/bin/setup
@@ -61,12 +61,14 @@ if command -v outport > /dev/null 2>&1; then
 else
   echo "outport not found — falling back to the default port 8390."
   echo "Install: brew install steveclarke/tap/outport"
+  socket_id="$(printf '%s' "$PWD" | cksum | awk '{print $1}')"
   printf '%s\n' \
     'GANDER_PORT=8390' \
     'GANDER_SERVICE_URL=http://127.0.0.1:8390' \
     'MCP_INSPECTOR_CLIENT_PORT=6274' \
     'MCP_INSPECTOR_SANDBOX_PORT=6275' > .env
   cp .env .pc_env
+  printf 'PC_SOCKET_PATH=/tmp/process-compose-gander-%s.sock\n' "$socket_id" >> .pc_env
 fi
 
 # The service token is shared by both processes: the service authenticates with

--- a/outport.yml
+++ b/outport.yml
@@ -21,9 +21,9 @@ computed:
       - .env
       - .pc_env
 
-  # process-compose reads .pc_env before anything else. Setting this both enables
-  # UDS mode and gives each worktree its own control socket, so `bin/dev status`
-  # in one checkout never talks to another checkout's stack.
+  # bin/dev loads .pc_env before every process-compose command. Setting this
+  # both enables UDS mode and gives each worktree its own control socket, so a
+  # command in one checkout never talks to another checkout's stack.
   PC_SOCKET_PATH:
     value: "/tmp/process-compose-${project_name}${instance:+-${instance}}.sock"
     env_file: .pc_env

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -6,9 +6,10 @@ shell:
   shell_command: "bash"
   shell_argument: "-lc"
 
-# GANDER_PORT, GANDER_TOKEN and GANDER_SERVICE_URL come from .env / .pc_env,
-# which process-compose loads before anything starts. Paths are built from $PWD
-# rather than hardcoded, so a worktree keeps its own database and config.
+# GANDER_PORT, GANDER_TOKEN and GANDER_SERVICE_URL are generated in .env and
+# .pc_env. bin/dev loads .pc_env before invoking process-compose, which also
+# reads .env by default. Paths are built from $PWD rather than hardcoded, so a
+# worktree keeps its own database and config.
 
 processes:
   service:


### PR DESCRIPTION
## Summary

- load each checkout's generated `.pc_env` before every process-compose command so status, restart, logs, and shutdown target the correct worktree socket
- preserve process-compose connection errors and fail when status returns an empty successful response instead of silently reporting nothing
- require an explicit worktree socket and generate deterministic process-compose and app sockets in the no-Outport setup fallback
- add focused regression coverage for JSON and human status, socket routing, connection errors, empty responses, and incomplete setup

## Readiness

- simplify and code review: clean; added the missing-socket guard found during review
- adversarial review: clean after two cold passes
- resolved against current `master`, including the new `bin/gander` app-control socket
- finalize: clean

## Test plan

- `pnpm vitest run bin/dev.test.ts` — 6 passed
- `bash -n bin/dev bin/setup`
- `shellcheck bin/dev bin/setup`
- `pnpm test` — 17 files, 142 tests passed
- `pnpm typecheck` — all three workspace projects passed
- reran `bin/setup` and confirmed both `PC_SOCKET_PATH` and `GANDER_APP_SOCKET` are allocated for the isolated worktree
- started the exact merged tree with `bin/dev -D`, confirmed app/service/urls through `bin/dev status --json` with the service Ready, then stopped it
- confirmed a stopped stack now surfaces process-compose's socket error plus the actionable Gander message
