### PR TITLE
Add question reply threads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,10 @@ reviewed", not "unchanged".
 **Question lifecycle:** `open` (reviewer captures with `n`) → `addressed` (agent,
 over MCP, with optional commit ref and note) → `resolved` (reviewer re-checks
 the file). Resolution is always the reviewer's act; no MCP tool may resolve
-anything. The MCP contract is deliberately two tools —
-`get_review_questions` and `mark_question_addressed`. Agents have `git` and `gh`
-for code; this contract carries only the reviewer's questions. Keep it small.
+anything. Replies form a thread without changing that lifecycle. The MCP
+contract is deliberately three tools — `get_review_questions`,
+`reply_to_question`, and `mark_question_addressed`. Agents have `git` and `gh`
+for code; this contract carries only the review conversation. Keep it small.
 
 `GANDER_SERVICE_URL` and `GANDER_TOKEN` override the config file at *connection*
 time, not load time (`resolveServiceConnection` in `main/config.ts`) — otherwise

--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -171,11 +171,12 @@ claude mcp add --transport http gander "$GANDER_SERVICE_URL/mcp" \
   --header "Authorization: Bearer $GANDER_TOKEN"
 ```
 
-Run it in the repository being reviewed, not in this one. Two tools appear:
+Run it in the repository being reviewed, not in this one. Three tools appear:
 
 | Tool | Purpose |
 |------|---------|
 | `get_review_questions` | Open questions for a repo + branch (or pull request number), with file and line |
+| `reply_to_question` | Adds an agent reply to a question without changing its lifecycle state |
 | `mark_question_addressed` | Flags one as acted on, with an optional commit ref and note |
 
 Nothing over MCP resolves a question. That stays the reviewer's act, made by

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -47,6 +47,10 @@ an agent has acted on one, and `resolved` when the reviewer re-checks the file.
 Agents reach them over MCP at `/mcp` on the review service — see `DEVSTACK.md`
 for registration.
 
+Questions also carry reply threads. Reviewer and agent replies remain attached
+to the question and do not change its lifecycle state; agents add replies with
+the dedicated MCP reply tool.
+
 Each opened pull request records its own branch, which is how the service maps an
 agent's working branch to a pull request without holding GitHub credentials.
 

--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -129,6 +129,20 @@ describe("Gander end to end", () => {
     await $("button[aria-label='Close settings']").click();
     await expect($(".diff .monaco-editor[data-mount-marker='preserved']")).toBeDisplayed();
 
+    await browser.keys("n");
+    const question = await $("textarea[placeholder='What needs answering or changing here?']");
+    await question.waitForDisplayed();
+    await question.setValue("Why does this need to happen here?");
+    await browser.keys("Enter");
+    await $("button[aria-label='Questions']").click();
+    await expect($(".message.original .text")).toHaveText("Why does this need to happen here?");
+
+    const reply = await $(".reply-form input");
+    await reply.setValue("Because both callers share this path.");
+    await browser.keys("Enter");
+    await expect($(".message.reply .author")).toHaveText("REVIEWER");
+    await expect($(".message.reply .text")).toHaveText("Because both callers share this path.");
+
     const checkbox = await fileCheckbox("a.rb");
     await checkbox.click();
     await expect(checkbox).toHaveAttribute("aria-checked", "true");
@@ -139,6 +153,8 @@ describe("Gander end to end", () => {
     await expect(browser).toHaveTitle("Gander");
     await expect($(".progress")).toHaveText("1/2 reviewed");
     await expect(await fileCheckbox("a.rb")).toHaveAttribute("aria-checked", "true");
+    await $("button[aria-label='Questions']").click();
+    await expect($(".message.reply .text")).toHaveText("Because both callers share this path.");
   });
 
   it("opens a pull request twice quickly with one valid clone", async () => {

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -17,6 +17,7 @@ export interface GanderApi {
   refreshPr(repoId: string, prNumber: number): Promise<PrView>;
   reviewedSnapshot(repoId: string, prNumber: number, path: string): Promise<string | null>;
   addQuestion(repoId: string, prNumber: number, input: Omit<NewQuestion, "headSha">): Promise<PrView>;
+  addReviewerReply(repoId: string, prNumber: number, id: number, text: string): Promise<PrView>;
   deleteQuestion(repoId: string, prNumber: number, id: number): Promise<PrView>;
   getSettings(): Promise<AppSettings>;
   updateSettings(settings: AppSettings): Promise<AppSettings>;

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -52,6 +52,7 @@ async function bootstrap(): Promise<GanderConfig> {
   ipcMain.handle("gander:setChecked", async (_e, repoId: string, n: number, path: string, checked: boolean) => reviewer.setChecked(repoId, n, path, checked));
   ipcMain.handle("gander:reviewedSnapshot", async (_e, repoId: string, n: number, path: string) => reviewer.reviewedSnapshot(repoId, n, path));
   ipcMain.handle("gander:addQuestion", async (_e, repoId: string, n: number, input: { path: string | null; line: number | null; text: string }) => reviewer.addQuestion(repoId, n, input));
+  ipcMain.handle("gander:addReviewerReply", async (_e, repoId: string, n: number, id: number, text: string) => reviewer.addReviewerReply(repoId, n, id, text));
   ipcMain.handle("gander:deleteQuestion", async (_e, repoId: string, n: number, id: number) => reviewer.deleteQuestion(repoId, n, id));
   ipcMain.handle("gander:setCheckedMany", async (_e, repoId: string, n: number, paths: string[], checked: boolean) => reviewer.setCheckedMany(repoId, n, paths, checked));
   registerSettingsIpc(ipcMain, cfg);

--- a/packages/app/src/main/review.test.ts
+++ b/packages/app/src/main/review.test.ts
@@ -67,6 +67,18 @@ describe("review pipeline", () => {
     expect(reopened.files.find((f) => f.path === "a.rb")!.checked).toBe(true);
   });
 
+  it("adds a reviewer reply through the real service and keeps it on reopen", async () => {
+    await reviewer.openPr("acme/atlas", 1);
+    const withQuestion = await reviewer.addQuestion("acme/atlas", 1, { path: "a.rb", line: 2, text: "Why?" });
+    const id = withQuestion.questions[0]!.id;
+
+    const replied = await reviewer.addReviewerReply("acme/atlas", 1, id, "Because the caller retries.");
+    expect(replied.questions[0]).toMatchObject({
+      state: "open", replies: [{ author: "reviewer", text: "Because the caller retries." }],
+    });
+    expect((await reviewer.openPr("acme/atlas", 1)).questions[0]?.replies).toHaveLength(1);
+  });
+
   it("setCheckedMany checks a batch from the cached view and persists it", async () => {
     await reviewer.openPr("acme/atlas", 1);
     const view = await reviewer.setCheckedMany("acme/atlas", 1, ["a.rb", "b.rb"], true);

--- a/packages/app/src/main/review.ts
+++ b/packages/app/src/main/review.ts
@@ -15,6 +15,7 @@ export interface Reviewer {
   setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<PrView>;
   setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView>;
   addQuestion(repoId: string, prNumber: number, input: Omit<NewQuestion, "headSha">): Promise<PrView>;
+  addReviewerReply(repoId: string, prNumber: number, id: number, text: string): Promise<PrView>;
   deleteQuestion(repoId: string, prNumber: number, id: number): Promise<PrView>;
   /** The file as it stood when the reviewer last checked it — the base for the delta view. */
   reviewedSnapshot(repoId: string, prNumber: number, path: string): Promise<string | null>;
@@ -189,6 +190,14 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     },
     async reviewedSnapshot(repoId, prNumber, path) {
       return (await deps.service.getSnapshot(repoId, prNumber, path)).headContent;
+    },
+    async addReviewerReply(repoId, prNumber, id, text) {
+      const view = requireOpen(repoId, prNumber);
+      const question = view.questions.find((q) => q.id === id);
+      if (!question) throw new Error(`Question ${id} is not part of PR #${prNumber}`);
+      const reply = await deps.service.addReviewerReply(repoId, prNumber, id, text);
+      question.replies = [...question.replies, reply];
+      return view;
     },
     async deleteQuestion(repoId, prNumber, id) {
       const view = requireOpen(repoId, prNumber);

--- a/packages/app/src/main/service-client.ts
+++ b/packages/app/src/main/service-client.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
-import { FileCheckoffSchema, QuestionSchema, ReviewStateSchema, type FileCheckoff, type NewQuestion, type PrContext, type PutFileState, type Question, type ReviewState } from "@gander/shared";
+import { FileCheckoffSchema, QuestionReplySchema, QuestionSchema, ReviewStateSchema, type FileCheckoff, type NewQuestion, type PrContext, type PutFileState, type Question, type QuestionReply, type ReviewState } from "@gander/shared";
 
 export interface ServiceClient {
   getReview(repoId: string, prNumber: number): Promise<ReviewState>;
   putFileState(repoId: string, prNumber: number, input: PutFileState): Promise<FileCheckoff>;
   listQuestions(repoId: string, prNumber: number): Promise<Question[]>;
   addQuestion(repoId: string, prNumber: number, input: NewQuestion): Promise<Question>;
+  addReviewerReply(repoId: string, prNumber: number, id: number, text: string): Promise<QuestionReply>;
   deleteQuestion(repoId: string, prNumber: number, id: number): Promise<void>;
   setPrContext(repoId: string, prNumber: number, context: PrContext): Promise<void>;
   getSnapshot(repoId: string, prNumber: number, path: string): Promise<{ baseContent: string | null; headContent: string | null }>;
@@ -60,6 +61,10 @@ export function createServiceClient(baseUrl: string, token: string): ServiceClie
     addQuestion: async (repoId, prNumber, input) => {
       const path = `/api/reviews/${enc(repoId)}/${prNumber}/questions`;
       return validate(QuestionSchema, path, await req("POST", path, input));
+    },
+    addReviewerReply: async (repoId, prNumber, id, text) => {
+      const path = `/api/reviews/${enc(repoId)}/${prNumber}/questions/${id}/replies`;
+      return validate(QuestionReplySchema, path, await req("POST", path, { text }));
     },
     deleteQuestion: async (repoId, prNumber, id) => {
       await req("DELETE", `/api/reviews/${enc(repoId)}/${prNumber}/questions/${id}`);

--- a/packages/app/src/preload/api.test.ts
+++ b/packages/app/src/preload/api.test.ts
@@ -14,6 +14,14 @@ describe("preload API", () => {
     expect(invoke).toHaveBeenLastCalledWith("gander:updateSettings", settings);
   });
 
+  it("routes reviewer replies through the reply IPC channel", async () => {
+    const invoke = vi.fn(async () => ({}));
+    const api = createGanderApi(invoke, vi.fn());
+
+    await api.addReviewerReply("acme/atlas", 7, 12, "A reviewer reply");
+    expect(invoke).toHaveBeenLastCalledWith("gander:addReviewerReply", "acme/atlas", 7, 12, "A reviewer reply");
+  });
+
   it("routes launch targets and subscribes to later open-target events", async () => {
     const invoke = vi.fn(async () => ({ repoId: "acme/atlas", prNumber: 4 }));
     const cleanup = vi.fn();

--- a/packages/app/src/preload/api.ts
+++ b/packages/app/src/preload/api.ts
@@ -22,6 +22,7 @@ export function createGanderApi(invoke: Invoke, subscribe: Subscribe): GanderApi
     refreshPr: (repoId, prNumber) => call("refreshPr", repoId, prNumber),
     reviewedSnapshot: (repoId, prNumber, path) => call("reviewedSnapshot", repoId, prNumber, path),
     addQuestion: (repoId, prNumber, input) => call("addQuestion", repoId, prNumber, input),
+    addReviewerReply: (repoId, prNumber, id, text) => call("addReviewerReply", repoId, prNumber, id, text),
     deleteQuestion: (repoId, prNumber, id) => call("deleteQuestion", repoId, prNumber, id),
     getSettings: () => call("getSettings"),
     updateSettings: (settings) => call("updateSettings", settings),

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -46,6 +46,7 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
     async fetchNow() {},
     async reviewedSnapshot() { return null; },
     async addQuestion() {},
+    async addReviewerReply() {},
     async deleteQuestion() {},
     async setChecked(path: string, checked: boolean) {
       calls.setChecked.push([path, checked]);
@@ -158,6 +159,7 @@ describe("FileTree", () => {
       commitRef: null,
       note: null,
       createdAt: "2026-08-18T00:00:00.000Z",
+      replies: [],
     }]));
     const wrapper = mount(FileTree, { props: { store } });
 

--- a/packages/app/src/renderer/src/components/QuestionsDrawer.vue
+++ b/packages/app/src/renderer/src/components/QuestionsDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, reactive } from "vue";
 import { MessageSquare, PanelBottom, PanelRight, Trash2, X } from "lucide-vue-next";
 import type { Store } from "../store.js";
 import { revealLine } from "../selection.js";
@@ -8,6 +8,8 @@ const props = defineProps<{ store: Store; dock: "right" | "bottom" }>();
 defineEmits<{ close: []; dock: ["right" | "bottom"] }>();
 
 const questions = computed(() => props.store.view?.questions ?? []);
+const drafts = reactive<Record<number, string>>({});
+const submitting = reactive(new Set<number>());
 
 function fileName(path: string | null): string {
   if (path === null) return "This pull request";
@@ -18,6 +20,20 @@ function goTo(q: { path: string | null; line: number | null }): void {
   if (q.path === null) return;
   props.store.select(q.path);
   if (q.line !== null) revealLine(q.line);
+}
+
+async function reply(questionId: number): Promise<void> {
+  const text = drafts[questionId]?.trim() ?? "";
+  if (!text || submitting.has(questionId)) return;
+  const before = questions.value.find((q) => q.id === questionId)?.replies.length ?? 0;
+  submitting.add(questionId);
+  try {
+    await props.store.addReviewerReply(questionId, text);
+    const after = questions.value.find((q) => q.id === questionId)?.replies.length ?? 0;
+    if (after > before) drafts[questionId] = "";
+  } finally {
+    submitting.delete(questionId);
+  }
 }
 </script>
 
@@ -55,11 +71,27 @@ function goTo(q: { path: string | null; line: number | null }): void {
             <Trash2 :size="13" />
           </button>
         </div>
-        <p class="text">{{ q.text }}</p>
+        <div class="message original">
+          <span class="author">Reviewer</span>
+          <p class="text">{{ q.text }}</p>
+        </div>
+        <div v-for="reply in q.replies" :key="reply.id" class="message reply">
+          <span class="author" :class="reply.author">{{ reply.author === "reviewer" ? "Reviewer" : "Agent" }}</span>
+          <p class="text">{{ reply.text }}</p>
+        </div>
         <p v-if="q.note || q.commitRef" class="answer">
           <span v-if="q.note">{{ q.note }}</span>
           <code v-if="q.commitRef">{{ q.commitRef }}</code>
         </p>
+        <form class="reply-form" @submit.prevent="reply(q.id)">
+          <input
+            v-model="drafts[q.id]"
+            data-app-typing="true"
+            :aria-label="`Reply to question ${q.id}`"
+            placeholder="Reply…"
+            :disabled="submitting.has(q.id)"
+          />
+        </form>
       </li>
     </ul>
   </aside>
@@ -90,7 +122,15 @@ li.current { background: rgba(77,159,236,.08); }
 .del { margin-left: auto; background: none; border: none; color: var(--faint); cursor: pointer; display: flex; flex: none; }
 .del:hover { color: var(--red); }
 .line { color: var(--faint); }
-.answer { margin: 6px 0 0; display: flex; align-items: baseline; gap: 7px; font-size: 11.5px; color: var(--faint); }
+.message { margin-top: 8px; padding-left: 9px; border-left: 2px solid var(--border); }
+.message.reply { margin-left: 8px; }
+.author { display: block; color: var(--dim); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
+.author.agent { color: var(--accent); }
+.answer { margin: 8px 0 0 10px; display: flex; align-items: baseline; gap: 7px; font-size: 11.5px; color: var(--faint); }
 .answer code { font: 10.5px var(--mono); background: #262b34; border-radius: 4px; padding: 1px 5px; flex: none; }
-.text { margin: 6px 0 0; font-size: 12.5px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere; }
+.text { margin: 3px 0 0; font-size: 12.5px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere; }
+.reply-form { margin-top: 9px; }
+.reply-form input { width: 100%; background: #14161b; border: 1px solid var(--border); border-radius: 6px; color: var(--fg); font: inherit; font-size: 12px; padding: 6px 8px; }
+.reply-form input:focus { outline: none; border-color: var(--accent); }
+.reply-form input:disabled { color: var(--faint); }
 </style>

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -27,6 +27,7 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     serviceHealthy: async () => true,
     reviewedSnapshot: async () => null,
     addQuestion: async () => prView(),
+    addReviewerReply: async () => prView(),
     deleteQuestion: async () => prView(),
     getSettings: async () => ({ editor: { fontFamily: "monospace", fontSize: 16 } }),
     updateSettings: async (settings) => settings,
@@ -105,6 +106,21 @@ describe("store", () => {
     await store.refresh();
     expect(store.selectedPath).toBe("b.rb");
     expect(store.view).not.toBeNull();
+  });
+
+  it("sends a reviewer reply for the open review", async () => {
+    let call: [string, number, number, string] | null = null;
+    const store = createStore(fakeApi({
+      addReviewerReply: async (repo, pr, id, text) => {
+        call = [repo, pr, id, text];
+        return prView();
+      },
+    }));
+    await store.loadRepos();
+    await store.selectRepo("acme/atlas");
+    await store.openPr(1);
+    await store.addReviewerReply(12, "A reviewer reply");
+    expect(call).toEqual(["acme/atlas", 1, 12, "A reviewer reply"]);
   });
 
   it("busy is true only while a long-running action is in flight, and clears even on failure", async () => {

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -32,6 +32,7 @@ export interface Store {
   setCheckedMany(paths: string[], checked: boolean): Promise<void>;
   reviewedSnapshot(path: string): Promise<string | null>;
   addQuestion(text: string, path: string | null, line: number | null): Promise<void>;
+  addReviewerReply(id: number, text: string): Promise<void>;
   deleteQuestion(id: number): Promise<void>;
   select(path: string): void;
   progress(): { done: number; total: number };
@@ -151,6 +152,12 @@ export function createStore(api: GanderApi): Store {
       await guard(async () => {
         if (!store.currentRepoId || !store.view) throw new Error("no PR open");
         store.view = await api.deleteQuestion(store.currentRepoId, store.view.pr.number, id);
+      });
+    },
+    async addReviewerReply(id: number, text: string) {
+      await guard(async () => {
+        if (!store.currentRepoId || !store.view) throw new Error("no PR open");
+        store.view = await api.addReviewerReply(store.currentRepoId, store.view.pr.number, id, text);
       });
     },
     select(path: string) {

--- a/packages/service/src/mcp.test.ts
+++ b/packages/service/src/mcp.test.ts
@@ -49,10 +49,10 @@ afterEach(async () => {
 });
 
 describe("MCP endpoint", () => {
-  it("offers exactly the two tools the contract defines", async () => {
+  it("offers the three question conversation tools", async () => {
     const client = await connect();
     const names = (await client.listTools()).tools.map((t) => t.name).sort();
-    expect(names).toEqual(["get_review_questions", "mark_question_addressed"]);
+    expect(names).toEqual(["get_review_questions", "mark_question_addressed", "reply_to_question"]);
     await client.close();
   });
 
@@ -72,8 +72,39 @@ describe("MCP endpoint", () => {
     expect(payload.title).toBe("Feature");
     expect(payload.questions).toEqual([{
       id: expect.any(Number), file: "a.rb", line: 12, text: "Why the retry here?", state: "open",
-      capturedAtSha: null, lineMayHaveMoved: false,
+      replies: [], capturedAtSha: null, lineMayHaveMoved: false,
     }]);
+    await client.close();
+  });
+
+  it("lets an agent reply and returns the thread without changing question state", async () => {
+    storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
+    const q = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: 12, text: "Why?", headSha: "sha-1" });
+
+    const client = await connect();
+    const replied = await client.callTool({
+      name: "reply_to_question",
+      arguments: { id: q.id, text: "This belongs in the model because both callers need it." },
+    });
+    expect(textOf(replied as { content?: unknown })).toContain("state was not changed");
+
+    const payload = JSON.parse(textOf((await client.callTool({
+      name: "get_review_questions",
+      arguments: { repo: "acme/atlas", branch: "feat/thing" },
+    })) as { content?: unknown })) as { questions: Array<{ state: string; replies: Array<{ author: string; text: string }> }> };
+    expect(payload.questions[0]).toMatchObject({
+      state: "open",
+      replies: [{ author: "agent", text: "This belongs in the model because both callers need it." }],
+    });
+    expect(storage.listQuestions("acme/atlas", 7)[0]?.state).toBe("open");
+    await client.close();
+  });
+
+  it("reports an unknown question when an agent tries to reply", async () => {
+    const client = await connect();
+    const result = await client.callTool({ name: "reply_to_question", arguments: { id: 999, text: "Anyone there?" } });
+    expect(result.isError).toBe(true);
+    expect(textOf(result as { content?: unknown })).toContain("does not exist");
     await client.close();
   });
 

--- a/packages/service/src/mcp.ts
+++ b/packages/service/src/mcp.ts
@@ -4,11 +4,11 @@ import { z } from "zod";
 import type { Storage } from "./storage.js";
 
 /**
- * The MCP contract is deliberately tiny: agents read the reviewer's questions and say
- * when they have acted on one. Nothing here reads diffs, lists files, touches checkoffs,
- * or resolves a question — resolution is the reviewer's act alone, made in the app by
- * re-checking the file. Agents already have git and gh for code; this carries only the
- * questions.
+ * The MCP contract is deliberately tiny: agents read the reviewer's questions, reply,
+ * and say when they have acted on one. Nothing here reads diffs, lists files, touches
+ * checkoffs, or resolves a question — resolution is the reviewer's act alone, made in
+ * the app by re-checking the file. Agents already have git and gh for code; this carries
+ * only the conversation.
  */
 export function buildMcpServer(storage: Storage, version: string): McpServer {
   const server = new McpServer({ name: "gander", version });
@@ -56,6 +56,12 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
           line: q.line,
           text: q.text,
           state: q.state,
+          replies: q.replies.map((reply) => ({
+            id: reply.id,
+            author: reply.author,
+            text: reply.text,
+            createdAt: reply.createdAt,
+          })),
           capturedAtSha: q.headSha,
           // The branch may have moved since the reviewer read it, in which case the line
           // number is the one they saw, not necessarily the one there now.
@@ -95,6 +101,30 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
         : "";
 
       return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) + hint }] };
+    },
+  );
+
+  server.registerTool(
+    "reply_to_question",
+    {
+      title: "Reply to a review question",
+      description:
+        "Add an agent reply to a review question. Use this for clarification, reasoning, or a response that should remain with the review. " +
+        "Replying does not address or resolve the question and does not change its lifecycle state.",
+      inputSchema: {
+        id: z.number().int().positive().describe("Question id from get_review_questions."),
+        text: z.string().trim().min(1).describe("The reply to add to the question thread."),
+      },
+    },
+    async ({ id, text }) => {
+      const added = storage.addAgentReply(id, { text });
+      if (added === null) {
+        return {
+          content: [{ type: "text", text: `Question ${id} does not exist.` }],
+          isError: true,
+        };
+      }
+      return { content: [{ type: "text", text: `Reply added to question ${id}. Its state was not changed.` }] };
     },
   );
 

--- a/packages/service/src/server.test.ts
+++ b/packages/service/src/server.test.ts
@@ -106,6 +106,27 @@ describe("service API", () => {
       expect(res.statusCode).toBe(400);
     });
 
+    it("adds a reviewer reply to the question thread without changing its state", async () => {
+      const created = await server.inject({ method: "POST", url, headers: AUTH, payload: { path: "a.rb", line: 3, text: "Why?", headSha: "sha-1" } });
+      const id = created.json().id as number;
+      const reply = await server.inject({
+        method: "POST", url: `${url}/${id}/replies`, headers: AUTH, payload: { text: "It is required by the caller." },
+      });
+
+      expect(reply.statusCode).toBe(201);
+      expect(reply.json()).toMatchObject({ author: "reviewer", text: "It is required by the caller." });
+      expect((await server.inject({ method: "GET", url, headers: AUTH })).json()[0]).toMatchObject({
+        state: "open", replies: [{ author: "reviewer", text: "It is required by the caller." }],
+      });
+    });
+
+    it("rejects blank replies and replies scoped to another review", async () => {
+      const created = await server.inject({ method: "POST", url, headers: AUTH, payload: { path: "a.rb", line: null, text: "Why?", headSha: null } });
+      const id = created.json().id as number;
+      expect((await server.inject({ method: "POST", url: `${url}/${id}/replies`, headers: AUTH, payload: { text: "   " } })).statusCode).toBe(400);
+      expect((await server.inject({ method: "POST", url: `/api/reviews/acme%2Fatlas/8/questions/${id}/replies`, headers: AUTH, payload: { text: "Wrong review" } })).statusCode).toBe(404);
+    });
+
     it("404s on deleting a question that is not there", async () => {
       expect((await server.inject({ method: "DELETE", url: `${url}/999`, headers: AUTH })).statusCode).toBe(404);
     });

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -1,5 +1,5 @@
 import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
-import { NewQuestionSchema, PrContextSchema, PutFileStateSchema } from "@gander/shared";
+import { NewQuestionReplySchema, NewQuestionSchema, PrContextSchema, PutFileStateSchema } from "@gander/shared";
 import { handleMcpRequest } from "./mcp.js";
 import type { Storage } from "./storage.js";
 
@@ -111,6 +111,27 @@ export function buildServer(opts: { storage: Storage; token: string; version: st
         return reply.code(404).send({ error: `no question ${id} on ${req.params.repoId}#${prNumber}` });
       }
       return reply.code(204).send();
+    },
+  );
+
+  app.post<{ Params: { repoId: string; prNumber: string; id: string } }>(
+    "/api/reviews/:repoId/:prNumber/questions/:id/replies",
+    async (req, reply) => {
+      const prNumber = parsePrNumber(req.params.prNumber, reply);
+      if (prNumber === undefined) return;
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id) || id <= 0) {
+        return reply.code(400).send({ error: `id must be a positive integer, got ${JSON.stringify(req.params.id)}` });
+      }
+      const parsed = NewQuestionReplySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return reply.code(400).send({ error: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ") });
+      }
+      const added = opts.storage.addReviewerReply(req.params.repoId, prNumber, id, parsed.data);
+      if (added === null) {
+        return reply.code(404).send({ error: `no question ${id} on ${req.params.repoId}#${prNumber}` });
+      }
+      return reply.code(201).send(added);
     },
   );
 

--- a/packages/service/src/storage.test.ts
+++ b/packages/service/src/storage.test.ts
@@ -111,6 +111,49 @@ describe("storage", () => {
       expect(marked).toMatchObject({ state: "addressed", commitRef: "abc1234", note: "Dropped the retry" });
     });
 
+    it("appends reviewer and agent replies without changing the question state", () => {
+      const q = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: 4, text: "Why?", headSha: null });
+
+      expect(storage.addReviewerReply("acme/atlas", 7, q.id, { text: "Because this runs twice." })).toMatchObject({
+        author: "reviewer", text: "Because this runs twice.",
+      });
+      expect(storage.addAgentReply(q.id, { text: "That constraint belongs in the model." })).toMatchObject({
+        author: "agent", text: "That constraint belongs in the model.",
+      });
+
+      expect(storage.listQuestions("acme/atlas", 7)[0]).toMatchObject({
+        state: "open",
+        replies: [
+          { author: "reviewer", text: "Because this runs twice." },
+          { author: "agent", text: "That constraint belongs in the model." },
+        ],
+      });
+
+      storage.markQuestionAddressed(q.id, { commitRef: null, note: null });
+      storage.addAgentReply(q.id, { text: "One more detail." });
+      expect(storage.listQuestions("acme/atlas", 7)[0]?.state).toBe("addressed");
+
+      storage.putFileState("acme/atlas", 7, {
+        checked: true, path: "a.rb", baseHash: "b", headHash: "h",
+        baseContent: "old", headContent: "new", machine: "studio",
+      });
+      storage.addReviewerReply("acme/atlas", 7, q.id, { text: "Closing note." });
+      expect(storage.listQuestions("acme/atlas", 7)[0]?.state).toBe("resolved");
+    });
+
+    it("scopes reviewer replies to the question's review", () => {
+      const q = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
+      expect(storage.addReviewerReply("acme/atlas", 8, q.id, { text: "Wrong review" })).toBeNull();
+      expect(storage.listQuestions("acme/atlas", 7)[0]?.replies).toEqual([]);
+    });
+
+    it("deletes a question's reply thread with the question", () => {
+      const q = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
+      storage.addAgentReply(q.id, { text: "Here is why." });
+      expect(storage.deleteQuestion("acme/atlas", 7, q.id)).toBe(true);
+      expect(storage.addAgentReply(q.id, { text: "Too late" })).toBeNull();
+    });
+
     it("refuses to re-address a question the reviewer already resolved", () => {
       const q = storage.addQuestion("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
       storage.markQuestionAddressed(q.id, { commitRef: null, note: null });
@@ -192,6 +235,8 @@ describe("storage", () => {
         // And the new columns work rather than throwing on first write.
         const id = upgraded.listQuestions("acme/atlas", 7)[0]!.id;
         expect(upgraded.markQuestionAddressed(id, { commitRef: "abc", note: "done" })?.state).toBe("addressed");
+        expect(upgraded.addAgentReply(id, { text: "Reply after upgrade" })?.author).toBe("agent");
+        expect(upgraded.listQuestions("acme/atlas", 7)[0]?.replies).toMatchObject([{ text: "Reply after upgrade" }]);
         upgraded.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
         expect(upgraded.findPrByHeadRef("acme/atlas", "feat/thing")).toBe(7);
       } finally {

--- a/packages/service/src/storage.ts
+++ b/packages/service/src/storage.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { gzipSync, gunzipSync } from "node:zlib";
-import type { FileCheckoff, MarkAddressed, NewQuestion, PrContext, PutFileState, Question, ReviewState } from "@gander/shared";
+import type { FileCheckoff, MarkAddressed, NewQuestion, NewQuestionReply, PrContext, PutFileState, Question, QuestionReply, ReviewState } from "@gander/shared";
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS reviews (
@@ -40,6 +40,14 @@ CREATE TABLE IF NOT EXISTS questions (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 CREATE INDEX IF NOT EXISTS questions_by_review ON questions(review_id);
+CREATE TABLE IF NOT EXISTS question_replies (
+  id INTEGER PRIMARY KEY,
+  question_id INTEGER NOT NULL REFERENCES questions(id) ON DELETE CASCADE,
+  author TEXT NOT NULL CHECK(author IN ('reviewer', 'agent')),
+  text TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE INDEX IF NOT EXISTS question_replies_by_question ON question_replies(question_id, id);
 `;
 
 export interface Storage {
@@ -55,18 +63,29 @@ export interface Storage {
   markQuestionAddressed(id: number, input: MarkAddressed): Question | null;
   listQuestions(repoId: string, prNumber: number): Question[];
   addQuestion(repoId: string, prNumber: number, input: NewQuestion): Question;
+  addReviewerReply(repoId: string, prNumber: number, id: number, input: NewQuestionReply): QuestionReply | null;
+  addAgentReply(id: number, input: NewQuestionReply): QuestionReply | null;
   deleteQuestion(repoId: string, prNumber: number, id: number): boolean;
   close(): void;
 }
 
 interface QuestionRow { id: number; path: string | null; line: number | null; text: string; state: string; head_sha: string | null; commit_ref: string | null; note: string | null; created_at: string }
+interface QuestionReplyRow { id: number; question_id: number; author: string; text: string; created_at: string }
 
-const rowToQuestion = (r: QuestionRow): Question => ({
+const rowToReply = (r: QuestionReplyRow): QuestionReply => ({
+  id: r.id,
+  author: r.author as QuestionReply["author"],
+  text: r.text,
+  createdAt: r.created_at,
+});
+
+const rowToQuestion = (r: QuestionRow, replies: QuestionReply[] = []): Question => ({
   id: r.id, path: r.path, line: r.line, text: r.text,
   state: r.state as Question["state"],
   headSha: r.head_sha,
   commitRef: r.commit_ref, note: r.note,
   createdAt: r.created_at,
+  replies,
 });
 
 const QUESTION_COLUMNS = "id, path, line, text, state, head_sha, commit_ref, note, created_at";
@@ -99,6 +118,7 @@ const unpack = (b: Buffer | null): string | null => (b === null ? null : gunzipS
 
 export function openStorage(dbPath: string): Storage {
   const db = new Database(dbPath);
+  db.pragma("foreign_keys = ON");
   db.pragma("journal_mode = WAL");
   db.exec(SCHEMA);
   migrate(db);
@@ -114,6 +134,13 @@ export function openStorage(dbPath: string): Storage {
     baseHash: r.base_hash, headHash: r.head_hash,
     checkedAt: r.checked_at, machine: r.machine,
   });
+
+  const repliesForQuestion = (id: number): QuestionReply[] =>
+    (db.prepare("SELECT id, question_id, author, text, created_at FROM question_replies WHERE question_id = ? ORDER BY id").all(id) as QuestionReplyRow[])
+      .map(rowToReply);
+
+  const replyById = (id: number | bigint): QuestionReply =>
+    rowToReply(db.prepare("SELECT id, question_id, author, text, created_at FROM question_replies WHERE id = ?").get(id) as QuestionReplyRow);
 
   return {
     getReview(repoId, prNumber) {
@@ -202,13 +229,26 @@ export function openStorage(dbPath: string): Storage {
         WHERE id = ? AND state = 'open'
       `).run(input.commitRef, input.note, id).changes;
       if (changed === 0) return null;
-      return rowToQuestion(db.prepare(`SELECT ${QUESTION_COLUMNS} FROM questions WHERE id = ?`).get(id) as QuestionRow);
+      return rowToQuestion(db.prepare(`SELECT ${QUESTION_COLUMNS} FROM questions WHERE id = ?`).get(id) as QuestionRow, repliesForQuestion(id));
     },
 
     listQuestions(repoId, prNumber) {
       const rid = reviewId(repoId, prNumber);
       const rows = db.prepare(`SELECT ${QUESTION_COLUMNS} FROM questions WHERE review_id = ? ORDER BY id`).all(rid) as QuestionRow[];
-      return rows.map(rowToQuestion);
+      const replyRows = db.prepare(`
+        SELECT qr.id, qr.question_id, qr.author, qr.text, qr.created_at
+        FROM question_replies qr
+        JOIN questions q ON q.id = qr.question_id
+        WHERE q.review_id = ?
+        ORDER BY qr.id
+      `).all(rid) as QuestionReplyRow[];
+      const replies = new Map<number, QuestionReply[]>();
+      for (const row of replyRows) {
+        const current = replies.get(row.question_id) ?? [];
+        current.push(rowToReply(row));
+        replies.set(row.question_id, current);
+      }
+      return rows.map((row) => rowToQuestion(row, replies.get(row.id) ?? []));
     },
 
     addQuestion(repoId, prNumber, input) {
@@ -218,6 +258,23 @@ export function openStorage(dbPath: string): Storage {
         .run(rid, input.path, input.line, input.text, input.headSha);
       const row = db.prepare(`SELECT ${QUESTION_COLUMNS} FROM questions WHERE id = ?`).get(lastInsertRowid) as QuestionRow;
       return rowToQuestion(row);
+    },
+
+    addReviewerReply(repoId, prNumber, id, input) {
+      const rid = reviewId(repoId, prNumber);
+      const result = db.prepare(`
+        INSERT INTO question_replies (question_id, author, text)
+        SELECT q.id, 'reviewer', ? FROM questions q WHERE q.id = ? AND q.review_id = ?
+      `).run(input.text, id, rid);
+      return result.changes === 0 ? null : replyById(result.lastInsertRowid);
+    },
+
+    addAgentReply(id, input) {
+      const result = db.prepare(`
+        INSERT INTO question_replies (question_id, author, text)
+        SELECT id, 'agent', ? FROM questions WHERE id = ?
+      `).run(input.text, id);
+      return result.changes === 0 ? null : replyById(result.lastInsertRowid);
     },
 
     deleteQuestion(repoId, prNumber, id) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,6 +37,22 @@ export type PutFileState = z.infer<typeof PutFileStateSchema>;
 export const QuestionStateSchema = z.enum(["open", "addressed", "resolved"]);
 export type QuestionState = z.infer<typeof QuestionStateSchema>;
 
+export const QuestionReplyAuthorSchema = z.enum(["reviewer", "agent"]);
+export type QuestionReplyAuthor = z.infer<typeof QuestionReplyAuthorSchema>;
+
+export const QuestionReplySchema = z.object({
+  id: z.number().int().positive(),
+  author: QuestionReplyAuthorSchema,
+  text: z.string().min(1),
+  createdAt: z.string(),
+});
+export type QuestionReply = z.infer<typeof QuestionReplySchema>;
+
+export const NewQuestionReplySchema = z.object({
+  text: z.string().trim().min(1),
+});
+export type NewQuestionReply = z.infer<typeof NewQuestionReplySchema>;
+
 export const QuestionSchema = z.object({
   id: z.number().int().positive(),
   /** null for a note about the pull request as a whole rather than one file. */
@@ -52,6 +68,7 @@ export const QuestionSchema = z.object({
   /** One-line note an agent left when it marked the question addressed. */
   note: z.string().nullable(),
   createdAt: z.string(),
+  replies: z.array(QuestionReplySchema),
 });
 export type Question = z.infer<typeof QuestionSchema>;
 


### PR DESCRIPTION
## Summary

- add persistent question reply threads with reviewer and agent authors
- show the full thread in the questions drawer and let the reviewer reply inline
- return replies from `get_review_questions` and add `reply_to_question` for agents
- preserve `open` → `addressed` → `resolved`; replies never change lifecycle state

## Readiness

- Simplify: clean
- Code review: clean, no unresolved findings
- Finalize: clean
- Adversarial: skipped; additive SQLite migration and public API/MCP change reviewed through real storage, Fastify, and MCP coverage
- PR #26 changes only `get_review_questions` visibility metadata; this branch keeps its overlap additive to the per-question `replies` field

## Test plan

- `pnpm test` — 180 passed
- `pnpm typecheck`
- `pnpm test:e2e` — 6 passed, including reviewer reply persistence across restart
- `bin/mcp check` — live endpoint advertises all three tools

Closes #2
