### PR TITLE
Give the review progress indicator a cohesive text style

### DIFF
--- a/packages/app/src/renderer/src/components/TopBar.test.ts
+++ b/packages/app/src/renderer/src/components/TopBar.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import type { Store } from "../store.js";
+import TopBar from "./TopBar.vue";
+
+function storeWithProgress(done: number, total: number): Store {
+  return {
+    repos: [],
+    prs: [],
+    currentRepoId: null,
+    view: null,
+    busy: false,
+    progress: () => ({ done, total }),
+  } as unknown as Store;
+}
+
+describe("TopBar", () => {
+  it.each([
+    { done: 0, total: 0, state: "progress-empty" },
+    { done: 2, total: 5, state: "progress-partial" },
+    { done: 5, total: 5, state: "progress-complete" },
+  ])("renders $done/$total progress as one $state status", ({ done, total, state }) => {
+    const wrapper = mount(TopBar, {
+      props: {
+        store: storeWithProgress(done, total),
+        questions: 0,
+        settingsActive: false,
+        integratedTitleBar: false,
+      },
+    });
+
+    const progress = wrapper.get(".progress");
+    expect(progress.text()).toBe(`${done}/${total} reviewed`);
+    expect(progress.classes()).toContain(state);
+    expect(progress.find("b").exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+});

--- a/packages/app/src/renderer/src/components/TopBar.vue
+++ b/packages/app/src/renderer/src/components/TopBar.vue
@@ -78,6 +78,10 @@ const currentRepoLabel = computed(() =>
 );
 const currentPr = computed(() => props.store.view?.pr ?? null);
 const progress = computed(() => props.store.progress());
+const progressState = computed(() => {
+  if (progress.value.total === 0) return "progress-empty";
+  return progress.value.done === progress.value.total ? "progress-complete" : "progress-partial";
+});
 const TITLE_BAR_INSET = 78;
 const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET : 0);
 </script>
@@ -157,7 +161,7 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
       >
         <RefreshCw :size="16" :class="{ spin: store.busy }" />
       </button>
-      <span class="progress"><b>{{ progress.done }}</b>/{{ progress.total }} reviewed</span>
+      <span class="progress" :class="progressState">{{ progress.done }}/{{ progress.total }} reviewed</span>
     </div>
   </div>
 
@@ -241,7 +245,8 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
 .spacer { flex: 1; }
 .right { display: flex; align-items: center; gap: 10px; padding: 0 12px; }
 .progress { font-size: 12px; color: var(--muted-foreground); background: var(--badge-background); border-radius: 10px; padding: 2px 10px; white-space: nowrap; }
-.progress b { color: var(--success); }
+.progress.progress-empty { color: var(--faint-foreground); }
+.progress.progress-complete { color: var(--success); background: var(--success-background); }
 /* Icon-only, sized to stay a comfortable pointer target at any zoom level. */
 .fetch {
   display: flex; align-items: center; justify-content: center;


### PR DESCRIPTION
## Summary

- render the review progress label as one cohesive text unit
- keep empty and partial progress neutral, and reserve success styling for a genuinely completed review
- cover empty, partial, and complete progress states with a focused component test

## Why

The progress pill styled only its numerator green, which split a single status into competing visual fragments and made `0/0 reviewed` look successful. The updated treatment applies state styling to the whole pill and uses the existing theme tokens, so it stays coherent across supported themes.

## Validation

- `pnpm test` — 229 passed
- `pnpm typecheck`
- `pnpm test:e2e` — 7 passed
- UI detector and `git diff --check`
- regression test confirmed to fail against the previous implementation

Closes #38
