### PR TITLE
Show the file-tree scrollbar only on hover

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -314,6 +314,36 @@ describe("Gander end to end", () => {
     await expect($(".message.reply .text")).toHaveText("Because both callers share this path.");
   });
 
+  it("shows the overflowing file-tree scrollbar only while the tree is hovered", async () => {
+    await registerAndSelect(requiredEnv("GANDER_E2E_SCROLLBAR_URL"), "scrollbar");
+    await openPullRequest("Scroll a long file tree");
+
+    const tree = await $(".review-surface > .tree");
+    await tree.waitForDisplayed();
+    const treeMetrics = async () => browser.execute(() => {
+      const panel = document.querySelector<HTMLElement>(".review-surface > .tree");
+      const row = panel?.querySelector<HTMLElement>(".tnode");
+      if (!panel || !row) return null;
+      return {
+        clientHeight: panel.clientHeight,
+        rowWidth: row.getBoundingClientRect().width,
+        scrollHeight: panel.scrollHeight,
+        scrollbarColor: getComputedStyle(panel).scrollbarColor,
+      };
+    });
+
+    const resting = await treeMetrics();
+    expect(resting).not.toBeNull();
+    expect(resting!.scrollHeight).toBeGreaterThan(resting!.clientHeight);
+    expect(resting!.scrollbarColor).toBe("rgba(0, 0, 0, 0) rgba(0, 0, 0, 0)");
+
+    await tree.moveTo();
+    await browser.waitUntil(async () => (await treeMetrics())?.scrollbarColor
+      === "rgb(147, 153, 178) rgb(88, 91, 112)");
+    const hovered = await treeMetrics();
+    expect(hovered!.rowWidth).toBe(resting!.rowWidth);
+  });
+
   it("opens a pull request twice quickly with one valid clone", async () => {
     await registerAndSelect(requiredEnv("GANDER_E2E_RACE_URL"), "race");
     await openPullRequest("Open without corrupting the clone", true);

--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -329,6 +329,7 @@ describe("Gander end to end", () => {
         rowWidth: row.getBoundingClientRect().width,
         scrollHeight: panel.scrollHeight,
         scrollbarColor: getComputedStyle(panel).scrollbarColor,
+        scrollbarWidth: getComputedStyle(panel).scrollbarWidth,
       };
     });
 
@@ -336,10 +337,11 @@ describe("Gander end to end", () => {
     expect(resting).not.toBeNull();
     expect(resting!.scrollHeight).toBeGreaterThan(resting!.clientHeight);
     expect(resting!.scrollbarColor).toBe("rgba(0, 0, 0, 0) rgba(0, 0, 0, 0)");
+    expect(resting!.scrollbarWidth).toBe("thin");
 
     await tree.moveTo();
     await browser.waitUntil(async () => (await treeMetrics())?.scrollbarColor
-      === "rgb(147, 153, 178) rgb(88, 91, 112)");
+      === "color(srgb 0.576471 0.6 0.698039 / 0.45) rgba(0, 0, 0, 0)");
     const hovered = await treeMetrics();
     expect(hovered!.rowWidth).toBe(resting!.rowWidth);
   });

--- a/packages/app/e2e/run.ts
+++ b/packages/app/e2e/run.ts
@@ -40,7 +40,7 @@ async function main(): Promise<void> {
   const databasePath = join(root, "gander.db");
   const userDataPath = join(root, "user-data");
   const raceMarkerPath = join(root, "concurrent-race-requests");
-  const [persistence, race, launcher, icons] = await Promise.all([
+  const [persistence, race, launcher, icons, scrollbar] = await Promise.all([
     repoFixture("acme/persistence", "Persist reviewed files"),
     repoFixture("acme/race", "Open without corrupting the clone"),
     repoFixture("acme/launcher", "Open from the command line"),
@@ -54,8 +54,16 @@ async function main(): Promise<void> {
       "types/index.d.ts": "export declare const ready: boolean;\n",
       "unknown/file.mystery": "unknown\n",
     }),
+    repoFixture(
+      "acme/scrollbar",
+      "Scroll a long file tree",
+      Object.fromEntries(Array.from({ length: 80 }, (_, index) => [
+        `src/file-${String(index + 1).padStart(2, "0")}.ts`,
+        `export const value${index + 1} = ${index + 1};\n`,
+      ])),
+    ),
   ]);
-  const fixtures = [persistence, race, launcher, icons];
+  const fixtures = [persistence, race, launcher, icons, scrollbar];
   const storage = openStorage(databasePath);
   const service = buildServer({ storage, token: SERVICE_TOKEN, version: "e2e" });
   const github = Fastify({ logger: false });
@@ -117,6 +125,7 @@ async function main(): Promise<void> {
       GANDER_E2E_RACE_MARKER: raceMarkerPath,
       GANDER_E2E_LAUNCHER_REPO: launcher.repoId,
       GANDER_E2E_ICONS_URL: icons.url,
+      GANDER_E2E_SCROLLBAR_URL: scrollbar.url,
       // Where the app listens with no allocated socket in the environment: beside the
       // suite's own user data, so this run cannot reach a development app.
       GANDER_E2E_APP_SOCKET: join(userDataPath, "app.sock"),

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -40,6 +40,8 @@ const unconfigured = ref(false);
 const capturing = ref(false);
 const drawerOpen = ref(false);
 const treeVisible = ref(true);
+const treeScrolling = shallowRef(false);
+let treeScrollTimer: ReturnType<typeof setTimeout> | undefined;
 const activeSurface = shallowRef<"review" | "settings">("review");
 const treeTypography = computed(() => effectiveTreeTypography(editorSettings.settings));
 // Which section the settings surface opens on. The prompt about a missing service leads
@@ -85,6 +87,12 @@ const questionsSize = computed({
   },
 });
 const questionCount = computed(() => store.view?.questions.length ?? 0);
+
+function onTreeScroll(): void {
+  treeScrolling.value = true;
+  clearTimeout(treeScrollTimer);
+  treeScrollTimer = setTimeout(() => { treeScrolling.value = false; }, 500);
+}
 
 // Monaco takes keyboard input through a hidden textarea, so clicking a line to position
 // the cursor makes the diff the focused "text field" — and a naive typing check hands it
@@ -139,6 +147,7 @@ window.addEventListener("focus", onFocus);
 onBeforeUnmount(() => {
   clearInterval(timer);
   clearInterval(healthTimer);
+  clearTimeout(treeScrollTimer);
   window.removeEventListener("focus", onFocus);
   window.removeEventListener("keydown", onKey, true);
   unsubscribeOpenTarget?.();
@@ -185,7 +194,9 @@ onBeforeUnmount(() => {
             :icon-theme="editorSettings.settings.workbench.iconTheme"
             :typography="treeTypography"
             class="tree"
+            :class="{ scrolling: treeScrolling }"
             :style="{ width: `${treeWidth}px` }"
+            @scroll.passive="onTreeScroll"
           />
           <Splitter
             v-if="treeVisible"
@@ -250,6 +261,22 @@ onBeforeUnmount(() => {
 .workspace.bottom { flex-direction: column; }
 .drawer { flex: none; }
 .workspace.bottom .drawer { border-left: none; border-top: 1px solid var(--workbench-border); }
-.tree { flex: none; border-right: 1px solid var(--workbench-border); overflow: hidden auto; }
+.tree {
+  --scrollbar-thumb: transparent;
+  --scrollbar-track: transparent;
+  flex: none;
+  border-right: 1px solid var(--workbench-border);
+  overflow: hidden auto;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  scrollbar-gutter: stable;
+  scrollbar-width: auto;
+  transition: scrollbar-color 120ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.tree:hover, .tree:focus-within, .tree.scrolling {
+  --scrollbar-thumb: var(--faint-foreground);
+  --scrollbar-track: var(--workbench-border);
+}
 .diff { flex: 1; min-width: 0; min-height: 0; overflow: hidden; }
+@media (prefers-reduced-motion: reduce) { .tree { transition: none; } }
+@media (forced-colors: active) { .tree { scrollbar-color: auto; } }
 </style>

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -269,14 +269,17 @@ onBeforeUnmount(() => {
   overflow: hidden auto;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   scrollbar-gutter: stable;
-  scrollbar-width: auto;
+  scrollbar-width: thin;
   transition: scrollbar-color 120ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 .tree:hover, .tree:focus-within, .tree.scrolling {
-  --scrollbar-thumb: var(--faint-foreground);
-  --scrollbar-track: var(--workbench-border);
+  --scrollbar-thumb: color-mix(in srgb, var(--faint-foreground) 45%, transparent);
+  --scrollbar-track: transparent;
 }
 .diff { flex: 1; min-width: 0; min-height: 0; overflow: hidden; }
 @media (prefers-reduced-motion: reduce) { .tree { transition: none; } }
+@media (prefers-contrast: more) {
+  .tree:hover, .tree:focus-within, .tree.scrolling { --scrollbar-thumb: var(--workbench-foreground); }
+}
 @media (forced-colors: active) { .tree { scrollbar-color: auto; } }
 </style>


### PR DESCRIPTION
## Summary

- hide the file-tree scrollbar while the panel is idle
- match VS Code with a thin, translucent thumb and transparent track
- reveal it on hover, keyboard focus, and active scrolling without shifting file rows
- respect reduced-motion and forced-colors accessibility preferences
- add an overflowing Electron E2E fixture covering the resting and hovered states

## Why

The file tree used the native automatic scrollbar appearance, leaving a persistent track and thumb beside the diff whenever its content overflowed. The tree now keeps that browser surface quiet until the reviewer interacts with it.

## Validation

- `pnpm test` — 221 tests passing
- `pnpm typecheck` — all packages passing
- `pnpm test:e2e` — 8 tests passing
- Impeccable UI detector — no findings

Closes #42
