### PR TITLE
Package the review service for a host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ human reviews it. One window over every repo and pull request, a Monaco diff,
 hierarchical file checkoff, and a question pipeline that carries the reviewer's
 notes to coding agents over MCP.
 
+`docs/deploy.md` covers running the service on a host.
+
 `docs/superpowers/specs/2026-08-15-gander-design.md` is the approved, binding
 design spec — read it before changing behaviour. `docs/STATE.md` says where the
 project stands. Interface work and the agent reply channel are GitHub issues.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,17 @@
+# One service, one volume, one secret. See docs/deploy.md.
+services:
+  gander:
+    build:
+      context: .
+      dockerfile: packages/service/Dockerfile
+    restart: unless-stopped
+    environment:
+      # No default. The service refuses to start without it.
+      GANDER_TOKEN: ${GANDER_TOKEN:?set GANDER_TOKEN in .env}
+    ports:
+      - "${GANDER_PUBLISH_PORT:-8390}:8390"
+    volumes:
+      - gander-data:/data
+
+volumes:
+  gander-data:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,65 @@
+# Running the review service on a host
+
+The app derives everything it shows from Git and GitHub. The service holds the
+part you author: which files you have checked off, the content you checked them
+against, and your questions.
+
+Run it in a development checkout and that state lives on one machine, reachable
+only while a dev stack happens to be up. Run it on a host and a review is
+readable from any machine you review from, and agents reach your questions
+whether or not a window is open anywhere.
+
+One reviewer, one token. The service is not built to be internet-facing: put it
+on a private network or a VPN, or behind a proxy with an access rule.
+
+## Bring it up
+
+Docker and a host on your network are the only requirements.
+
+```bash
+git clone https://github.com/steveclarke/gander.git
+cd gander
+
+printf 'GANDER_TOKEN=%s\n' "$(openssl rand -hex 32)" > .env
+chmod 600 .env
+
+docker compose up -d --build
+curl -s http://127.0.0.1:8390/healthz     # {"ok":true,"version":"..."}
+```
+
+| Setting | Default | |
+|---|---|---|
+| `GANDER_TOKEN` | — | Required. Guards the API and the MCP endpoint alike |
+| `GANDER_PUBLISH_PORT` | `8390` | Host port, when 8390 is taken |
+
+The database is a SQLite file on the `gander-data` volume, at `/data/gander.db`.
+It is the only state; back up the volume and you have backed up every review.
+
+To update: `git pull && docker compose up -d --build`.
+
+## Point the app at it
+
+The app reads `GANDER_SERVICE_URL` and `GANDER_TOKEN` from the environment,
+falling back to `serviceUrl` and `serviceToken` in its config file. Either works;
+the environment wins.
+
+```bash
+GANDER_SERVICE_URL=https://gander.example.internal GANDER_TOKEN=… bin/dev
+```
+
+## Point an agent at it
+
+Agents read your questions over MCP at `/mcp` on the same service, with the same
+token. Registered once against a hosted service, rather than per checkout:
+
+```bash
+claude mcp add --transport http gander https://gander.example.internal/mcp \
+  --header "Authorization: Bearer $GANDER_TOKEN"
+```
+
+## Keep the details together
+
+The URL and the token are needed on every machine you review from, and by every
+agent you want reading your questions. Keep them in your password manager as one
+item, with the `claude mcp add` line written out — then setting up a new machine
+is reading one card rather than reconstructing a deployment.

--- a/packages/service/Dockerfile
+++ b/packages/service/Dockerfile
@@ -1,0 +1,43 @@
+# The review service, for a host that is not a development checkout.
+#
+# Runs the TypeScript sources under tsx, the same way the dev stack does. The
+# service is small and has no build step of its own; adding one here would mean
+# two ways to run the same code and one of them going stale.
+
+FROM node:24-slim AS deps
+
+# better-sqlite3 ships prebuilds for glibc Node; these are the fallback for a
+# platform without one.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3 make g++ \
+ && rm -rf /var/lib/apt/lists/*
+RUN corepack enable
+
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/service/package.json packages/service/
+RUN pnpm install --frozen-lockfile --filter @gander/service...
+
+FROM node:24-slim AS runtime
+RUN corepack enable
+WORKDIR /app
+
+COPY --from=deps /app/node_modules node_modules
+COPY --from=deps /app/packages/shared/node_modules packages/shared/node_modules
+COPY --from=deps /app/packages/service/node_modules packages/service/node_modules
+COPY package.json pnpm-workspace.yaml ./
+COPY packages/shared packages/shared
+COPY packages/service packages/service
+
+# The database is the only state, and it belongs to the volume rather than the image.
+ENV GANDER_HOST=0.0.0.0 \
+    GANDER_PORT=8390 \
+    GANDER_DB=/data/gander.db
+VOLUME ["/data"]
+EXPOSE 8390
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.GANDER_PORT??8390)+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["pnpm", "--filter", "@gander/service", "start"]

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "start": "tsx src/main.ts",
     "dev": "tsx src/main.ts",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
First half of #12. The service can now run somewhere other than a development
checkout.

- `packages/service/Dockerfile` — node:24-slim, sources run under tsx, database on a volume at `/data`, healthcheck on `/healthz`
- `compose.yml` — one service, one volume, `GANDER_TOKEN` required with no default
- `docs/deploy.md` — how anyone brings up their own instance and points the app and an agent at it

Verified against a running container: health, 401 without a token, 200 with it,
a question written and read back across a restart, and an MCP `initialize`
handshake.

## Still open on #12

Pointing the app at a hosted service is currently `GANDER_SERVICE_URL=… bin/dev`
— the dev stack always starts a local service and injects its own URL and token,
so there is no first-class "review against the host" mode yet. Also deferred:
publishing an image from CI, the version handshake, and the offline read cache.

https://claude.ai/code/session_014mnrLdA3iKT64p1Hum4y25