### PR TITLE
Expose all question states over MCP

### DIFF
--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -175,7 +175,7 @@ Run it in the repository being reviewed, not in this one. Two tools appear:
 
 | Tool | Purpose |
 |------|---------|
-| `get_review_questions` | Open questions for a repo + branch (or pull request number), with file and line |
+| `get_review_questions` | Open questions for a repo + branch (or pull request number), plus counts for every state; addressed and resolved questions can be included explicitly |
 | `mark_question_addressed` | Flags one as acted on, with an optional commit ref and note |
 
 Nothing over MCP resolves a question. That stays the reviewer's act, made by

--- a/packages/service/src/mcp.test.ts
+++ b/packages/service/src/mcp.test.ts
@@ -87,8 +87,12 @@ describe("MCP endpoint", () => {
     const openOnly = JSON.parse(textOf((await client.callTool({
       name: "get_review_questions",
       arguments: { repo: "acme/atlas", branch: "feat/thing" },
-    })) as { content?: unknown })) as { questions: unknown[] };
+    })) as { content?: unknown })) as {
+      questionCounts: { open: number; addressed: number; resolved: number };
+      questions: unknown[];
+    };
     expect(openOnly.questions).toHaveLength(1);
+    expect(openOnly.questionCounts).toEqual({ open: 1, addressed: 1, resolved: 0 });
 
     const both = JSON.parse(textOf((await client.callTool({
       name: "get_review_questions",

--- a/packages/service/src/mcp.test.ts
+++ b/packages/service/src/mcp.test.ts
@@ -98,6 +98,39 @@ describe("MCP endpoint", () => {
     await client.close();
   });
 
+  it("explains when resolved questions are hidden and returns them when asked", async () => {
+    storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
+    const resolved = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: null, text: "handled", headSha: null });
+    storage.markQuestionAddressed(resolved.id, { commitRef: "abc1234", note: "Dropped the retry" });
+    storage.putFileState("acme/atlas", 7, {
+      checked: true, path: "a.rb", baseHash: "base", headHash: "head",
+      baseContent: "before", headContent: "after", machine: "studio",
+    });
+
+    const client = await connect();
+    const openOnly = JSON.parse(textOf((await client.callTool({
+      name: "get_review_questions",
+      arguments: { repo: "acme/atlas", branch: "feat/thing" },
+    })) as { content?: unknown })) as {
+      questionCounts: { open: number; addressed: number; resolved: number };
+      message: string;
+      questions: unknown[];
+    };
+    expect(openOnly.questions).toEqual([]);
+    expect(openOnly.questionCounts).toEqual({ open: 0, addressed: 0, resolved: 1 });
+    expect(openOnly.message).toBe("No open questions returned. 1 resolved question is hidden; pass includeResolved: true to retrieve it.");
+
+    const withResolved = JSON.parse(textOf((await client.callTool({
+      name: "get_review_questions",
+      arguments: { repo: "acme/atlas", branch: "feat/thing", includeResolved: true },
+    })) as { content?: unknown })) as { questions: Array<Record<string, unknown>> };
+    expect(withResolved.questions).toEqual([{
+      id: resolved.id, file: "a.rb", line: null, text: "handled", state: "resolved",
+      commitRef: "abc1234", note: "Dropped the retry", capturedAtSha: null, lineMayHaveMoved: false,
+    }]);
+    await client.close();
+  });
+
   it("marks a question addressed, and the state is really in storage", async () => {
     storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
     const q = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });

--- a/packages/service/src/mcp.ts
+++ b/packages/service/src/mcp.ts
@@ -31,6 +31,7 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
       description:
         "Questions the reviewer has left on a pull request, with the file and line each one is about. " +
         "Derive repo and branch from the working directory. Returns open questions by default — those are the ones still needing work. " +
+        "The response always counts open, addressed, and resolved questions so hidden states are visible. " +
         "The response names the branch, title, and stack position of the pull request the questions belong to: check it matches the checkout being worked in, " +
         "because a stacked pull request's sibling is a different branch with different questions.",
       inputSchema: {
@@ -38,29 +39,52 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
         branch: z.string().optional().describe("The working branch. Use this when the pull request number is unknown."),
         prNumber: z.number().int().positive().optional().describe("Pull request number, if known."),
         includeAddressed: z.boolean().optional().describe("Also return questions already marked addressed. Defaults to false."),
+        includeResolved: z.boolean().optional().describe("Also return questions the reviewer has resolved. Defaults to false."),
       },
     },
-    async ({ repo, branch, prNumber, includeAddressed }) => {
+    async ({ repo, branch, prNumber, includeAddressed, includeResolved }) => {
       const resolved = resolvePr(repo, prNumber, branch);
       if (typeof resolved === "string") return { content: [{ type: "text", text: resolved }], isError: true };
 
       const context = storage.getPrContext(repo, resolved);
       const members = context?.stackId == null ? [] : storage.listStackMembers(repo, context.stackId);
-      const wanted = includeAddressed === true ? ["open", "addressed"] : ["open"];
-      const questions = storage
-        .listQuestions(repo, resolved)
-        .filter((q) => wanted.includes(q.state))
+      const wanted = new Set(["open"]);
+      if (includeAddressed === true) wanted.add("addressed");
+      if (includeResolved === true) wanted.add("resolved");
+      const allQuestions = storage.listQuestions(repo, resolved);
+      const questionCounts: Record<"open" | "addressed" | "resolved", number> = { open: 0, addressed: 0, resolved: 0 };
+      for (const question of allQuestions) questionCounts[question.state] += 1;
+      const questions = allQuestions
+        .filter((q) => wanted.has(q.state))
         .map((q) => ({
           id: q.id,
           file: q.path,
           line: q.line,
           text: q.text,
           state: q.state,
+          ...(q.state === "open" ? {} : { commitRef: q.commitRef, note: q.note }),
           capturedAtSha: q.headSha,
           // The branch may have moved since the reviewer read it, in which case the line
           // number is the one they saw, not necessarily the one there now.
           lineMayHaveMoved: q.headSha !== null && context !== null && q.headSha !== context.headSha,
         }));
+
+      const hiddenStates = (["addressed", "resolved"] as const)
+        .filter((state) => !wanted.has(state) && questionCounts[state] > 0);
+      let message: string;
+      if (questions.length === 0 && hiddenStates.length === 1) {
+        const state = hiddenStates[0]!;
+        const count = questionCounts[state];
+        message = `No ${[...wanted].join(" or ")} questions returned. ${count} ${state} question${count === 1 ? " is" : "s are"} hidden; pass include${state[0]!.toUpperCase()}${state.slice(1)}: true to retrieve ${count === 1 ? "it" : "them"}.`;
+      } else if (questions.length === 0 && hiddenStates.length > 1) {
+        const hidden = hiddenStates.map((state) => `${questionCounts[state]} ${state}`).join(" and ");
+        const flags = hiddenStates.map((state) => `include${state[0]!.toUpperCase()}${state.slice(1)}: true`).join(" and ");
+        message = `No ${[...wanted].join(" or ")} questions returned. ${hidden} questions are hidden; pass ${flags} to retrieve them.`;
+      } else if (questions.length === 0 && allQuestions.length === 0) {
+        message = "No questions exist for this pull request.";
+      } else {
+        message = `Returned ${questions.length} of ${allQuestions.length} question${allQuestions.length === 1 ? "" : "s"} on this pull request.`;
+      }
 
       const payload = {
         repo,
@@ -69,6 +93,8 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
         branch: context?.headRef ?? null,
         title: context?.title ?? null,
         headSha: context?.headSha ?? null,
+        questionCounts,
+        message,
         stack: context?.stackSize == null || context.stackPosition == null
           ? null
           : {

--- a/packages/service/src/mcp.ts
+++ b/packages/service/src/mcp.ts
@@ -72,14 +72,14 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
       const hiddenStates = (["addressed", "resolved"] as const)
         .filter((state) => !wanted.has(state) && questionCounts[state] > 0);
       let message: string;
-      if (questions.length === 0 && hiddenStates.length === 1) {
-        const state = hiddenStates[0]!;
-        const count = questionCounts[state];
-        message = `No ${[...wanted].join(" or ")} questions returned. ${count} ${state} question${count === 1 ? " is" : "s are"} hidden; pass include${state[0]!.toUpperCase()}${state.slice(1)}: true to retrieve ${count === 1 ? "it" : "them"}.`;
-      } else if (questions.length === 0 && hiddenStates.length > 1) {
-        const hidden = hiddenStates.map((state) => `${questionCounts[state]} ${state}`).join(" and ");
-        const flags = hiddenStates.map((state) => `include${state[0]!.toUpperCase()}${state.slice(1)}: true`).join(" and ");
-        message = `No ${[...wanted].join(" or ")} questions returned. ${hidden} questions are hidden; pass ${flags} to retrieve them.`;
+      if (questions.length === 0 && hiddenStates.length > 0) {
+        const includeFlag = { addressed: "includeAddressed", resolved: "includeResolved" } as const;
+        const hiddenCount = hiddenStates.reduce((total, state) => total + questionCounts[state], 0);
+        const hidden = hiddenStates
+          .map((state) => `${questionCounts[state]} ${state} question${questionCounts[state] === 1 ? "" : "s"}`)
+          .join(" and ");
+        const flags = hiddenStates.map((state) => `${includeFlag[state]}: true`).join(" and ");
+        message = `No ${[...wanted].join(" or ")} questions returned. ${hidden} ${hiddenCount === 1 ? "is" : "are"} hidden; pass ${flags} to retrieve ${hiddenCount === 1 ? "it" : "them"}.`;
       } else if (questions.length === 0 && allQuestions.length === 0) {
         message = "No questions exist for this pull request.";
       } else {

--- a/packages/service/src/server.test.ts
+++ b/packages/service/src/server.test.ts
@@ -101,6 +101,22 @@ describe("service API", () => {
       expect((await server.inject({ method: "GET", url, headers: AUTH })).json()).toEqual([]);
     });
 
+    it("lists a resolved question with the agent's commit and note", async () => {
+      const question = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
+      storage.markQuestionAddressed(question.id, { commitRef: "abc1234", note: "Dropped the retry" });
+      storage.putFileState("acme/atlas", 7, {
+        checked: true, path: "a.rb", baseHash: "base", headHash: "head",
+        baseContent: "before", headContent: "after", machine: "studio",
+      });
+
+      const listed = await server.inject({ method: "GET", url, headers: AUTH });
+      expect(listed.json()).toEqual([
+        expect.objectContaining({
+          id: question.id, state: "resolved", commitRef: "abc1234", note: "Dropped the retry",
+        }),
+      ]);
+    });
+
     it("rejects an empty question rather than storing a blank note", async () => {
       const res = await server.inject({ method: "POST", url, headers: AUTH, payload: { path: "a.rb", line: null, text: "", headSha: null } });
       expect(res.statusCode).toBe(400);

--- a/packages/service/src/storage.test.ts
+++ b/packages/service/src/storage.test.ts
@@ -113,12 +113,14 @@ describe("storage", () => {
 
     it("refuses to re-address a question the reviewer already resolved", () => {
       const q = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
-      storage.markQuestionAddressed(q.id, { commitRef: null, note: null });
+      storage.markQuestionAddressed(q.id, { commitRef: "abc1234", note: "Dropped the retry" });
       storage.putFileState("acme/atlas", 7, {
         checked: true, path: "a.rb", baseHash: "b", headHash: "h",
         baseContent: "o", headContent: "n", machine: "m",
       });
-      expect(storage.listQuestions("acme/atlas", 7)[0]!.state).toBe("resolved");
+      expect(storage.listQuestions("acme/atlas", 7)[0]).toMatchObject({
+        state: "resolved", commitRef: "abc1234", note: "Dropped the retry",
+      });
       expect(storage.markQuestionAddressed(q.id, { commitRef: null, note: null })).toBeNull();
     });
 


### PR DESCRIPTION
## Summary
- add questionCounts and a plain message to get_review_questions so hidden states are visible
- add the optional includeResolved filter and return commitRef and note for requested non-open questions
- keep the two-tool MCP contract and reviewer-only resolution unchanged

## Contract
This is additive: includeResolved defaults to false; questionCounts contains open, addressed, and resolved; the existing questions array and default open-question objects retain their shape. Issue #2 can add replies to each question without changing these fields.

## Readiness
- simplify: clean
- code review: clean, one cleanup applied
- adversarial review: skipped as low risk
- finalize: clean

## Test plan
- focused storage, service API, and real MCP client tests: 45 passed
- pnpm test: 172 passed
- pnpm typecheck: passed
- bin/mcp check: MCP OK

Closes #16