### PR TITLE
Add configurable Catppuccin workbench theme

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -51,15 +51,37 @@ function fileCheckbox(filename: string) {
   return $(`//div[contains(@class, 'tnode')][.//span[contains(@class, 'fname') and normalize-space()='${filename}']]//span[@role='checkbox']`);
 }
 
+async function selectColorTheme(value: "Catppuccin Mocha" | "Gander Dark"): Promise<void> {
+  await browser.execute((colorTheme) => {
+    const select = document.querySelector<HTMLSelectElement>("select[name='workbench.colorTheme']");
+    if (!select) throw new Error("workbench.colorTheme select is missing");
+    select.value = colorTheme;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  }, value);
+}
+
 describe("Gander end to end", () => {
   it("opens the built application with the Gander title", async () => {
     await expect(browser).toHaveTitle("Gander");
     await expect($(".empty")).toHaveText("Pick a repository, then a pull request.");
   });
 
-  it("changes editor font settings in the UI and keeps them after restart", async () => {
+  it("changes workbench and editor settings live and keeps them after restart", async () => {
     await $("button[aria-label='Editor settings']").click();
     await expect($(".settings-pane h1")).toHaveText("Settings");
+    const theme = await $("select[name='workbench.colorTheme']");
+    await expect(theme).toHaveValue("Catppuccin Mocha");
+    await selectColorTheme("Gander Dark");
+    await browser.waitUntil(async () => await browser.execute(() =>
+      document.querySelector(".settings-pane [role='status']")?.textContent === "Saved automatically",
+    ));
+    expect(await browser.execute(() => ({
+      selected: document.querySelector<HTMLSelectElement>("select[name='workbench.colorTheme']")?.value,
+      theme: document.documentElement.dataset.colorTheme,
+      background: document.documentElement.style.getPropertyValue("--workbench-background"),
+      status: document.querySelector(".settings-pane [role='status']")?.textContent,
+    }))).toEqual({ selected: "Gander Dark", theme: "Gander Dark", background: "#16181d", status: "Saved automatically" });
+    await $("//button[contains(@class, 'category') and normalize-space()='Editor']").click();
     const family = await $("input[name='editor.fontFamily']");
     const size = await $("input[name='editor.fontSize']");
     await expect($("#editor-preview-label")).toHaveText("Preview");
@@ -80,11 +102,13 @@ describe("Gander end to end", () => {
 
     await $("//button[@role='tab' and normalize-space()='JSON']").click();
     await $(".settings-json-editor .monaco-editor").waitForDisplayed();
-    const jsonSource = await browser.execute(() =>
+    const jsonSource = (await browser.execute(() =>
       document.querySelector(".settings-json-editor .view-lines")?.textContent ?? "",
-    );
+    )).replaceAll("\u00a0", " ");
     expect(jsonSource).toContain("editor.fontFamily");
     expect(jsonSource).toContain("editor.fontSize");
+    expect(jsonSource).toContain("workbench.colorTheme");
+    expect(jsonSource).toContain("Gander Dark");
     await $("button[aria-label='Close settings']").click();
     await expect($(".settings-pane")).not.toBeDisplayed();
 
@@ -97,6 +121,8 @@ describe("Gander end to end", () => {
     await browser.reloadSession();
 
     await $("button[aria-label='Editor settings']").click();
+    await expect($("select[name='workbench.colorTheme']")).toHaveValue("Gander Dark");
+    await $("//button[contains(@class, 'category') and normalize-space()='Editor']").click();
     await expect($("input[name='editor.fontFamily']")).toHaveValue("'Courier New', monospace");
     await expect($("input[name='editor.fontSize']")).toHaveValue("18.5");
     await $("button[aria-label='Close settings']").click();
@@ -126,6 +152,11 @@ describe("Gander end to end", () => {
     });
     await $("button[aria-label='Editor settings']").click();
     await expect($(".settings-pane")).toBeDisplayed();
+    await selectColorTheme("Catppuccin Mocha");
+    await browser.waitUntil(async () => await browser.execute(() =>
+      document.documentElement.dataset.colorTheme === "Catppuccin Mocha"
+      && document.documentElement.style.getPropertyValue("--workbench-background") === "#1e1e2e",
+    ));
     await $("button[aria-label='Close settings']").click();
     await expect($(".diff .monaco-editor[data-mount-marker='preserved']")).toBeDisplayed();
 

--- a/packages/app/src/main/config.test.ts
+++ b/packages/app/src/main/config.test.ts
@@ -32,15 +32,31 @@ describe("config", () => {
   it("persists editor settings across save and load", () => {
     saveConfig({
       serviceUrl: "http://h:8390", serviceToken: "t", repos: [],
-      settings: { editor: { fontFamily: "'Fira Code', monospace", fontSize: 18.5 } },
+      settings: {
+        editor: { fontFamily: "'Fira Code', monospace", fontSize: 18.5 },
+        workbench: { colorTheme: "Gander Dark" },
+      },
     }, cfgPath);
     expect(loadConfig(cfgPath).settings.editor).toEqual({ fontFamily: "'Fira Code', monospace", fontSize: 18.5 });
+    expect(loadConfig(cfgPath).settings.workbench.colorTheme).toBe("Gander Dark");
+  });
+
+  it("adds the workbench default without discarding an older editor configuration", () => {
+    writeFileSync(cfgPath, JSON.stringify({
+      serviceUrl: "http://h:8390", serviceToken: "t", repos: [],
+      settings: { editor: { fontFamily: "Consolas, monospace", fontSize: 19 } },
+    }));
+    expect(loadConfig(cfgPath).settings).toEqual({
+      editor: { fontFamily: "Consolas, monospace", fontSize: 19 },
+      workbench: { colorTheme: "Catppuccin Mocha" },
+    });
   });
 
   it.each([
     { editor: { fontFamily: "", fontSize: 16 } },
     { editor: { fontFamily: DEFAULT_EDITOR_FONT_FAMILY, fontSize: 1000 } },
     { editor: { fontFamily: DEFAULT_EDITOR_FONT_FAMILY } },
+    { editor: { fontFamily: DEFAULT_EDITOR_FONT_FAMILY, fontSize: 16 }, workbench: { colorTheme: "Missing Theme" } },
   ])("falls back safely when persisted editor settings are invalid", (settings) => {
     writeFileSync(cfgPath, JSON.stringify({ serviceUrl: "http://h:8390", serviceToken: "t", repos: [], settings }));
     expect(loadConfig(cfgPath).settings).toEqual(DEFAULT_APP_SETTINGS);

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -11,6 +11,7 @@ import { createReviewer } from "./review.js";
 import { createServiceClient } from "./service-client.js";
 import { registerSettingsIpc } from "./settings-ipc.js";
 import { buildMenuTemplate } from "./menu.js";
+import { themeFor } from "../themes.js";
 
 async function bootstrap(): Promise<GanderConfig> {
   const cfg = loadConfig();
@@ -90,7 +91,9 @@ const appIcon = nativeImage.createFromPath(join(import.meta.dirname, "../../reso
 function createWindow(cfg: GanderConfig): void {
   const win = new BrowserWindow({
     width: 1360, height: 860,
-    backgroundColor: "#16181d",
+    // Match the persisted workbench while the renderer starts, so theme changes do not
+    // flash the bundled default on the next launch.
+    backgroundColor: themeFor(cfg.settings.workbench.colorTheme).workbench.background,
     // Ignored on macOS, where the dock icon comes from the bundle — app.dock.setIcon covers that.
     icon: appIcon,
     // sandbox: false — our preload output is an ES module (index.mjs, from "type": "module");

--- a/packages/app/src/main/settings-ipc.test.ts
+++ b/packages/app/src/main/settings-ipc.test.ts
@@ -27,7 +27,10 @@ describe("settings IPC", () => {
     const { cfg, handlers, persist } = fixture();
     await expect(handlers.get("gander:getSettings")?.()).resolves.toEqual(DEFAULT_APP_SETTINGS);
 
-    const next = { editor: { fontFamily: "Consolas, monospace", fontSize: 20 } };
+    const next = {
+      editor: { fontFamily: "Consolas, monospace", fontSize: 20 },
+      workbench: { colorTheme: "Gander Dark" as const },
+    };
     await expect(handlers.get("gander:updateSettings")?.({}, next)).resolves.toEqual(next);
     expect(cfg.settings).toEqual(next);
     expect(persist).toHaveBeenCalledOnce();
@@ -38,6 +41,7 @@ describe("settings IPC", () => {
     const { cfg, handlers, persist } = fixture();
     await expect(handlers.get("gander:updateSettings")?.({}, {
       editor: { fontFamily: "monospace", fontSize: 200 },
+      workbench: DEFAULT_APP_SETTINGS.workbench,
     })).rejects.toThrow(/fontSize/);
     expect(cfg.settings).toEqual(DEFAULT_APP_SETTINGS);
     expect(persist).not.toHaveBeenCalled();
@@ -48,6 +52,7 @@ describe("settings IPC", () => {
     persist.mockImplementation(() => { throw new Error("disk full"); });
     await expect(handlers.get("gander:updateSettings")?.({}, {
       editor: { fontFamily: "Consolas, monospace", fontSize: 20 },
+      workbench: DEFAULT_APP_SETTINGS.workbench,
     })).rejects.toThrow(/disk full/);
     expect(cfg.settings).toEqual(DEFAULT_APP_SETTINGS);
   });

--- a/packages/app/src/preload/api.test.ts
+++ b/packages/app/src/preload/api.test.ts
@@ -9,7 +9,10 @@ describe("preload API", () => {
     await api.getSettings();
     expect(invoke).toHaveBeenLastCalledWith("gander:getSettings");
 
-    const settings = { editor: { fontFamily: "Fira Code, monospace", fontSize: 17 } };
+    const settings = {
+      editor: { fontFamily: "Fira Code, monospace", fontSize: 17 },
+      workbench: { colorTheme: "Gander Dark" as const },
+    };
     await api.updateSettings(settings);
     expect(invoke).toHaveBeenLastCalledWith("gander:updateSettings", settings);
   });

--- a/packages/app/src/renderer/index.html
+++ b/packages/app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <title>Gander</title>
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'" />
   </head>
-  <body style="margin:0;background:#16181d">
+  <body style="margin:0;background:#1e1e2e">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -183,14 +183,14 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .app { display: grid; grid-template-rows: 50px 1fr auto; height: 100vh; }
-.error-banner { display: flex; align-items: center; gap: 10px; background: rgba(248,81,73,.12); color: var(--red); padding: 8px 14px; font-size: 12px; border-bottom: 1px solid var(--border); }
+.error-banner { display: flex; align-items: center; gap: 10px; background: var(--danger-background); color: var(--danger); padding: 8px 14px; font-size: 12px; border-bottom: 1px solid var(--workbench-border); }
 .error-banner span { flex: 1; }
 .error-banner button { background: none; border: none; color: inherit; cursor: pointer; display: flex; flex: none; }
-.empty { color: var(--faint); padding: 2rem; }
+.empty { color: var(--faint-foreground); padding: 2rem; }
 .working { display: flex; align-items: center; gap: 10px; }
 .spinner {
   width: 14px; height: 14px; border-radius: 50%;
-  border: 2px solid var(--border); border-top-color: var(--faint);
+  border: 2px solid var(--workbench-border); border-top-color: var(--faint-foreground);
   animation: spin 0.8s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
@@ -203,7 +203,7 @@ onBeforeUnmount(() => {
 .workspace.right { flex-direction: row; }
 .workspace.bottom { flex-direction: column; }
 .drawer { flex: none; }
-.workspace.bottom .drawer { border-left: none; border-top: 1px solid var(--border); }
-.tree { flex: none; border-right: 1px solid var(--border); overflow: hidden auto; }
+.workspace.bottom .drawer { border-left: none; border-top: 1px solid var(--workbench-border); }
+.tree { flex: none; border-right: 1px solid var(--workbench-border); overflow: hidden auto; }
 .diff { flex: 1; min-width: 0; min-height: 0; overflow: hidden; }
 </style>

--- a/packages/app/src/renderer/src/components/DiffPane.vue
+++ b/packages/app/src/renderer/src/components/DiffPane.vue
@@ -240,25 +240,25 @@ onBeforeUnmount(dispose);
   align-items: center;
   gap: 10px;
   padding: 8px 14px;
-  border-bottom: 1px solid var(--border);
-  background: var(--panel);
+  border-bottom: 1px solid var(--workbench-border);
+  background: var(--panel-background);
   flex: none;
 }
 .path {
   font: 12.5px var(--mono);
-  color: var(--text);
+  color: var(--workbench-foreground);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .path .dir {
-  color: var(--faint);
+  color: var(--faint-foreground);
 }
 .tabs {
   margin-left: auto;
   display: flex;
   gap: 2px;
-  background: #14161b;
+  background: var(--input-background);
   border-radius: 7px;
   padding: 2px;
   flex: none;
@@ -271,45 +271,45 @@ onBeforeUnmount(dispose);
   height: 22px;
   background: none;
   border: none;
-  color: var(--dim);
+  color: var(--muted-foreground);
   border-radius: 5px;
   cursor: pointer;
 }
 .tabs button.active {
-  background: #2c3340;
-  color: var(--text);
+  background: var(--elevated-background);
+  color: var(--workbench-foreground);
 }
 .check {
   flex: none;
   display: flex;
   align-items: center;
   gap: 5px;
-  border: 1px solid var(--border);
-  background: #22262e;
-  color: var(--text);
+  border: 1px solid var(--workbench-border);
+  background: var(--elevated-background);
+  color: var(--workbench-foreground);
   border-radius: 6px;
   padding: 4px 12px;
   font-size: 12px;
   cursor: pointer;
 }
 .check:hover {
-  border-color: var(--green);
-  color: var(--green);
+  border-color: var(--success);
+  color: var(--success);
 }
 .check.on {
-  border-color: var(--green);
-  color: var(--green);
-  background: rgba(63, 185, 80, 0.15);
+  border-color: var(--success);
+  color: var(--success);
+  background: var(--success-background);
 }
 .banner {
   display: flex;
   align-items: center;
   gap: 7px;
-  background: rgba(210, 153, 34, 0.08);
-  color: var(--yellow);
+  background: var(--warning-background);
+  color: var(--warning);
   padding: 7px 14px;
   font-size: 12px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--workbench-border);
   flex: none;
 }
 .editor {
@@ -322,7 +322,7 @@ onBeforeUnmount(dispose);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--faint);
+  color: var(--faint-foreground);
   font-size: 13px;
 }
 </style>

--- a/packages/app/src/renderer/src/components/EditorSettings.vue
+++ b/packages/app/src/renderer/src/components/EditorSettings.vue
@@ -132,27 +132,27 @@ onBeforeUnmount(() => {
 <style scoped>
 .editor-settings { height: 100%; overflow: auto; padding: 28px; }
 .heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; max-width: 820px; margin-bottom: 30px; }
-.heading h2 { color: var(--text); font-size: 20px; line-height: 1.25; }
-.heading p, .setting > p { color: var(--faint); font-size: 12px; }
+.heading h2 { color: var(--workbench-foreground); font-size: 20px; line-height: 1.25; }
+.heading p, .setting > p { color: var(--faint-foreground); font-size: 12px; }
 .reset { border: 0; background: none; color: var(--accent); cursor: pointer; font: inherit; font-size: 12px; white-space: nowrap; }
 .reset:disabled { cursor: default; opacity: .55; }
 .setting { max-width: 820px; margin-bottom: 26px; }
-.setting label, .setting-label { display: block; color: var(--text); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
-.setting code { color: var(--dim); font: 11.5px var(--mono); }
+.setting label, .setting-label { display: block; color: var(--workbench-foreground); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
+.setting code { color: var(--muted-foreground); font: 11.5px var(--mono); }
 .setting input {
   width: 100%; min-width: 0; margin-top: 8px; padding: 8px 10px;
-  border: 1px solid var(--border); border-radius: 6px;
-  outline: none; background: #14161b; color: var(--text); font: 13px/1.4 var(--mono);
+  border: 1px solid var(--workbench-border); border-radius: 6px;
+  outline: none; background: var(--input-background); color: var(--workbench-foreground); font: 13px/1.4 var(--mono);
 }
-.setting input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(77,159,236,.16); }
+.setting input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
 .setting input:disabled { opacity: .65; }
-.size-row { display: flex; align-items: center; gap: 8px; width: 130px; color: var(--faint); }
+.size-row { display: flex; align-items: center; gap: 8px; width: 130px; color: var(--faint-foreground); }
 .preview-setting { margin-top: 34px; }
 .preview {
   min-width: 0; overflow: hidden; margin-top: 8px; padding: 14px;
-  border: 1px solid var(--border); border-radius: 6px; background: #14161b;
-  color: var(--text); line-height: 1.5; white-space: nowrap;
+  border: 1px solid var(--workbench-border); border-radius: 6px; background: var(--input-background);
+  color: var(--workbench-foreground); line-height: 1.5; white-space: nowrap;
 }
 .preview code { color: inherit; font: inherit; }
-.error { max-width: 820px; color: var(--red); font-size: 12px; overflow-wrap: anywhere; }
+.error { max-width: 820px; color: var(--danger); font-size: 12px; overflow-wrap: anywhere; }
 </style>

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -131,21 +131,21 @@ function fileName(path: string): string {
 <style scoped>
 .tree.root { padding: 8px 0; }
 .tnode { display: flex; align-items: center; gap: 6px; padding: 3px 12px 3px 0; cursor: pointer; white-space: nowrap; }
-.tnode:hover { background: #232833; }
-.tnode.sel { background: rgba(77, 159, 236, 0.14); box-shadow: inset 2px 0 0 var(--accent); }
+.tnode:hover { background: var(--hover-background); }
+.tnode.sel { background: var(--selection-background); box-shadow: inset 2px 0 0 var(--accent); }
 .tnode .hierarchy-slot { width: 14px; flex: none; }
-.tnode .chev { flex: none; color: var(--faint); }
+.tnode .chev { flex: none; color: var(--faint-foreground); }
 .tnode .fname { font: 12.5px var(--mono); overflow: hidden; text-overflow: ellipsis; }
-.tnode.isdir .fname { font: 600 12px/1.5 -apple-system, BlinkMacSystemFont, sans-serif; color: var(--dim); }
+.tnode.isdir .fname { font: 600 12px/1.5 -apple-system, BlinkMacSystemFont, sans-serif; color: var(--muted-foreground); }
 .tnode .st { margin-left: auto; font: 11px var(--mono); flex: none; }
-.st.M { color: var(--yellow); }
-.st.A { color: var(--green); }
-.st.D { color: var(--red); }
-.st.R { color: var(--purple); }
-.cb { width: 15px; height: 15px; flex: none; border: 1.5px solid var(--faint); border-radius: 4px; display: flex; align-items: center; justify-content: center; font-size: 11px; color: transparent; }
-.cb.on { border-color: var(--green); color: var(--green); }
-.cb.part { border-color: var(--green); color: var(--green); }
-.tnode.checked .fname { color: var(--faint); }
+.st.M { color: var(--warning); }
+.st.A { color: var(--success); }
+.st.D { color: var(--danger); }
+.st.R { color: var(--info); }
+.cb { width: 15px; height: 15px; flex: none; border: 1.5px solid var(--faint-foreground); border-radius: 4px; display: flex; align-items: center; justify-content: center; font-size: 11px; color: transparent; }
+.cb.on { border-color: var(--success); color: var(--success); }
+.cb.part { border-color: var(--success); color: var(--success); }
+.tnode.checked .fname { color: var(--faint-foreground); }
 .qmark { color: var(--accent); flex: none; }
-.delta-mark { width: 7px; height: 7px; border-radius: 50%; background: var(--yellow); flex: none; }
+.delta-mark { width: 7px; height: 7px; border-radius: 50%; background: var(--warning); flex: none; }
 </style>

--- a/packages/app/src/renderer/src/components/QuestionCapture.vue
+++ b/packages/app/src/renderer/src/components/QuestionCapture.vue
@@ -55,12 +55,12 @@ async function submit(): Promise<void> {
 </template>
 
 <style scoped>
-.capture { position: fixed; inset: 0; background: rgba(0,0,0,.45); display: flex; align-items: flex-start; justify-content: center; padding-top: 14vh; z-index: 50; }
-.panel { width: min(620px, 90vw); background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 14px; display: flex; flex-direction: column; gap: 10px; box-shadow: 0 18px 50px rgba(0,0,0,.5); }
-label { font-size: 12px; color: var(--faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-label b { color: var(--fg); font-weight: 600; }
-textarea { background: #14161b; border: 1px solid var(--border); border-radius: 7px; color: var(--fg); font: inherit; font-size: 13px; padding: 9px 11px; resize: vertical; }
+.capture { position: fixed; inset: 0; background: var(--overlay-background); display: flex; align-items: flex-start; justify-content: center; padding-top: 14vh; z-index: 50; }
+.panel { width: min(620px, 90vw); background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: 10px; padding: 14px; display: flex; flex-direction: column; gap: 10px; box-shadow: 0 18px 50px var(--workbench-shadow); }
+label { font-size: 12px; color: var(--faint-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+label b { color: var(--workbench-foreground); font-weight: 600; }
+textarea { background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 7px; color: var(--workbench-foreground); font: inherit; font-size: 13px; padding: 9px 11px; resize: vertical; }
 textarea:focus { outline: none; border-color: var(--accent); }
-.hint { font-size: 11px; color: var(--faint); }
-kbd { font: 10.5px var(--mono); background: #262b34; border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }
+.hint { font-size: 11px; color: var(--faint-foreground); }
+kbd { font: 10.5px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: 4px; padding: 1px 5px; }
 </style>

--- a/packages/app/src/renderer/src/components/QuestionsDrawer.vue
+++ b/packages/app/src/renderer/src/components/QuestionsDrawer.vue
@@ -98,39 +98,39 @@ async function reply(questionId: number): Promise<void> {
 </template>
 
 <style scoped>
-.drawer { display: flex; flex-direction: column; background: var(--panel); border-left: 1px solid var(--border); overflow: hidden auto; }
-header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--border); color: var(--dim); flex: none; }
+.drawer { display: flex; flex-direction: column; background: var(--panel-background); border-left: 1px solid var(--workbench-border); overflow: hidden auto; }
+header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--workbench-border); color: var(--muted-foreground); flex: none; }
 .title { font-size: 12px; font-weight: 600; letter-spacing: .3px; text-transform: uppercase; }
-.count { font: 11px var(--mono); background: #262b34; border-radius: 9px; padding: 1px 7px; }
+.count { font: 11px var(--mono); background: var(--badge-background); border-radius: 9px; padding: 1px 7px; }
 .dockbtn { margin-left: auto; }
 .dockbtn + .close { margin-left: 0; }
-.close { margin-left: auto; background: none; border: none; color: var(--faint); cursor: pointer; display: flex; }
-.close:hover { color: var(--fg); }
+.close { margin-left: auto; background: none; border: none; color: var(--faint-foreground); cursor: pointer; display: flex; }
+.close:hover { color: var(--workbench-foreground); }
 
-.empty { color: var(--faint); font-size: 12px; padding: 16px 12px; line-height: 1.6; }
-kbd { font: 11px var(--mono); background: #262b34; border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }
+.empty { color: var(--faint-foreground); font-size: 12px; padding: 16px 12px; line-height: 1.6; }
+kbd { font: 11px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: 4px; padding: 1px 5px; }
 
 ul { list-style: none; margin: 0; padding: 0; }
-li { padding: 10px 12px; border-bottom: 1px solid var(--border); }
-li.current { background: rgba(77,159,236,.08); }
+li { padding: 10px 12px; border-bottom: 1px solid var(--workbench-border); }
+li.current { background: var(--selection-background); }
 .row { display: flex; align-items: center; gap: 8px; }
 .file { background: none; border: none; padding: 0; color: var(--accent); font: inherit; font-size: 12px; cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.file:disabled { color: var(--faint); cursor: default; }
-.state { font: 10px var(--mono); color: var(--faint); text-transform: uppercase; letter-spacing: .4px; }
-.state.addressed { color: var(--yellow); }
-.state.resolved { color: var(--green); }
-.del { margin-left: auto; background: none; border: none; color: var(--faint); cursor: pointer; display: flex; flex: none; }
-.del:hover { color: var(--red); }
-.line { color: var(--faint); }
-.message { margin-top: 8px; padding-left: 9px; border-left: 2px solid var(--border); }
+.file:disabled { color: var(--faint-foreground); cursor: default; }
+.state { font: 10px var(--mono); color: var(--faint-foreground); text-transform: uppercase; letter-spacing: .4px; }
+.state.addressed { color: var(--warning); }
+.state.resolved { color: var(--success); }
+.del { margin-left: auto; background: none; border: none; color: var(--faint-foreground); cursor: pointer; display: flex; flex: none; }
+.del:hover { color: var(--danger); }
+.line { color: var(--faint-foreground); }
+.message { margin-top: 8px; padding-left: 9px; border-left: 2px solid var(--workbench-border); }
 .message.reply { margin-left: 8px; }
-.author { display: block; color: var(--dim); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
+.author { display: block; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
 .author.agent { color: var(--accent); }
-.answer { margin: 8px 0 0 10px; display: flex; align-items: baseline; gap: 7px; font-size: 11.5px; color: var(--faint); }
-.answer code { font: 10.5px var(--mono); background: #262b34; border-radius: 4px; padding: 1px 5px; flex: none; }
+.answer { margin: 8px 0 0 10px; display: flex; align-items: baseline; gap: 7px; font-size: 11.5px; color: var(--faint-foreground); }
+.answer code { font: 10.5px var(--mono); background: var(--badge-background); border-radius: 4px; padding: 1px 5px; flex: none; }
 .text { margin: 3px 0 0; font-size: 12.5px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere; }
 .reply-form { margin-top: 9px; }
-.reply-form input { width: 100%; background: #14161b; border: 1px solid var(--border); border-radius: 6px; color: var(--fg); font: inherit; font-size: 12px; padding: 6px 8px; }
+.reply-form input { width: 100%; background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 6px; color: var(--workbench-foreground); font: inherit; font-size: 12px; padding: 6px 8px; }
 .reply-form input:focus { outline: none; border-color: var(--accent); }
-.reply-form input:disabled { color: var(--faint); }
+.reply-form input:disabled { color: var(--faint-foreground); }
 </style>

--- a/packages/app/src/renderer/src/components/SettingsJsonEditor.vue
+++ b/packages/app/src/renderer/src/components/SettingsJsonEditor.vue
@@ -25,7 +25,6 @@ onMounted(() => {
     model,
     automaticLayout: true,
     ariaLabel: "Settings JSON editor",
-    theme: "vs-dark",
     minimap: { enabled: false },
     scrollBeyondLastLine: false,
     tabSize: 2,

--- a/packages/app/src/renderer/src/components/SettingsPane.vue
+++ b/packages/app/src/renderer/src/components/SettingsPane.vue
@@ -1,15 +1,17 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, shallowRef, watch } from "vue";
-import { Braces, Settings2, SlidersHorizontal, Type, X } from "lucide-vue-next";
+import { Braces, Palette, Settings2, SlidersHorizontal, Type, X } from "lucide-vue-next";
 import type { EditorSettingsStore } from "../editor-settings-store.js";
 import { settingsFromJson, settingsToJson, type AppSettings } from "../../../settings.js";
 import EditorSettings from "./EditorSettings.vue";
 import SettingsJsonEditor from "./SettingsJsonEditor.vue";
+import WorkbenchSettings from "./WorkbenchSettings.vue";
 
 const props = defineProps<{ store: EditorSettingsStore }>();
 const emit = defineEmits<{ close: [] }>();
 
 const mode = shallowRef<"ui" | "json">("ui");
+const category = shallowRef<"workbench" | "editor">("workbench");
 const saveState = shallowRef<"idle" | "saving" | "saved" | "error">("idle");
 const jsonSource = shallowRef(settingsToJson(props.store.settings));
 const jsonError = shallowRef<string | null>(null);
@@ -124,13 +126,29 @@ onBeforeUnmount(() => {
     <div class="settings-body">
       <nav class="categories" aria-label="Settings categories">
         <p>Categories</p>
-        <button class="category active" aria-current="page">
+        <button
+          class="category"
+          :class="{ active: category === 'workbench' }"
+          :aria-current="category === 'workbench' ? 'page' : undefined"
+          @click="category = 'workbench'"
+        >
+          <Palette :size="15" />Workbench
+        </button>
+        <button
+          class="category"
+          :class="{ active: category === 'editor' }"
+          :aria-current="category === 'editor' ? 'page' : undefined"
+          @click="category = 'editor'"
+        >
           <Type :size="15" />Editor
         </button>
       </nav>
 
       <div class="content">
-        <EditorSettings v-if="mode === 'ui'" :store="store" @saved="onUiSaved" />
+        <template v-if="mode === 'ui'">
+          <WorkbenchSettings v-if="category === 'workbench'" :store="store" @saved="onUiSaved" />
+          <EditorSettings v-else :store="store" @saved="onUiSaved" />
+        </template>
         <div v-else class="json-view">
           <div class="json-heading">
             <div>
@@ -155,36 +173,36 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
-.settings-pane { flex: 1; display: grid; grid-template-rows: auto 1fr 28px; min-width: 0; min-height: 0; background: var(--bg); }
-.titlebar { display: flex; align-items: center; justify-content: space-between; gap: 24px; min-height: 64px; padding: 10px 18px; border-bottom: 1px solid var(--border); background: var(--panel); }
+.settings-pane { flex: 1; display: grid; grid-template-rows: auto 1fr 28px; min-width: 0; min-height: 0; background: var(--workbench-background); }
+.titlebar { display: flex; align-items: center; justify-content: space-between; gap: 24px; min-height: 64px; padding: 10px 18px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); }
 .title { display: flex; align-items: center; gap: 10px; min-width: 0; }
-.title > svg { color: var(--dim); flex: none; }
-.title h1 { color: var(--text); font-size: 16px; line-height: 1.25; }
-.title p, .json-heading p { color: var(--faint); font-size: 11.5px; }
+.title > svg { color: var(--muted-foreground); flex: none; }
+.title h1 { color: var(--workbench-foreground); font-size: 16px; line-height: 1.25; }
+.title p, .json-heading p { color: var(--faint-foreground); font-size: 11.5px; }
 .title-actions, .view-switcher { display: flex; align-items: center; gap: 4px; }
-.view-switcher { padding: 2px; border-radius: 7px; background: #14161b; }
+.view-switcher { padding: 2px; border-radius: 7px; background: var(--input-background); }
 .view-switcher button, .close {
   display: flex; align-items: center; justify-content: center; gap: 6px;
   height: 28px; border: 0; border-radius: 5px; background: transparent;
-  color: var(--dim); cursor: pointer; font: inherit; font-size: 12px;
+  color: var(--muted-foreground); cursor: pointer; font: inherit; font-size: 12px;
 }
 .view-switcher button { padding: 0 10px; }
-.view-switcher button.active { background: #2c3340; color: var(--text); }
+.view-switcher button.active { background: var(--elevated-background); color: var(--workbench-foreground); }
 .view-switcher button:focus-visible, .close:focus-visible, .category:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .close { width: 28px; }
-.close:hover { background: rgba(255,255,255,.06); color: var(--text); }
+.close:hover { background: var(--hover-background); color: var(--workbench-foreground); }
 .settings-body { display: grid; grid-template-columns: 190px 1fr; min-width: 0; min-height: 0; }
-.categories { padding: 18px 10px; border-right: 1px solid var(--border); background: var(--panel2); }
-.categories > p { padding: 0 10px 8px; color: var(--faint); font-size: 10.5px; font-weight: 700; letter-spacing: .7px; text-transform: uppercase; }
-.category { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border: 0; border-radius: 5px; background: transparent; color: var(--dim); cursor: default; font: inherit; text-align: left; }
-.category.active { background: rgba(77,159,236,.12); color: var(--text); }
+.categories { padding: 18px 10px; border-right: 1px solid var(--workbench-border); background: var(--secondary-panel-background); }
+.categories > p { padding: 0 10px 8px; color: var(--faint-foreground); font-size: 10.5px; font-weight: 700; letter-spacing: .7px; text-transform: uppercase; }
+.category { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border: 0; border-radius: 5px; background: transparent; color: var(--muted-foreground); cursor: pointer; font: inherit; text-align: left; }
+.category.active { background: var(--selection-background); color: var(--workbench-foreground); }
 .content { min-width: 0; min-height: 0; overflow: hidden; }
 .json-view { display: grid; grid-template-rows: auto 1fr; height: 100%; min-width: 0; min-height: 0; }
 .json-heading { padding: 22px 28px 16px; }
-.json-heading h2 { color: var(--text); font-size: 17px; margin-bottom: 3px; }
-.settings-status { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 0 12px; border-top: 1px solid var(--border); background: var(--panel); color: var(--green); font-size: 11px; }
-.settings-status .error { color: var(--red); }
-.format { margin-left: auto; color: var(--faint); }
+.json-heading h2 { color: var(--workbench-foreground); font-size: 17px; margin-bottom: 3px; }
+.settings-status { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 0 12px; border-top: 1px solid var(--workbench-border); background: var(--panel-background); color: var(--success); font-size: 11px; }
+.settings-status .error { color: var(--danger); }
+.format { margin-left: auto; color: var(--faint-foreground); }
 @media (max-width: 720px) {
   .settings-body { grid-template-columns: 1fr; }
   .categories { display: none; }

--- a/packages/app/src/renderer/src/components/StatusBar.vue
+++ b/packages/app/src/renderer/src/components/StatusBar.vue
@@ -49,13 +49,13 @@ const lastFetch = computed(() => {
 </template>
 
 <style scoped>
-.status { display: flex; align-items: center; gap: 8px; height: 24px; padding: 0 10px; background: var(--panel); border-top: 1px solid var(--border); font-size: 11px; color: var(--faint); flex: none; }
-.toggle { display: flex; align-items: center; background: none; border: none; color: var(--faint); cursor: pointer; padding: 0 2px; }
-.toggle:hover, .toggle[aria-pressed="true"] { color: var(--fg); }
+.status { display: flex; align-items: center; gap: 8px; height: 24px; padding: 0 10px; background: var(--panel-background); border-top: 1px solid var(--workbench-border); font-size: 11px; color: var(--faint-foreground); flex: none; }
+.toggle { display: flex; align-items: center; background: none; border: none; color: var(--faint-foreground); cursor: pointer; padding: 0 2px; }
+.toggle:hover, .toggle[aria-pressed="true"] { color: var(--workbench-foreground); }
 .service { display: flex; align-items: center; gap: 5px; }
-.dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); flex: none; }
-.service.down { color: var(--red); }
-.service.down .dot { background: var(--red); }
+.dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success); flex: none; }
+.service.down { color: var(--danger); }
+.service.down .dot { background: var(--danger); }
 .spacer { flex: 1; }
-.working { color: var(--dim); }
+.working { color: var(--muted-foreground); }
 </style>

--- a/packages/app/src/renderer/src/components/SwitcherDropdown.vue
+++ b/packages/app/src/renderer/src/components/SwitcherDropdown.vue
@@ -22,5 +22,5 @@ const emit = defineEmits<{ close: [] }>();
 
 <style scoped>
 .veil { position: fixed; inset: 0; z-index: 30; }
-.dd { position: fixed; top: 51px; background: var(--panel); border: 1px solid var(--border); border-radius: 0 0 12px 12px; box-shadow: 0 20px 50px rgba(0,0,0,.5); max-height: 65vh; overflow: auto; z-index: 31; min-width: 320px; }
+.dd { position: fixed; top: 51px; background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: 0 0 12px 12px; box-shadow: 0 20px 50px var(--workbench-shadow); max-height: 65vh; overflow: auto; z-index: 31; min-width: 320px; }
 </style>

--- a/packages/app/src/renderer/src/components/TopBar.vue
+++ b/packages/app/src/renderer/src/components/TopBar.vue
@@ -202,61 +202,61 @@ const progress = computed(() => props.store.progress());
 </template>
 
 <style scoped>
-.topbar { display: flex; align-items: stretch; background: var(--panel); border-bottom: 1px solid var(--border); height: 50px; }
-.seg { display: flex; align-items: center; gap: 10px; padding: 0 14px; min-width: 0; border-right: 1px solid var(--border); cursor: pointer; position: relative; }
-.seg:hover { background: #232833; }
+.topbar { display: flex; align-items: stretch; background: var(--panel-background); border-bottom: 1px solid var(--workbench-border); height: 50px; }
+.seg { display: flex; align-items: center; gap: 10px; padding: 0 14px; min-width: 0; border-right: 1px solid var(--workbench-border); cursor: pointer; position: relative; }
+.seg:hover { background: var(--hover-background); }
 .seg:focus-visible, .sw-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.seg .ic { color: var(--dim); flex: none; }
+.seg .ic { color: var(--muted-foreground); flex: none; }
 .seg .col { display: flex; flex-direction: column; justify-content: center; min-width: 0; }
-.seg .lbl { font-size: 10px; letter-spacing: .4px; color: var(--faint); text-transform: uppercase; }
+.seg .lbl { font-size: 10px; letter-spacing: .4px; color: var(--faint-foreground); text-transform: uppercase; }
 .seg .val { font-size: 12.5px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; gap: 6px; }
-.seg .caret { color: var(--faint); flex: none; margin-left: 4px; }
+.seg .caret { color: var(--faint-foreground); flex: none; margin-left: 4px; }
 .seg-repo { width: 190px; }
 .seg-review { flex: 1; max-width: 430px; }
 
-.chip { font: 10.5px var(--mono); background: #262b34; color: var(--dim); border-radius: 9px; padding: 0 7px; white-space: nowrap; flex: none; }
-.chip.draft { color: var(--yellow); border: 1px solid rgba(210,153,34,.4); background: rgba(210,153,34,.08); }
+.chip { font: 10.5px var(--mono); background: var(--badge-background); color: var(--muted-foreground); border-radius: 9px; padding: 0 7px; white-space: nowrap; flex: none; }
+.chip.draft { color: var(--warning); border: 1px solid var(--warning); background: var(--warning-background); }
 
 .spacer { flex: 1; }
 .right { display: flex; align-items: center; gap: 10px; padding: 0 12px; }
-.progress { font-size: 12px; color: var(--dim); background: #262b34; border-radius: 10px; padding: 2px 10px; white-space: nowrap; }
-.progress b { color: var(--green); }
+.progress { font-size: 12px; color: var(--muted-foreground); background: var(--badge-background); border-radius: 10px; padding: 2px 10px; white-space: nowrap; }
+.progress b { color: var(--success); }
 /* Icon-only, sized to stay a comfortable pointer target at any zoom level. */
 .fetch {
   display: flex; align-items: center; justify-content: center;
   width: 28px; height: 28px;
-  background: none; border: 1px solid var(--border); border-radius: 6px;
-  color: var(--fg); cursor: pointer;
+  background: none; border: 1px solid var(--workbench-border); border-radius: 6px;
+  color: var(--workbench-foreground); cursor: pointer;
 }
-.fetch:hover:not(:disabled) { background: rgba(255,255,255,.06); }
-.fetch.active { border-color: var(--accent); background: rgba(77,159,236,.14); color: var(--accent); }
-.fetch:disabled { cursor: default; color: var(--faint); }
+.fetch:hover:not(:disabled) { background: var(--hover-background); }
+.fetch.active { border-color: var(--accent); background: var(--selection-background); color: var(--accent); }
+.fetch:disabled { cursor: default; color: var(--faint-foreground); }
 .fetch { position: relative; }
 .badge {
   position: absolute; top: -5px; right: -5px;
   min-width: 15px; height: 15px; padding: 0 3px;
-  border-radius: 8px; background: var(--accent); color: #0d1117;
+  border-radius: 8px; background: var(--accent); color: var(--accent-foreground);
   font: 700 9.5px var(--mono); display: flex; align-items: center; justify-content: center;
 }
 .fetch .spin { animation: spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 @media (prefers-reduced-motion: reduce) { .fetch .spin { animation: none; } }
 
-.sw-h { font-size: 10.5px; letter-spacing: .8px; color: var(--faint); font-weight: 700; padding: 10px 14px 4px; }
-.sw-empty { padding: 10px 14px; color: var(--faint); font-size: 12px; }
+.sw-h { font-size: 10.5px; letter-spacing: .8px; color: var(--faint-foreground); font-weight: 700; padding: 10px 14px 4px; }
+.sw-empty { padding: 10px 14px; color: var(--faint-foreground); font-size: 12px; }
 .sw-item { display: flex; align-items: center; gap: 8px; padding: 6px 14px; cursor: pointer; }
-.sw-item:hover { background: rgba(77,159,236,.12); }
-.sw-item .ic { color: var(--dim); flex: none; }
-.sw-item .num { font: 12px var(--mono); color: var(--dim); }
+.sw-item:hover { background: var(--selection-background); }
+.sw-item .ic { color: var(--muted-foreground); flex: none; }
+.sw-item .num { font: 12px var(--mono); color: var(--muted-foreground); }
 .sw-item .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sw-item .nm.add { color: var(--accent); }
-.sw-item .meta { margin-left: auto; font: 11px var(--mono); color: var(--faint); }
+.sw-item .meta { margin-left: auto; font: 11px var(--mono); color: var(--faint-foreground); }
 
 .dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
-.dot.draft { background: var(--yellow); }
-.dot.open { background: var(--green); }
+.dot.draft { background: var(--warning); }
+.dot.open { background: var(--success); }
 
 .add-row { padding: 10px 12px; }
-.add-row input { width: 100%; background: var(--panel2); border: 1px solid var(--border); border-radius: 7px; color: var(--text); font-size: 13px; padding: 7px 10px; outline: none; }
+.add-row input { width: 100%; background: var(--secondary-panel-background); border: 1px solid var(--workbench-border); border-radius: 7px; color: var(--workbench-foreground); font-size: 13px; padding: 7px 10px; outline: none; }
 .add-row input:focus { border-color: var(--accent); }
 </style>

--- a/packages/app/src/renderer/src/components/WorkbenchSettings.test.ts
+++ b/packages/app/src/renderer/src/components/WorkbenchSettings.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { reactive } from "vue";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_APP_SETTINGS, type AppSettings } from "../../../settings.js";
+import type { EditorSettingsStore } from "../editor-settings-store.js";
+import WorkbenchSettings from "./WorkbenchSettings.vue";
+
+describe("WorkbenchSettings", () => {
+  it("lists bundled themes and saves the selected registry identifier", async () => {
+    const update = vi.fn(async (settings: AppSettings) => {
+      store.settings = settings;
+      return true;
+    });
+    const store: EditorSettingsStore = reactive({
+      settings: DEFAULT_APP_SETTINGS,
+      busy: false,
+      error: null,
+      async load() {},
+      update,
+    });
+    const wrapper = mount(WorkbenchSettings, { props: { store } });
+
+    const select = wrapper.get("select[name='workbench.colorTheme']");
+    expect((select.element as HTMLSelectElement).value).toBe("Catppuccin Mocha");
+    expect(select.findAll("option").map((option) => option.text())).toEqual([
+      "Catppuccin Mocha",
+      "Gander Dark",
+    ]);
+
+    await select.setValue("Gander Dark");
+    expect(update).toHaveBeenCalledWith({
+      ...DEFAULT_APP_SETTINGS,
+      workbench: { colorTheme: "Gander Dark" },
+    });
+    expect(wrapper.text()).toContain("Source: Gander");
+  });
+});

--- a/packages/app/src/renderer/src/components/WorkbenchSettings.vue
+++ b/packages/app/src/renderer/src/components/WorkbenchSettings.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { EditorSettingsStore } from "../editor-settings-store.js";
+import { DEFAULT_APP_SETTINGS, type ThemeId } from "../../../settings.js";
+import { THEME_IDS, themeFor } from "../../../themes.js";
+
+const props = defineProps<{ store: EditorSettingsStore }>();
+const emit = defineEmits<{ saved: [success: boolean] }>();
+
+const activeTheme = computed(() => themeFor(props.store.settings.workbench.colorTheme));
+const themes = THEME_IDS.map(themeFor);
+
+async function selectTheme(event: Event): Promise<void> {
+  const colorTheme = (event.currentTarget as HTMLSelectElement).value as ThemeId;
+  emit("saved", await props.store.update({
+    ...props.store.settings,
+    workbench: { colorTheme },
+  }));
+}
+
+async function reset(): Promise<void> {
+  emit("saved", await props.store.update({
+    ...props.store.settings,
+    workbench: DEFAULT_APP_SETTINGS.workbench,
+  }));
+}
+</script>
+
+<template>
+  <section class="workbench-settings" aria-labelledby="workbench-settings-title">
+    <header class="heading">
+      <div>
+        <h2 id="workbench-settings-title">Workbench</h2>
+        <p>Colors for Gander's interface and code surfaces.</p>
+      </div>
+      <button class="reset" type="button" :disabled="store.busy" @click="reset">Use default</button>
+    </header>
+
+    <div class="setting">
+      <label for="workbench-color-theme">Color theme</label>
+      <p>Controls <code>workbench.colorTheme</code>. Themes are bundled with Gander.</p>
+      <select
+        id="workbench-color-theme"
+        name="workbench.colorTheme"
+        :value="store.settings.workbench.colorTheme"
+        :disabled="store.busy"
+        @change="selectTheme"
+      >
+        <option v-for="theme in themes" :key="theme.id" :value="theme.id">{{ theme.label }}</option>
+      </select>
+      <p class="source">Source: {{ activeTheme.source }}</p>
+    </div>
+
+    <div class="swatches" role="img" :aria-label="`${activeTheme.label} color palette`">
+      <span v-for="(color, token) in activeTheme.workbench" :key="token" :style="{ backgroundColor: color }" />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.workbench-settings { height: 100%; overflow: auto; padding: 28px; }
+.heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; max-width: 820px; margin-bottom: 30px; }
+.heading h2 { color: var(--workbench-foreground); font-size: 20px; line-height: 1.25; }
+.heading p, .setting > p { color: var(--faint-foreground); font-size: 12px; }
+.reset { border: 0; background: none; color: var(--accent); cursor: pointer; font: inherit; font-size: 12px; white-space: nowrap; }
+.reset:disabled { cursor: default; opacity: .55; }
+.reset:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.setting { max-width: 820px; margin-bottom: 24px; }
+.setting label { display: block; color: var(--workbench-foreground); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
+.setting code { color: var(--muted-foreground); font: 11.5px var(--mono); }
+.setting select {
+  width: min(420px, 100%); margin-top: 8px; padding: 8px 34px 8px 10px;
+  border: 1px solid var(--workbench-border); border-radius: 6px;
+  outline: none; background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 13px;
+}
+.setting select:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
+.source { margin-top: 7px; }
+.swatches { display: flex; width: min(420px, 100%); height: 36px; overflow: hidden; border: 1px solid var(--workbench-border); border-radius: 6px; }
+.swatches span { flex: 1; min-width: 2px; }
+</style>

--- a/packages/app/src/renderer/src/editor-options.ts
+++ b/packages/app/src/renderer/src/editor-options.ts
@@ -14,7 +14,6 @@ export function diffEditorOptions(settings: EditorSettings): editor.IStandaloneD
     readOnly: true,
     automaticLayout: true,
     hideUnchangedRegions: { enabled: true },
-    theme: "vs-dark",
     ...editorFontOptions(settings),
   };
 }
@@ -23,7 +22,6 @@ export function codeEditorOptions(settings: EditorSettings): editor.IStandaloneE
   return {
     readOnly: true,
     automaticLayout: true,
-    theme: "vs-dark",
     ...editorFontOptions(settings),
   };
 }

--- a/packages/app/src/renderer/src/editor-settings-store.ts
+++ b/packages/app/src/renderer/src/editor-settings-store.ts
@@ -1,6 +1,8 @@
 import { reactive } from "vue";
+import * as monaco from "monaco-editor";
 import type { GanderApi } from "./api.js";
-import { DEFAULT_APP_SETTINGS, type AppSettings } from "../../settings.js";
+import { DEFAULT_APP_SETTINGS, parseAppSettings, type AppSettings } from "../../settings.js";
+import { applyAppTheme } from "./theme-runtime.js";
 
 export interface EditorSettingsStore {
   settings: AppSettings;
@@ -13,6 +15,7 @@ export interface EditorSettingsStore {
 function applyCodeSurfaceSettings(settings: AppSettings): void {
   document.documentElement.style.setProperty("--editor-font-family", settings.editor.fontFamily);
   document.documentElement.style.setProperty("--editor-font-size", `${settings.editor.fontSize}px`);
+  applyAppTheme(settings.workbench.colorTheme, document.documentElement, monaco.editor);
 }
 
 export function createEditorSettingsStore(api: Pick<GanderApi, "getSettings" | "updateSettings">): EditorSettingsStore {
@@ -34,7 +37,9 @@ export function createEditorSettingsStore(api: Pick<GanderApi, "getSettings" | "
       store.busy = true;
       store.error = null;
       try {
-        store.settings = await api.updateSettings(settings);
+        // Vue makes nested settings objects reactive. Normalize through the shared
+        // schema so Electron receives plain cloneable data from every settings view.
+        store.settings = await api.updateSettings(parseAppSettings(settings));
         applyCodeSurfaceSettings(store.settings);
         return true;
       } catch (error) {

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -29,7 +29,10 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     addQuestion: async () => prView(),
     addReviewerReply: async () => prView(),
     deleteQuestion: async () => prView(),
-    getSettings: async () => ({ editor: { fontFamily: "monospace", fontSize: 16 } }),
+    getSettings: async () => ({
+      editor: { fontFamily: "monospace", fontSize: 16 },
+      workbench: { colorTheme: "Catppuccin Mocha" },
+    }),
     updateSettings: async (settings) => settings,
     onOpenSettings: () => () => {},
     ...overrides,

--- a/packages/app/src/renderer/src/theme-runtime.test.ts
+++ b/packages/app/src/renderer/src/theme-runtime.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_THEME_ID, THEME_REGISTRY, themeFor } from "../../themes.js";
+import { applyAppTheme } from "./theme-runtime.js";
+
+describe("theme runtime", () => {
+  it("ships Catppuccin Mocha as the complete, attributed default", () => {
+    const theme = themeFor(DEFAULT_THEME_ID);
+    expect(theme.id).toBe("Catppuccin Mocha");
+    expect(theme.source).toBe("Catppuccin for VS Code 3.19.0");
+    expect(Object.keys(theme.workbench)).toHaveLength(26);
+    expect(Object.values(theme.workbench).every(Boolean)).toBe(true);
+    expect(theme.monaco.colors["editor.background"]).toBe("#1e1e2e");
+    expect(theme.monaco.colors["diffEditor.insertedTextBackground"]).toBe("#a6e3a133");
+  });
+
+  it("applies Vue tokens and registers/selects Monaco from the same registry entry", () => {
+    const root = document.createElement("html");
+    const monacoThemeApi = { defineTheme: vi.fn(), setTheme: vi.fn() };
+
+    applyAppTheme("Catppuccin Mocha", root, monacoThemeApi);
+
+    const theme = THEME_REGISTRY["Catppuccin Mocha"];
+    expect(root.dataset.colorTheme).toBe(theme.id);
+    expect(root.style.getPropertyValue("--workbench-background")).toBe(theme.workbench.background);
+    expect(root.style.getPropertyValue("--input-background")).toBe(theme.workbench.inputBackground);
+    expect(root.style.getPropertyValue("--danger-background")).toBe(theme.workbench.dangerBackground);
+    expect(monacoThemeApi.defineTheme).toHaveBeenCalledWith(theme.monacoName, theme.monaco);
+    expect(monacoThemeApi.setTheme).toHaveBeenCalledWith(theme.monacoName);
+
+    applyAppTheme("Gander Dark", root, monacoThemeApi);
+    expect(root.dataset.colorTheme).toBe("Gander Dark");
+    expect(root.style.getPropertyValue("--workbench-background")).toBe("#16181d");
+    expect(monacoThemeApi.setTheme).toHaveBeenLastCalledWith("gander-dark");
+  });
+});

--- a/packages/app/src/renderer/src/theme-runtime.ts
+++ b/packages/app/src/renderer/src/theme-runtime.ts
@@ -1,0 +1,55 @@
+import type { editor } from "monaco-editor";
+import { themeFor, type GanderTheme, type ThemeId } from "../../themes.js";
+
+export interface MonacoThemeApi {
+  defineTheme(themeName: string, themeData: editor.IStandaloneThemeData): void;
+  setTheme(themeName: string): void;
+}
+
+const cssTokenNames: Readonly<Record<keyof GanderTheme["workbench"], string>> = {
+  background: "--workbench-background",
+  panelBackground: "--panel-background",
+  secondaryPanelBackground: "--secondary-panel-background",
+  elevatedBackground: "--elevated-background",
+  inputBackground: "--input-background",
+  badgeBackground: "--badge-background",
+  border: "--workbench-border",
+  foreground: "--workbench-foreground",
+  mutedForeground: "--muted-foreground",
+  faintForeground: "--faint-foreground",
+  accent: "--accent",
+  accentForeground: "--accent-foreground",
+  success: "--success",
+  danger: "--danger",
+  warning: "--warning",
+  info: "--info",
+  hoverBackground: "--hover-background",
+  selectionBackground: "--selection-background",
+  focusRing: "--focus-ring",
+  overlay: "--overlay-background",
+  shadow: "--workbench-shadow",
+  successBackground: "--success-background",
+  dangerBackground: "--danger-background",
+  warningBackground: "--warning-background",
+  addedGutterBackground: "--added-gutter-background",
+  deletedGutterBackground: "--deleted-gutter-background",
+};
+
+export function applyWorkbenchTheme(theme: GanderTheme, root: HTMLElement): void {
+  for (const key of Object.keys(cssTokenNames) as (keyof GanderTheme["workbench"])[]) {
+    root.style.setProperty(cssTokenNames[key], theme.workbench[key]);
+  }
+  root.dataset.colorTheme = theme.id;
+  root.style.colorScheme = theme.monaco.base === "vs" ? "light" : "dark";
+}
+
+export function applyAppTheme(
+  themeId: ThemeId,
+  root: HTMLElement,
+  monacoThemeApi: MonacoThemeApi,
+): void {
+  const theme = themeFor(themeId);
+  applyWorkbenchTheme(theme, root);
+  monacoThemeApi.defineTheme(theme.monacoName, theme.monaco);
+  monacoThemeApi.setTheme(theme.monacoName);
+}

--- a/packages/app/src/renderer/src/theme.css
+++ b/packages/app/src/renderer/src/theme.css
@@ -1,9 +1,32 @@
 :root {
-  --bg: #16181d; --panel: #1c1f26; --panel2: #191c22; --border: #2a2e37;
-  --text: #d7dae0; --dim: #8b919d; --faint: #5c6370;
-  --accent: #4d9fec; --green: #3fb950; --red: #f85149; --yellow: #d29922; --purple: #bc8cff;
-  --add-bg: rgba(63,185,80,.13); --del-bg: rgba(248,81,73,.12);
-  --add-gut: rgba(63,185,80,.25); --del-gut: rgba(248,81,73,.25);
+  /* Static default prevents an unthemed first frame; theme-runtime replaces every
+     color token from the active registry entry as soon as settings are created. */
+  --workbench-background: #1e1e2e;
+  --panel-background: #181825;
+  --secondary-panel-background: #11111b;
+  --elevated-background: #313244;
+  --input-background: #313244;
+  --badge-background: #45475a;
+  --workbench-border: #585b70;
+  --workbench-foreground: #cdd6f4;
+  --muted-foreground: #a6adc8;
+  --faint-foreground: #9399b2;
+  --accent: #cba6f7;
+  --accent-foreground: #11111b;
+  --success: #a6e3a1;
+  --danger: #f38ba8;
+  --warning: #fab387;
+  --info: #89b4fa;
+  --hover-background: #31324480;
+  --selection-background: #cba6f733;
+  --focus-ring: #cba6f766;
+  --overlay-background: #11111bbf;
+  --workbench-shadow: #11111bcc;
+  --success-background: #a6e3a126;
+  --danger-background: #f38ba826;
+  --warning-background: #fab3871f;
+  --added-gutter-background: #a6e3a140;
+  --deleted-gutter-background: #f38ba840;
   --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
   --editor-font-family: 'JetBrainsMono NF', 'FiraCode NF', 'Jetbrains Mono', 'Fira Code', Consolas, 'Courier New', monospace;
   --editor-font-size: 16px;
@@ -11,7 +34,7 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html, body { height: 100%; }
 body {
-  background: var(--bg); color: var(--text);
+  background: var(--workbench-background); color: var(--workbench-foreground);
   font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 code, pre { font-family: var(--editor-font-family); font-size: var(--editor-font-size); }

--- a/packages/app/src/settings.test.ts
+++ b/packages/app/src/settings.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { reactive } from "vue";
 import {
   DEFAULT_APP_SETTINGS,
   DEFAULT_EDITOR_FONT_FAMILY,
@@ -7,20 +8,37 @@ import {
   settingsToJson,
 } from "./settings.js";
 
-describe("editor settings", () => {
+describe("application settings", () => {
   it("uses the issue defaults without changing the ordered fallback list", () => {
     expect(DEFAULT_APP_SETTINGS).toEqual({
       editor: {
         fontFamily: "'JetBrainsMono NF', 'FiraCode NF', 'Jetbrains Mono', 'Fira Code', Consolas, 'Courier New', monospace",
         fontSize: 16,
       },
+      workbench: { colorTheme: "Catppuccin Mocha" },
     });
     expect(DEFAULT_APP_SETTINGS.editor.fontFamily).toBe(DEFAULT_EDITOR_FONT_FAMILY);
   });
 
   it("accepts VS Code-compatible fractional font sizes", () => {
     expect(parseAppSettings({ editor: { fontFamily: "Fira Code, monospace", fontSize: 15.5 } }))
-      .toEqual({ editor: { fontFamily: "Fira Code, monospace", fontSize: 15.5 } });
+      .toEqual({
+        editor: { fontFamily: "Fira Code, monospace", fontSize: 15.5 },
+        workbench: { colorTheme: "Catppuccin Mocha" },
+      });
+  });
+
+  it("normalizes Vue settings proxies into data Electron can clone", () => {
+    const reactiveSettings = reactive({
+      editor: { ...DEFAULT_APP_SETTINGS.editor },
+      workbench: { colorTheme: "Gander Dark" as const },
+    });
+    const parsed = parseAppSettings(reactiveSettings);
+
+    expect(() => structuredClone(parsed)).not.toThrow();
+    expect(parsed).not.toBe(reactiveSettings);
+    expect(parsed.editor).not.toBe(reactiveSettings.editor);
+    expect(parsed.workbench).not.toBe(reactiveSettings.workbench);
   });
 
   it.each([
@@ -28,6 +46,7 @@ describe("editor settings", () => {
     [{ editor: { fontFamily: "monospace", fontSize: 5 } }, "fontSize"],
     [{ editor: { fontFamily: "monospace", fontSize: 101 } }, "fontSize"],
     [{ editor: { fontFamily: "monospace", fontSize: Number.NaN } }, "fontSize"],
+    [{ editor: { fontFamily: "monospace", fontSize: 16 }, workbench: { colorTheme: "Unknown" } }, "colorTheme"],
   ])("rejects invalid persisted or IPC input", (value, field) => {
     expect(() => parseAppSettings(value)).toThrow(new RegExp(field));
   });
@@ -37,6 +56,7 @@ describe("editor settings", () => {
     expect(JSON.parse(source)).toEqual({
       "editor.fontFamily": DEFAULT_EDITOR_FONT_FAMILY,
       "editor.fontSize": 16,
+      "workbench.colorTheme": "Catppuccin Mocha",
     });
     expect(source).not.toContain("serviceToken");
     expect(settingsFromJson(source, DEFAULT_APP_SETTINGS)).toEqual(DEFAULT_APP_SETTINGS);
@@ -47,16 +67,19 @@ describe("editor settings", () => {
     expect(settingsFromJson(JSON.stringify({
       "editor.fontFamily": "Consolas, monospace",
       "editor.fontSize": 18,
+      "workbench.colorTheme": "Gander Dark",
     }), current)).toEqual({
       futureSetting: true,
       editor: { fontFamily: "Consolas, monospace", fontSize: 18 },
+      workbench: { colorTheme: "Gander Dark" },
     });
   });
 
   it.each([
     ["{", /Invalid settings JSON/],
     [JSON.stringify({ "editor.fontFamily": "monospace" }), /editor\.fontSize/],
-    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, serviceToken: "nope" }), /Unrecognized key/],
+    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, "workbench.colorTheme": "Unknown" }), /workbench\.colorTheme/],
+    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, "workbench.colorTheme": "Catppuccin Mocha", serviceToken: "nope" }), /Unrecognized key/],
   ])("rejects invalid or non-public settings JSON", (source, message) => {
     expect(() => settingsFromJson(source, DEFAULT_APP_SETTINGS)).toThrow(message);
   });

--- a/packages/app/src/settings.ts
+++ b/packages/app/src/settings.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DEFAULT_THEME_ID, THEME_IDS, type ThemeId } from "./themes.js";
 
 export const DEFAULT_EDITOR_FONT_FAMILY =
   "'JetBrainsMono NF', 'FiraCode NF', 'Jetbrains Mono', 'Fira Code', Consolas, 'Courier New', monospace";
@@ -10,24 +11,41 @@ export const EditorSettingsSchema = z.object({
   fontSize: z.number().finite().min(6).max(100),
 });
 
+export const ThemeIdSchema = z.enum(THEME_IDS);
+
+export const WorkbenchSettingsSchema = z.object({
+  colorTheme: ThemeIdSchema,
+});
+
+export const DEFAULT_WORKBENCH_SETTINGS: Readonly<WorkbenchSettings> = Object.freeze({
+  colorTheme: DEFAULT_THEME_ID,
+});
+
 export const AppSettingsSchema = z.object({
   editor: EditorSettingsSchema,
+  // Existing config files predate workbench settings. Preserve their editor choices
+  // while adding the bundled default instead of rejecting the whole settings object.
+  workbench: WorkbenchSettingsSchema.default(DEFAULT_WORKBENCH_SETTINGS),
 }).passthrough();
 
 export const SettingsJsonSchema = z.object({
   "editor.fontFamily": EditorSettingsSchema.shape.fontFamily,
   "editor.fontSize": EditorSettingsSchema.shape.fontSize,
+  "workbench.colorTheme": ThemeIdSchema,
 }).strict();
 
 export type EditorSettings = z.infer<typeof EditorSettingsSchema>;
+export type WorkbenchSettings = z.infer<typeof WorkbenchSettingsSchema>;
 export type AppSettings = z.infer<typeof AppSettingsSchema>;
 export type SettingsJson = z.infer<typeof SettingsJsonSchema>;
+export type { ThemeId };
 
 export const DEFAULT_APP_SETTINGS: AppSettings = Object.freeze({
   editor: Object.freeze({
     fontFamily: DEFAULT_EDITOR_FONT_FAMILY,
     fontSize: 16,
   }),
+  workbench: DEFAULT_WORKBENCH_SETTINGS,
 });
 
 export function parseAppSettings(value: unknown): AppSettings {
@@ -36,13 +54,14 @@ export function parseAppSettings(value: unknown): AppSettings {
   const details = parsed.error.issues
     .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
     .join(", ");
-  throw new Error(`Invalid editor settings: ${details}`);
+  throw new Error(`Invalid application settings: ${details}`);
 }
 
 export function settingsToJson(settings: AppSettings): string {
   const publicSettings: SettingsJson = {
     "editor.fontFamily": settings.editor.fontFamily,
     "editor.fontSize": settings.editor.fontSize,
+    "workbench.colorTheme": settings.workbench.colorTheme,
   };
   return JSON.stringify(publicSettings, null, 2);
 }
@@ -68,6 +87,9 @@ export function settingsFromJson(source: string, current: AppSettings): AppSetti
     editor: {
       fontFamily: parsed.data["editor.fontFamily"],
       fontSize: parsed.data["editor.fontSize"],
+    },
+    workbench: {
+      colorTheme: parsed.data["workbench.colorTheme"],
     },
   };
 }

--- a/packages/app/src/themes.ts
+++ b/packages/app/src/themes.ts
@@ -1,0 +1,206 @@
+import type { editor } from "monaco-editor";
+
+export const THEME_IDS = ["Catppuccin Mocha", "Gander Dark"] as const;
+export type ThemeId = (typeof THEME_IDS)[number];
+
+export interface WorkbenchThemeTokens {
+  background: string;
+  panelBackground: string;
+  secondaryPanelBackground: string;
+  elevatedBackground: string;
+  inputBackground: string;
+  badgeBackground: string;
+  border: string;
+  foreground: string;
+  mutedForeground: string;
+  faintForeground: string;
+  accent: string;
+  accentForeground: string;
+  success: string;
+  danger: string;
+  warning: string;
+  info: string;
+  hoverBackground: string;
+  selectionBackground: string;
+  focusRing: string;
+  overlay: string;
+  shadow: string;
+  successBackground: string;
+  dangerBackground: string;
+  warningBackground: string;
+  addedGutterBackground: string;
+  deletedGutterBackground: string;
+}
+
+export interface GanderTheme {
+  id: ThemeId;
+  label: string;
+  source: string;
+  workbench: WorkbenchThemeTokens;
+  monacoName: string;
+  monaco: editor.IStandaloneThemeData;
+}
+
+const catppuccinMochaWorkbench = {
+  background: "#1e1e2e",
+  panelBackground: "#181825",
+  secondaryPanelBackground: "#11111b",
+  elevatedBackground: "#313244",
+  inputBackground: "#313244",
+  badgeBackground: "#45475a",
+  border: "#585b70",
+  foreground: "#cdd6f4",
+  mutedForeground: "#a6adc8",
+  faintForeground: "#9399b2",
+  accent: "#cba6f7",
+  accentForeground: "#11111b",
+  success: "#a6e3a1",
+  danger: "#f38ba8",
+  warning: "#fab387",
+  info: "#89b4fa",
+  hoverBackground: "#31324480",
+  selectionBackground: "#cba6f733",
+  focusRing: "#cba6f766",
+  overlay: "#11111bbf",
+  shadow: "#11111bcc",
+  successBackground: "#a6e3a126",
+  dangerBackground: "#f38ba826",
+  warningBackground: "#fab3871f",
+  addedGutterBackground: "#a6e3a140",
+  deletedGutterBackground: "#f38ba840",
+} satisfies WorkbenchThemeTokens;
+
+// Adapted from Catppuccin for VS Code 3.19.0's generated Mocha theme. The
+// bundled notice records the source and license; Gander never reads VS Code at runtime.
+const catppuccinMochaMonaco: editor.IStandaloneThemeData = {
+  base: "vs-dark",
+  inherit: true,
+  rules: [
+    { token: "", foreground: "cdd6f4" },
+    { token: "comment", foreground: "9399b2", fontStyle: "italic" },
+    { token: "string", foreground: "a6e3a1" },
+    { token: "string.escape", foreground: "f5c2e7" },
+    { token: "number", foreground: "fab387" },
+    { token: "keyword", foreground: "cba6f7" },
+    { token: "operator", foreground: "94e2d5" },
+    { token: "delimiter", foreground: "9399b2" },
+    { token: "type", foreground: "f9e2af" },
+    { token: "type.identifier", foreground: "f9e2af" },
+    { token: "identifier", foreground: "cdd6f4" },
+    { token: "variable", foreground: "cdd6f4" },
+    { token: "variable.predefined", foreground: "f38ba8" },
+    { token: "function", foreground: "89b4fa" },
+    { token: "tag", foreground: "cba6f7" },
+    { token: "attribute.name", foreground: "89b4fa" },
+    { token: "attribute.value", foreground: "a6e3a1" },
+    { token: "constant", foreground: "fab387" },
+    { token: "regexp", foreground: "f5c2e7" },
+    { token: "annotation", foreground: "fab387" },
+  ],
+  colors: {
+    "editor.background": "#1e1e2e",
+    "editor.foreground": "#cdd6f4",
+    "editorCursor.foreground": "#f5e0dc",
+    "editorLineNumber.foreground": "#7f849c",
+    "editorLineNumber.activeForeground": "#cba6f7",
+    "editor.selectionBackground": "#9399b240",
+    "editor.selectionHighlightBackground": "#9399b233",
+    "editor.lineHighlightBackground": "#cdd6f412",
+    "editor.findMatchBackground": "#5e3f53",
+    "editor.findMatchHighlightBackground": "#3e5767",
+    "editor.foldBackground": "#89dceb40",
+    "editorIndentGuide.background1": "#45475a",
+    "editorIndentGuide.activeBackground1": "#585b70",
+    "editorWhitespace.foreground": "#9399b266",
+    "editorGutter.background": "#1e1e2e",
+    "editorGutter.addedBackground": "#a6e3a1",
+    "editorGutter.deletedBackground": "#f38ba8",
+    "editorGutter.modifiedBackground": "#f9e2af",
+    "editorOverviewRuler.border": "#cdd6f412",
+    "editorWidget.background": "#181825",
+    "editorWidget.foreground": "#cdd6f4",
+    "editorWidget.border": "#585b70",
+    "input.background": "#313244",
+    "input.foreground": "#cdd6f4",
+    "input.placeholderForeground": "#cdd6f473",
+    "focusBorder": "#cba6f7",
+    "scrollbar.shadow": "#11111b",
+    "scrollbarSlider.background": "#585b7080",
+    "scrollbarSlider.hoverBackground": "#6c7086",
+    "scrollbarSlider.activeBackground": "#31324466",
+    "diffEditor.border": "#585b70",
+    "diffEditor.insertedTextBackground": "#a6e3a133",
+    "diffEditor.removedTextBackground": "#f38ba833",
+    "diffEditor.insertedLineBackground": "#a6e3a126",
+    "diffEditor.removedLineBackground": "#f38ba826",
+    "diffEditor.diagonalFill": "#585b7099",
+  },
+};
+
+const ganderDarkWorkbench = {
+  background: "#16181d",
+  panelBackground: "#1c1f26",
+  secondaryPanelBackground: "#191c22",
+  elevatedBackground: "#2c3340",
+  inputBackground: "#14161b",
+  badgeBackground: "#262b34",
+  border: "#2a2e37",
+  foreground: "#d7dae0",
+  mutedForeground: "#8b919d",
+  faintForeground: "#8b919d",
+  accent: "#4d9fec",
+  accentForeground: "#0d1117",
+  success: "#3fb950",
+  danger: "#f85149",
+  warning: "#d29922",
+  info: "#bc8cff",
+  hoverBackground: "#232833",
+  selectionBackground: "#4d9fec24",
+  focusRing: "#4d9fec29",
+  overlay: "#00000073",
+  shadow: "#00000080",
+  successBackground: "#3fb95021",
+  dangerBackground: "#f851491f",
+  warningBackground: "#d2992214",
+  addedGutterBackground: "#3fb95040",
+  deletedGutterBackground: "#f8514940",
+} satisfies WorkbenchThemeTokens;
+
+const ganderDarkMonaco: editor.IStandaloneThemeData = {
+  base: "vs-dark",
+  inherit: true,
+  rules: [],
+  colors: {
+    "editor.background": "#14161b",
+    "editor.foreground": "#d7dae0",
+    "diffEditor.insertedLineBackground": "#3fb95021",
+    "diffEditor.removedLineBackground": "#f851491f",
+    "diffEditor.insertedTextBackground": "#3fb95040",
+    "diffEditor.removedTextBackground": "#f8514940",
+  },
+};
+
+export const THEME_REGISTRY: Readonly<Record<ThemeId, GanderTheme>> = Object.freeze({
+  "Catppuccin Mocha": Object.freeze({
+    id: "Catppuccin Mocha",
+    label: "Catppuccin Mocha",
+    source: "Catppuccin for VS Code 3.19.0",
+    workbench: Object.freeze(catppuccinMochaWorkbench),
+    monacoName: "gander-catppuccin-mocha",
+    monaco: Object.freeze(catppuccinMochaMonaco),
+  }),
+  "Gander Dark": Object.freeze({
+    id: "Gander Dark",
+    label: "Gander Dark",
+    source: "Gander",
+    workbench: Object.freeze(ganderDarkWorkbench),
+    monacoName: "gander-dark",
+    monaco: Object.freeze(ganderDarkMonaco),
+  }),
+});
+
+export const DEFAULT_THEME_ID: ThemeId = "Catppuccin Mocha";
+
+export function themeFor(id: ThemeId): GanderTheme {
+  return THEME_REGISTRY[id];
+}

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,10 @@
+# Bundled third-party themes
+
+Gander's Catppuccin Mocha workbench and Monaco definitions are adapted from
+`Catppuccin for VS Code` version 3.19.0, published at
+<https://github.com/catppuccin/vscode>. The bundled source values live in
+`packages/app/src/themes.ts`; Gander does not read an installed VS Code
+extension or VS Code settings at runtime.
+
+Catppuccin is used under the MIT license in
+`catppuccin-vscode-LICENSE.txt`.

--- a/third_party/catppuccin-vscode-LICENSE.txt
+++ b/third_party/catppuccin-vscode-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Catppuccin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- add a typed bundled theme registry with Catppuccin Mocha as the default and Gander Dark as a switchable fallback
- apply each theme's semantic tokens across the Vue workbench and register its matching Monaco theme from the same source
- persist and validate `workbench.colorTheme` in the Settings UI and Settings JSON without remounting the active review
- include Catppuccin for VS Code 3.19.0 provenance and its MIT license

Closes #3

## Readiness

- Simplify: clean
- Code review: clean; reactive IPC normalization and duplicate palette keys fixed
- Impeccable audit/polish: detector clean; semantic theme tokens and accessible faint text verified
- Adversarial review: skipped (low-risk UI/settings change)

## Test plan

- `pnpm test` — 190 tests pass
- `pnpm typecheck` — all packages pass
- `pnpm test:e2e` — Electron settings, live switching, no-remount behavior, Settings JSON, and restart persistence pass
