### PR TITLE
Show zoom level and controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ stands.
 Gander exposes VS Code-style public keys in its Settings JSON view. File-tree
 typography is deliberately separate from editor typography:
 
+- `window.zoomLevel` sets the persisted scale for every window. `0` is 100%,
+  and fractional values provide finer control than the View menu shortcuts.
 - `workbench.tree.fontFamily` and `workbench.tree.fontSize` control file and
   directory labels.
 - `workbench.tree.inheritEditorTypography` explicitly switches the tree to

--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -112,6 +112,27 @@ describe("Gander end to end", () => {
     }
   });
 
+  it("changes the visible workbench zoom from the status-bar toolbar", async () => {
+    const trigger = await $("button[aria-label^='Zoom:']");
+    await expect(trigger).toHaveText("100%");
+    await trigger.click();
+
+    const zoomIn = await $("button[aria-label='Zoom in']");
+    await zoomIn.waitForDisplayed();
+    await zoomIn.click();
+    await browser.waitUntil(async () => (await trigger.getText()) === "110%");
+    expect(await browser.electron.execute((electron) =>
+      electron.BrowserWindow.getAllWindows()[0]?.webContents.getZoomLevel(),
+    )).toBeCloseTo(0.5);
+
+    const reset = await $("button[aria-label='Reset zoom to 100%']");
+    await reset.click();
+    await browser.waitUntil(async () => (await trigger.getText()) === "100%");
+    expect(await browser.electron.execute((electron) =>
+      electron.BrowserWindow.getAllWindows()[0]?.webContents.getZoomLevel(),
+    )).toBeCloseTo(0);
+  });
+
   it("changes workbench and editor settings live and keeps them after restart", async () => {
     await $("button[aria-label='Editor settings']").click();
     await expect($(".settings-pane h1")).toHaveText("Settings");
@@ -121,7 +142,9 @@ describe("Gander end to end", () => {
     await expect(iconTheme).toHaveValue("catppuccin-mocha");
     const treeFamily = await $("input[name='workbench.tree.fontFamily']");
     const treeSize = await $("input[name='workbench.tree.fontSize']");
+    const zoomLevel = await $("input[name='window.zoomLevel']");
     const inheritEditorTypography = await $("input[name='workbench.tree.inheritEditorTypography']");
+    await expect(zoomLevel).toHaveValue("0");
     await expect(treeFamily).toHaveValue('-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif');
     await expect(treeSize).toHaveValue("13");
     await expect(inheritEditorTypography).not.toBeChecked();
@@ -177,6 +200,7 @@ describe("Gander end to end", () => {
     )).replaceAll("\u00a0", " ");
     expect(jsonSource).toContain("editor.fontFamily");
     expect(jsonSource).toContain("editor.fontSize");
+    expect(jsonSource).toContain("window.zoomLevel");
     expect(jsonSource).toContain("workbench.colorTheme");
     expect(jsonSource).toContain("workbench.iconTheme");
     expect(jsonSource).toContain("workbench.tree.fontFamily");
@@ -202,6 +226,7 @@ describe("Gander end to end", () => {
         .gander.initialWindowState.colorTheme,
     )).toBe("Gander Dark");
     await expect($("select[name='workbench.iconTheme']")).toHaveValue("catppuccin-mocha");
+    await expect($("input[name='window.zoomLevel']")).toHaveValue("0");
     await expect($("input[name='workbench.tree.fontFamily']")).toHaveValue("Arial, sans-serif");
     await expect($("input[name='workbench.tree.fontSize']")).toHaveValue("14.5");
     await expect($("input[name='workbench.tree.inheritEditorTypography']")).not.toBeChecked();

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -49,4 +49,7 @@ export interface GanderApi {
   getSettings(): Promise<AppSettings>;
   updateSettings(settings: AppSettings): Promise<AppSettings>;
   onOpenSettings(listener: () => void): () => void;
+  getZoomLevel(): Promise<number>;
+  setZoomLevel(level: number): Promise<number>;
+  onZoomChanged(listener: (level: number) => void): () => void;
 }

--- a/packages/app/src/main/config.test.ts
+++ b/packages/app/src/main/config.test.ts
@@ -33,6 +33,7 @@ describe("config", () => {
       serviceUrl: "http://h:8390", serviceToken: "t", repos: [],
       settings: {
         editor: { fontFamily: "'Fira Code', monospace", fontSize: 18.5 },
+        window: { zoomLevel: 0.5 },
         workbench: {
           colorTheme: "Gander Dark",
           iconTheme: "catppuccin-mocha",
@@ -41,6 +42,7 @@ describe("config", () => {
       },
     }, cfgPath);
     expect(loadConfig(cfgPath).settings.editor).toEqual({ fontFamily: "'Fira Code', monospace", fontSize: 18.5 });
+    expect(loadConfig(cfgPath).settings.window.zoomLevel).toBe(0.5);
     expect(loadConfig(cfgPath).settings.workbench.colorTheme).toBe("Gander Dark");
     expect(loadConfig(cfgPath).settings.workbench.tree).toEqual({
       fontFamily: "system-ui",
@@ -56,6 +58,7 @@ describe("config", () => {
     }));
     expect(loadConfig(cfgPath).settings).toEqual({
       editor: { fontFamily: "Consolas, monospace", fontSize: 19 },
+      window: DEFAULT_APP_SETTINGS.window,
       workbench: DEFAULT_APP_SETTINGS.workbench,
     });
   });
@@ -73,6 +76,25 @@ describe("config", () => {
       iconTheme: "catppuccin-mocha",
       tree: DEFAULT_APP_SETTINGS.workbench.tree,
     });
+  });
+
+  it("migrates the legacy root zoom level unless window.zoomLevel is already explicit", () => {
+    writeFileSync(cfgPath, JSON.stringify({
+      serviceUrl: "", serviceToken: "", repos: [], zoomLevel: 1,
+      settings: {
+        editor: DEFAULT_APP_SETTINGS.editor,
+        workbench: DEFAULT_APP_SETTINGS.workbench,
+      },
+    }));
+    const migrated = loadConfig(cfgPath);
+    expect(migrated.settings.window.zoomLevel).toBe(1);
+    expect(migrated.zoomLevel).toBeUndefined();
+
+    writeFileSync(cfgPath, JSON.stringify({
+      serviceUrl: "", serviceToken: "", repos: [], zoomLevel: 1,
+      settings: { ...DEFAULT_APP_SETTINGS, window: { zoomLevel: -0.5 } },
+    }));
+    expect(loadConfig(cfgPath).settings.window.zoomLevel).toBe(-0.5);
   });
 
   it.each([
@@ -159,10 +181,10 @@ describe("config", () => {
 
     // The app writes the config on ordinary actions — a zoom change, opening a pull
     // request. An unconfigured one has to come back, not fail the next launch.
-    first.zoomLevel = 1;
+    first.settings = { ...first.settings, window: { zoomLevel: 1 } };
     saveConfig(first, path);
     const second = loadConfig(path);
-    expect(second.zoomLevel).toBe(1);
+    expect(second.settings.window.zoomLevel).toBe(1);
     expect(second.serviceUrl).toBe("");
   });
 

--- a/packages/app/src/main/config.test.ts
+++ b/packages/app/src/main/config.test.ts
@@ -78,25 +78,6 @@ describe("config", () => {
     });
   });
 
-  it("migrates the legacy root zoom level unless window.zoomLevel is already explicit", () => {
-    writeFileSync(cfgPath, JSON.stringify({
-      serviceUrl: "", serviceToken: "", repos: [], zoomLevel: 1,
-      settings: {
-        editor: DEFAULT_APP_SETTINGS.editor,
-        workbench: DEFAULT_APP_SETTINGS.workbench,
-      },
-    }));
-    const migrated = loadConfig(cfgPath);
-    expect(migrated.settings.window.zoomLevel).toBe(1);
-    expect(migrated.zoomLevel).toBeUndefined();
-
-    writeFileSync(cfgPath, JSON.stringify({
-      serviceUrl: "", serviceToken: "", repos: [], zoomLevel: 1,
-      settings: { ...DEFAULT_APP_SETTINGS, window: { zoomLevel: -0.5 } },
-    }));
-    expect(loadConfig(cfgPath).settings.window.zoomLevel).toBe(-0.5);
-  });
-
   it.each([
     { editor: { fontFamily: "", fontSize: 16 } },
     { editor: { fontFamily: DEFAULT_EDITOR_FONT_FAMILY, fontSize: 1000 } },

--- a/packages/app/src/main/config.ts
+++ b/packages/app/src/main/config.ts
@@ -4,7 +4,6 @@ import { dirname, join } from "node:path";
 import { z } from "zod";
 import type { RepoEntry } from "@gander/shared";
 import { AppSettingsSchema, DEFAULT_APP_SETTINGS, type AppSettings } from "../settings.js";
-import { clampZoomLevel } from "../zoom.js";
 
 // owner/repo, matching repoIdFromUrl's output — a hand-edited config must not be able to flow
 // an arbitrary string into both a filesystem path (clone directory name) and a GitHub API URL.
@@ -20,9 +19,6 @@ const ConfigSchema = z
     serviceUrl: z.string().url().or(z.literal("")).default(""),
     serviceToken: z.string().default(""),
     githubToken: z.string().min(1).optional(),
-    // Electron zoom level: 0 is 100%, each step is a 20% change. Persisted so the
-    // window reopens at the size the reader last chose.
-    zoomLevel: z.number().optional(),
     // The pull request open when the app last closed, reopened on launch.
     lastReview: z.object({ repoId: RepoIdSchema, prNumber: z.number().int().positive() }).optional(),
     // Invalid appearance values must not prevent the app from starting. Older config files
@@ -36,7 +32,6 @@ export interface GanderConfig {
   serviceUrl: string;
   serviceToken: string;
   githubToken?: string;
-  zoomLevel?: number;
   lastReview?: LastReview;
   settings: AppSettings;
   repos: RepoEntry[];
@@ -53,30 +48,9 @@ export function loadConfig(path = defaultPath()): GanderConfig {
   // A missing file is a first run, not a failure. Anything present but malformed still
   // throws: that is a file someone edited, and silently replacing it would lose their work.
   if (!existsSync(path)) return unconfigured();
-  const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
-  const parsed = ConfigSchema.safeParse(raw);
+  const parsed = ConfigSchema.safeParse(JSON.parse(readFileSync(path, "utf8")));
   if (!parsed.success) throw new Error(`Invalid config at ${path}: ${parsed.error.issues.map((i) => i.path.join(".")).join(", ")}`);
-  const cfg = parsed.data as GanderConfig;
-  // Before window.zoomLevel became a public setting, the same value lived at the config
-  // root. Prefer an explicitly saved public setting, otherwise carry the old value forward.
-  const legacy = typeof raw === "object" && raw !== null && "zoomLevel" in raw
-    ? (raw as { zoomLevel?: unknown }).zoomLevel
-    : undefined;
-  const rawSettings = typeof raw === "object" && raw !== null && "settings" in raw
-    ? (raw as { settings?: unknown }).settings
-    : undefined;
-  const hasPublicZoom = typeof rawSettings === "object" && rawSettings !== null && "window" in rawSettings
-    && typeof (rawSettings as { window?: unknown }).window === "object"
-    && (rawSettings as { window: object }).window !== null
-    && "zoomLevel" in (rawSettings as { window: object }).window;
-  if (!hasPublicZoom && typeof legacy === "number") {
-    cfg.settings = {
-      ...cfg.settings,
-      window: { ...cfg.settings.window, zoomLevel: clampZoomLevel(legacy) },
-    };
-  }
-  delete cfg.zoomLevel;
-  return cfg;
+  return parsed.data as GanderConfig;
 }
 
 export function saveConfig(cfg: GanderConfig, path = defaultPath()): void {

--- a/packages/app/src/main/config.ts
+++ b/packages/app/src/main/config.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { z } from "zod";
 import type { RepoEntry } from "@gander/shared";
 import { AppSettingsSchema, DEFAULT_APP_SETTINGS, type AppSettings } from "../settings.js";
+import { clampZoomLevel } from "../zoom.js";
 
 // owner/repo, matching repoIdFromUrl's output — a hand-edited config must not be able to flow
 // an arbitrary string into both a filesystem path (clone directory name) and a GitHub API URL.
@@ -52,9 +53,30 @@ export function loadConfig(path = defaultPath()): GanderConfig {
   // A missing file is a first run, not a failure. Anything present but malformed still
   // throws: that is a file someone edited, and silently replacing it would lose their work.
   if (!existsSync(path)) return unconfigured();
-  const parsed = ConfigSchema.safeParse(JSON.parse(readFileSync(path, "utf8")));
+  const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  const parsed = ConfigSchema.safeParse(raw);
   if (!parsed.success) throw new Error(`Invalid config at ${path}: ${parsed.error.issues.map((i) => i.path.join(".")).join(", ")}`);
-  return parsed.data as GanderConfig;
+  const cfg = parsed.data as GanderConfig;
+  // Before window.zoomLevel became a public setting, the same value lived at the config
+  // root. Prefer an explicitly saved public setting, otherwise carry the old value forward.
+  const legacy = typeof raw === "object" && raw !== null && "zoomLevel" in raw
+    ? (raw as { zoomLevel?: unknown }).zoomLevel
+    : undefined;
+  const rawSettings = typeof raw === "object" && raw !== null && "settings" in raw
+    ? (raw as { settings?: unknown }).settings
+    : undefined;
+  const hasPublicZoom = typeof rawSettings === "object" && rawSettings !== null && "window" in rawSettings
+    && typeof (rawSettings as { window?: unknown }).window === "object"
+    && (rawSettings as { window: object }).window !== null
+    && "zoomLevel" in (rawSettings as { window: object }).window;
+  if (!hasPublicZoom && typeof legacy === "number") {
+    cfg.settings = {
+      ...cfg.settings,
+      window: { ...cfg.settings.window, zoomLevel: clampZoomLevel(legacy) },
+    };
+  }
+  delete cfg.zoomLevel;
+  return cfg;
 }
 
 export function saveConfig(cfg: GanderConfig, path = defaultPath()): void {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -14,6 +14,9 @@ import { registerSettingsIpc } from "./settings-ipc.js";
 import { buildMenuTemplate } from "./menu.js";
 import { updateNativeWindowTheme, windowAppearance } from "./window-appearance.js";
 import { linkedWorktreeLabel } from "./development-context.js";
+import { createZoomController, type ZoomController } from "./zoom-controller.js";
+
+let zoomController: ZoomController;
 
 async function bootstrap(): Promise<GanderConfig> {
   const cfg = loadConfig();
@@ -96,33 +99,28 @@ async function bootstrap(): Promise<GanderConfig> {
     return result;
   });
 
+  zoomController = createZoomController(cfg, () => BrowserWindow.getAllWindows());
+  ipcMain.handle("gander:getZoomLevel", async () => zoomController.current());
+  ipcMain.handle("gander:setZoomLevel", async (_event, level: number) => zoomController.set(level));
+
   registerSettingsIpc(ipcMain, cfg, saveConfig, (settings) => {
     updateNativeWindowTheme(process.platform, BrowserWindow.getAllWindows(), settings.workbench.colorTheme);
+    zoomController.apply(settings.window.zoomLevel);
   });
 
   return cfg;
 }
 
-// Electron's built-in zoom roles change the level but forget it on quit. These do the
-// same steps — 0.5 matches Chromium's own increment — and write the result to the
-// config, so the window reopens at the size the reader chose.
-const ZOOM_MIN = -3;
-const ZOOM_MAX = 6;
-
-function installMenu(cfg: GanderConfig): void {
-  const setZoom = (level: number): void => {
-    const clamped = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, level));
-    for (const win of BrowserWindow.getAllWindows()) win.webContents.setZoomLevel(clamped);
-    cfg.zoomLevel = clamped;
-    saveConfig(cfg);
-  };
-  const currentZoom = (): number => BrowserWindow.getFocusedWindow()?.webContents.getZoomLevel() ?? cfg.zoomLevel ?? 0;
-
+function installMenu(): void {
   const openSettings = (): void => {
     const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
     win?.webContents.send("gander:openSettings");
   };
-  const template = buildMenuTemplate(process.platform, app.name, { openSettings, setZoom, currentZoom });
+  const template = buildMenuTemplate(process.platform, app.name, {
+    openSettings,
+    setZoom: zoomController.set,
+    currentZoom: zoomController.current,
+  });
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
@@ -174,7 +172,7 @@ async function createWindow(cfg: GanderConfig): Promise<void> {
 
   // Applied on every load, not just the first: Chromium resets zoom per navigation,
   // and the dev server reloads the renderer on every edit.
-  win.webContents.on("did-finish-load", () => win.webContents.setZoomLevel(cfg.zoomLevel ?? 0));
+  win.webContents.on("did-finish-load", () => win.webContents.setZoomLevel(cfg.settings.window.zoomLevel));
 
   if (process.env.ELECTRON_RENDERER_URL) win.loadURL(process.env.ELECTRON_RENDERER_URL);
   else win.loadFile(join(import.meta.dirname, "../renderer/index.html"));
@@ -215,7 +213,7 @@ app.whenReady().then(async () => {
     app.exit(1);
     return;
   }
-  installMenu(cfg);
+  installMenu();
   await createWindow(cfg);
 
   try {

--- a/packages/app/src/main/menu.test.ts
+++ b/packages/app/src/main/menu.test.ts
@@ -35,4 +35,25 @@ describe("application menu", () => {
     settings?.click?.({} as Electron.MenuItem, undefined, {} as Electron.KeyboardEvent);
     expect(callbacks.openSettings).toHaveBeenCalledOnce();
   });
+
+  it("routes every View zoom command through the shared zoom actions", () => {
+    const callbacks = actions();
+    callbacks.currentZoom.mockReturnValue(1);
+    const template = buildMenuTemplate("darwin", "Gander", callbacks);
+    const view = template.find((item) => item.label === "View");
+    const items = submenu(view!);
+
+    items.find((item) => item.label === "Zoom In" && item.visible !== false)?.click?.(
+      {} as Electron.MenuItem, undefined, {} as Electron.KeyboardEvent,
+    );
+    expect(callbacks.setZoom).toHaveBeenLastCalledWith(1.5);
+    items.find((item) => item.label === "Zoom Out")?.click?.(
+      {} as Electron.MenuItem, undefined, {} as Electron.KeyboardEvent,
+    );
+    expect(callbacks.setZoom).toHaveBeenLastCalledWith(0.5);
+    items.find((item) => item.label === "Actual Size")?.click?.(
+      {} as Electron.MenuItem, undefined, {} as Electron.KeyboardEvent,
+    );
+    expect(callbacks.setZoom).toHaveBeenLastCalledWith(0);
+  });
 });

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -1,12 +1,11 @@
 import type { MenuItemConstructorOptions } from "electron";
+import { DEFAULT_ZOOM_LEVEL, ZOOM_LEVEL_STEP } from "../zoom.js";
 
 interface MenuActions {
   openSettings(): void;
   setZoom(level: number): void;
   currentZoom(): number;
 }
-
-const ZOOM_STEP = 0.5;
 
 export function buildMenuTemplate(
   platform: NodeJS.Platform,
@@ -52,12 +51,12 @@ export function buildMenuTemplate(
     {
       label: "View",
       submenu: [
-        { label: "Zoom In", accelerator: "CommandOrControl+Plus", click: () => actions.setZoom(actions.currentZoom() + ZOOM_STEP) },
+        { label: "Zoom In", accelerator: "CommandOrControl+Plus", click: () => actions.setZoom(actions.currentZoom() + ZOOM_LEVEL_STEP) },
         // Chromium delivers Cmd+= for an unshifted Cmd+ on most layouts; both are bound
         // so the key next to Backspace works without reaching for Shift.
-        { label: "Zoom In", accelerator: "CommandOrControl+=", visible: false, click: () => actions.setZoom(actions.currentZoom() + ZOOM_STEP) },
-        { label: "Zoom Out", accelerator: "CommandOrControl+-", click: () => actions.setZoom(actions.currentZoom() - ZOOM_STEP) },
-        { label: "Actual Size", accelerator: "CommandOrControl+0", click: () => actions.setZoom(0) },
+        { label: "Zoom In", accelerator: "CommandOrControl+=", visible: false, click: () => actions.setZoom(actions.currentZoom() + ZOOM_LEVEL_STEP) },
+        { label: "Zoom Out", accelerator: "CommandOrControl+-", click: () => actions.setZoom(actions.currentZoom() - ZOOM_LEVEL_STEP) },
+        { label: "Actual Size", accelerator: "CommandOrControl+0", click: () => actions.setZoom(DEFAULT_ZOOM_LEVEL) },
         { type: "separator" },
         { role: "togglefullscreen" },
         { role: "toggleDevTools" },

--- a/packages/app/src/main/settings-ipc.test.ts
+++ b/packages/app/src/main/settings-ipc.test.ts
@@ -35,6 +35,7 @@ describe("settings IPC", () => {
 
     const next = {
       editor: { fontFamily: "Consolas, monospace", fontSize: 20 },
+      window: { zoomLevel: 0.5 },
       workbench: {
         colorTheme: "Gander Dark" as const,
         iconTheme: "catppuccin-mocha" as const,
@@ -52,6 +53,7 @@ describe("settings IPC", () => {
     const { cfg, handlers, persist, onSettingsChanged } = fixture();
     await expect(handlers.get("gander:updateSettings")?.({}, {
       editor: { fontFamily: "monospace", fontSize: 200 },
+      window: DEFAULT_APP_SETTINGS.window,
       workbench: DEFAULT_APP_SETTINGS.workbench,
     })).rejects.toThrow(/fontSize/);
     expect(cfg.settings).toEqual(DEFAULT_APP_SETTINGS);
@@ -64,6 +66,7 @@ describe("settings IPC", () => {
     persist.mockImplementation(() => { throw new Error("disk full"); });
     await expect(handlers.get("gander:updateSettings")?.({}, {
       editor: { fontFamily: "Consolas, monospace", fontSize: 20 },
+      window: DEFAULT_APP_SETTINGS.window,
       workbench: DEFAULT_APP_SETTINGS.workbench,
     })).rejects.toThrow(/disk full/);
     expect(cfg.settings).toEqual(DEFAULT_APP_SETTINGS);

--- a/packages/app/src/main/zoom-controller.test.ts
+++ b/packages/app/src/main/zoom-controller.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_APP_SETTINGS } from "../settings.js";
+import { ZOOM_LEVEL_MAX } from "../zoom.js";
+import type { GanderConfig } from "./config.js";
+import { createZoomController } from "./zoom-controller.js";
+
+describe("zoom controller", () => {
+  it("persists, applies, and announces one clamped zoom state to every window", () => {
+    const cfg: GanderConfig = {
+      serviceUrl: "",
+      serviceToken: "",
+      repos: [],
+      settings: DEFAULT_APP_SETTINGS,
+    };
+    const windows = [
+      { webContents: { setZoomLevel: vi.fn(), send: vi.fn() } },
+      { webContents: { setZoomLevel: vi.fn(), send: vi.fn() } },
+    ];
+    const persist = vi.fn();
+    const zoom = createZoomController(cfg, () => windows, persist);
+
+    expect(zoom.set(100)).toBe(ZOOM_LEVEL_MAX);
+    expect(zoom.current()).toBe(ZOOM_LEVEL_MAX);
+    expect(persist).toHaveBeenCalledWith(expect.objectContaining({
+      settings: expect.objectContaining({ window: { zoomLevel: ZOOM_LEVEL_MAX } }),
+    }));
+    for (const window of windows) {
+      expect(window.webContents.setZoomLevel).toHaveBeenCalledWith(ZOOM_LEVEL_MAX);
+      expect(window.webContents.send).toHaveBeenCalledWith("gander:zoomChanged", ZOOM_LEVEL_MAX);
+    }
+  });
+
+  it("applies a settings change without persisting it twice", () => {
+    const cfg: GanderConfig = {
+      serviceUrl: "",
+      serviceToken: "",
+      repos: [],
+      settings: DEFAULT_APP_SETTINGS,
+    };
+    const window = { webContents: { setZoomLevel: vi.fn(), send: vi.fn() } };
+    const persist = vi.fn();
+    const zoom = createZoomController(cfg, () => [window], persist);
+
+    zoom.apply(-0.5);
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(window.webContents.setZoomLevel).toHaveBeenCalledWith(-0.5);
+    expect(window.webContents.send).toHaveBeenCalledWith("gander:zoomChanged", -0.5);
+  });
+});

--- a/packages/app/src/main/zoom-controller.ts
+++ b/packages/app/src/main/zoom-controller.ts
@@ -1,0 +1,48 @@
+import type { GanderConfig } from "./config.js";
+import { saveConfig } from "./config.js";
+import { clampZoomLevel } from "../zoom.js";
+
+interface ZoomWindow {
+  webContents: {
+    setZoomLevel(level: number): void;
+    send(channel: string, level: number): void;
+  };
+}
+
+export interface ZoomController {
+  current(): number;
+  set(level: number): number;
+  apply(level: number): number;
+}
+
+export function createZoomController(
+  cfg: GanderConfig,
+  windows: () => ZoomWindow[],
+  persist: (config: GanderConfig) => void = saveConfig,
+): ZoomController {
+  const apply = (level: number): number => {
+    const clamped = clampZoomLevel(level);
+    for (const window of windows()) {
+      window.webContents.setZoomLevel(clamped);
+      window.webContents.send("gander:zoomChanged", clamped);
+    }
+    return clamped;
+  };
+
+  return {
+    current: () => cfg.settings.window.zoomLevel,
+    set(level) {
+      const clamped = clampZoomLevel(level);
+      const settings = {
+        ...cfg.settings,
+        window: { ...cfg.settings.window, zoomLevel: clamped },
+      };
+      // Persist before changing the running app so disk and memory remain authoritative
+      // together if the settings file cannot be written.
+      persist({ ...cfg, settings });
+      cfg.settings = settings;
+      return apply(clamped);
+    },
+    apply,
+  };
+}

--- a/packages/app/src/preload/api.test.ts
+++ b/packages/app/src/preload/api.test.ts
@@ -40,6 +40,7 @@ describe("preload API", () => {
 
     const settings = {
       editor: { fontFamily: "Fira Code, monospace", fontSize: 17 },
+      window: DEFAULT_APP_SETTINGS.window,
       workbench: { ...DEFAULT_APP_SETTINGS.workbench, colorTheme: "Gander Dark" as const },
     };
     await api.updateSettings(settings);
@@ -81,5 +82,26 @@ describe("preload API", () => {
 
     expect(api.onOpenSettings(listener)).toBe(cleanup);
     expect(subscribe).toHaveBeenCalledWith("gander:openSettings", listener);
+  });
+
+  it("routes zoom calls and forwards main-process zoom changes", async () => {
+    const invoke = vi.fn(async () => 0.5);
+    const cleanup = vi.fn();
+    let subscribed: ((...args: any[]) => void) | undefined;
+    const subscribe: Parameters<typeof createGanderApi>[1] = vi.fn((_channel, listener) => {
+      subscribed = listener;
+      return cleanup;
+    });
+    const api = createGanderApi(invoke, subscribe);
+    const listener = vi.fn();
+
+    await api.getZoomLevel();
+    expect(invoke).toHaveBeenLastCalledWith("gander:getZoomLevel");
+    await api.setZoomLevel(0.5);
+    expect(invoke).toHaveBeenLastCalledWith("gander:setZoomLevel", 0.5);
+    expect(api.onZoomChanged(listener)).toBe(cleanup);
+    expect(subscribe).toHaveBeenCalledWith("gander:zoomChanged", expect.any(Function));
+    subscribed?.(1);
+    expect(listener).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/app/src/preload/api.ts
+++ b/packages/app/src/preload/api.ts
@@ -82,5 +82,8 @@ export function createGanderApi(
     getSettings: () => call("getSettings"),
     updateSettings: (settings) => call("updateSettings", settings),
     onOpenSettings: (listener) => subscribe("gander:openSettings", listener),
+    getZoomLevel: () => call("getZoomLevel"),
+    setZoomLevel: (level) => call("setZoomLevel", level),
+    onZoomChanged: (listener) => subscribe("gander:zoomChanged", (level: number) => listener(level)),
   };
 }

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -15,17 +15,21 @@ import { X } from "lucide-vue-next";
 import { createEditorSettingsStore } from "./editor-settings-store.js";
 import { effectiveTreeTypography } from "../../settings.js";
 import "./theme.css";
+import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../zoom.js";
 
 const store = createStore(api);
 const editorSettings = createEditorSettingsStore(api, api.initialWindowState.colorTheme);
 const integratedTitleBar = api.initialWindowState.windowStyle === "integrated-titlebar";
 let unsubscribeOpenTarget: (() => void) | null = null;
 let unsubscribeOpenSettings: (() => void) | null = null;
+let unsubscribeZoomChanged: (() => void) | null = null;
 
 onMounted(async () => {
   // Registered first, so commands arriving while the app restores its last review are not dropped.
   unsubscribeOpenTarget = api.onOpenTarget((target) => { void store.openTarget(target); });
   unsubscribeOpenSettings = api.onOpenSettings(() => openSettings());
+  unsubscribeZoomChanged = api.onZoomChanged((level) => { zoomLevel.value = level; });
+  zoomLevel.value = await api.getZoomLevel();
   void editorSettings.load();
   // An installed app starts with no connection at all. Knowing that here is what lets the
   // window say where to set one instead of showing an empty review that cannot be filled.
@@ -41,6 +45,7 @@ const capturing = ref(false);
 const drawerOpen = ref(false);
 const treeVisible = ref(true);
 const activeSurface = shallowRef<"review" | "settings">("review");
+const zoomLevel = shallowRef(DEFAULT_ZOOM_LEVEL);
 const treeTypography = computed(() => effectiveTreeTypography(editorSettings.settings));
 // Which section the settings surface opens on. The prompt about a missing service leads
 // straight to the one that fixes it, rather than to whatever was showing last.
@@ -73,6 +78,11 @@ function toggleSettings(): void {
   // Read back on the way out as well as on the save: the review surface must never
   // claim there is no service while the status bar says it is connected.
   if (activeSurface.value === "review") void refreshConnectionState();
+}
+
+async function changeZoom(level: number): Promise<void> {
+  zoomLevel.value = clampZoomLevel(level);
+  zoomLevel.value = await api.setZoomLevel(level);
 }
 
 // v-model needs something assignable, and which dimension the questions splitter drags
@@ -143,6 +153,7 @@ onBeforeUnmount(() => {
   window.removeEventListener("keydown", onKey, true);
   unsubscribeOpenTarget?.();
   unsubscribeOpenSettings?.();
+  unsubscribeZoomChanged?.();
 });
 </script>
 
@@ -226,7 +237,10 @@ onBeforeUnmount(() => {
       :tree-visible="treeVisible"
       :is-development="api.initialWindowState.isDevelopment"
       :worktree-label="api.initialWindowState.worktreeLabel"
+      :zoom-level="zoomLevel"
       @toggle-tree="treeVisible = !treeVisible"
+      @change-zoom="changeZoom"
+      @open-zoom-settings="openSettings('workbench')"
     />
     <QuestionCapture :store="store" :open="capturing" @close="capturing = false" />
   </div>

--- a/packages/app/src/renderer/src/components/StatusBar.test.ts
+++ b/packages/app/src/renderer/src/components/StatusBar.test.ts
@@ -15,10 +15,10 @@ const store = {
 describe("StatusBar", () => {
   it("shows a development marker only for a development launch", () => {
     const development = mount(StatusBar, {
-      props: { store, treeVisible: true, isDevelopment: true, worktreeLabel: null },
+      props: { store, treeVisible: true, isDevelopment: true, worktreeLabel: null, zoomLevel: 0 },
     });
     const release = mount(StatusBar, {
-      props: { store, treeVisible: true, isDevelopment: false, worktreeLabel: null },
+      props: { store, treeVisible: true, isDevelopment: false, worktreeLabel: null, zoomLevel: 0 },
     });
 
     expect(development.get(".development").text()).toBe("DEV");
@@ -37,6 +37,7 @@ describe("StatusBar", () => {
         treeVisible: true,
         isDevelopment: true,
         worktreeLabel: "feature/review-status",
+        zoomLevel: 0,
       },
     });
 

--- a/packages/app/src/renderer/src/components/StatusBar.vue
+++ b/packages/app/src/renderer/src/components/StatusBar.vue
@@ -2,14 +2,20 @@
 import { computed, onBeforeUnmount, ref } from "vue";
 import { PanelLeft } from "lucide-vue-next";
 import type { Store } from "../store.js";
+import ZoomControl from "./ZoomControl.vue";
 
 const props = defineProps<{
   store: Store;
   treeVisible: boolean;
   isDevelopment: boolean;
   worktreeLabel: string | null;
+  zoomLevel: number;
 }>();
-defineEmits<{ toggleTree: [] }>();
+defineEmits<{
+  toggleTree: [];
+  changeZoom: [level: number];
+  openZoomSettings: [];
+}>();
 
 const developmentLabel = computed(() => props.worktreeLabel
   ? `Development build · ${props.worktreeLabel}`
@@ -63,6 +69,11 @@ const lastFetch = computed(() => {
       <span class="development-kind">DEV</span>
       <span v-if="worktreeLabel" class="worktree-label">{{ `· ${worktreeLabel}` }}</span>
     </span>
+    <ZoomControl
+      :level="zoomLevel"
+      @change="$emit('changeZoom', $event)"
+      @open-settings="$emit('openZoomSettings')"
+    />
   </footer>
 </template>
 

--- a/packages/app/src/renderer/src/components/WindowZoomSettings.test.ts
+++ b/packages/app/src/renderer/src/components/WindowZoomSettings.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from "@vue/test-utils";
+import { reactive } from "vue";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_APP_SETTINGS, type AppSettings } from "../../../settings.js";
+import type { EditorSettingsStore } from "../editor-settings-store.js";
+import WindowZoomSettings from "./WindowZoomSettings.vue";
+
+describe("WindowZoomSettings", () => {
+  it("saves fractional default zoom and resets it to 100%", async () => {
+    const update = vi.fn(async (settings: AppSettings) => {
+      store.settings = settings;
+      return true;
+    });
+    const store: EditorSettingsStore = reactive({
+      settings: DEFAULT_APP_SETTINGS,
+      busy: false,
+      error: null,
+      async load() {},
+      update,
+    });
+    const wrapper = mount(WindowZoomSettings, { props: { store } });
+    const input = wrapper.get("input[name='window.zoomLevel']");
+
+    expect((input.element as HTMLInputElement).value).toBe("0");
+    expect(wrapper.get("#window-zoom-percentage").text()).toBe("100%");
+    await input.setValue("0.5");
+    await input.trigger("change");
+    await flushPromises();
+    expect(update).toHaveBeenLastCalledWith({
+      ...DEFAULT_APP_SETTINGS,
+      window: { zoomLevel: 0.5 },
+    });
+    expect(wrapper.get("#window-zoom-percentage").text()).toBe("110%");
+
+    await wrapper.get("button").trigger("click");
+    await flushPromises();
+    expect(update).toHaveBeenLastCalledWith(DEFAULT_APP_SETTINGS);
+  });
+});

--- a/packages/app/src/renderer/src/components/WindowZoomSettings.vue
+++ b/packages/app/src/renderer/src/components/WindowZoomSettings.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { onBeforeUnmount, shallowRef, watch } from "vue";
+import type { EditorSettingsStore } from "../editor-settings-store.js";
+import { DEFAULT_APP_SETTINGS } from "../../../settings.js";
+import { ZOOM_LEVEL_MAX, ZOOM_LEVEL_MIN, zoomPercentage } from "../../../zoom.js";
+
+const props = defineProps<{ store: EditorSettingsStore }>();
+const emit = defineEmits<{ saved: [success: boolean] }>();
+
+const zoomLevel = shallowRef<number | string>(props.store.settings.window.zoomLevel);
+const localError = shallowRef<string | null>(null);
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+watch(
+  () => props.store.settings.window.zoomLevel,
+  (level) => { zoomLevel.value = level; },
+);
+
+async function save(): Promise<void> {
+  const level = Number(zoomLevel.value);
+  if (!Number.isFinite(level) || level < ZOOM_LEVEL_MIN || level > ZOOM_LEVEL_MAX) {
+    localError.value = `Enter a zoom level from ${ZOOM_LEVEL_MIN} to ${ZOOM_LEVEL_MAX}.`;
+    return;
+  }
+  localError.value = null;
+  emit("saved", await props.store.update({
+    ...props.store.settings,
+    window: { ...props.store.settings.window, zoomLevel: level },
+  }));
+}
+
+function scheduleSave(): void {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+    void save();
+  }, 400);
+}
+
+function flushSave(): void {
+  if (!saveTimer) return;
+  clearTimeout(saveTimer);
+  saveTimer = null;
+  void save();
+}
+
+async function reset(): Promise<void> {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = null;
+  zoomLevel.value = DEFAULT_APP_SETTINGS.window.zoomLevel;
+  localError.value = null;
+  emit("saved", await props.store.update({
+    ...props.store.settings,
+    window: DEFAULT_APP_SETTINGS.window,
+  }));
+}
+
+onBeforeUnmount(flushSave);
+</script>
+
+<template>
+  <section class="window-zoom" aria-labelledby="window-zoom-title">
+    <div class="section-heading">
+      <div>
+        <h3 id="window-zoom-title">Window zoom level</h3>
+        <p>Sets the default scale for every Gander window.</p>
+      </div>
+      <button class="reset" type="button" :disabled="store.busy" @click="reset">Use default</button>
+    </div>
+
+    <div class="setting">
+      <label for="window-zoom-level">Zoom level</label>
+      <p>
+        Controls <code>window.zoomLevel</code>. Each whole step changes the scale by 20%;
+        decimals give finer control.
+      </p>
+      <div class="level-row">
+        <input
+          id="window-zoom-level"
+          v-model.number="zoomLevel"
+          name="window.zoomLevel"
+          type="number"
+          :min="ZOOM_LEVEL_MIN"
+          :max="ZOOM_LEVEL_MAX"
+          step="0.1"
+          :disabled="store.busy"
+          aria-describedby="window-zoom-percentage"
+          @input="scheduleSave"
+          @change="flushSave"
+        />
+        <span id="window-zoom-percentage">{{ zoomPercentage(Number(zoomLevel) || 0) }}%</span>
+      </div>
+    </div>
+
+    <p v-if="localError" class="error" role="alert">{{ localError }}</p>
+  </section>
+</template>
+
+<style scoped>
+.window-zoom { max-width: 820px; margin-top: 34px; padding-top: 28px; border-top: 1px solid var(--workbench-border); }
+.section-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; margin-bottom: 22px; }
+.section-heading h3 { color: var(--workbench-foreground); font-size: 15px; line-height: 1.3; }
+.section-heading p, .setting > p { color: var(--faint-foreground); font-size: 12px; }
+.reset { border: 0; background: none; color: var(--accent); cursor: pointer; font: inherit; font-size: 12px; white-space: nowrap; }
+.reset:disabled { cursor: default; opacity: .55; }
+.reset:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.setting { margin-bottom: 22px; }
+.setting label { display: block; color: var(--workbench-foreground); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
+.setting code { color: var(--muted-foreground); font: 11.5px var(--mono); }
+.level-row { display: flex; align-items: center; gap: 9px; width: 150px; color: var(--muted-foreground); font-variant-numeric: tabular-nums; }
+.level-row input {
+  width: 100%; min-width: 0; margin-top: 8px; padding: 8px 10px;
+  border: 1px solid var(--workbench-border); border-radius: 6px;
+  outline: none; background: var(--input-background); color: var(--workbench-foreground); font: 13px/1.4 var(--mono);
+}
+.level-row input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
+.level-row input:disabled { opacity: .65; }
+.level-row span { margin-top: 8px; }
+.error { color: var(--danger); font-size: 12px; overflow-wrap: anywhere; }
+</style>

--- a/packages/app/src/renderer/src/components/WorkbenchSettings.vue
+++ b/packages/app/src/renderer/src/components/WorkbenchSettings.vue
@@ -5,6 +5,7 @@ import { DEFAULT_APP_SETTINGS, type FileIconThemeId, type ThemeId } from "../../
 import { THEME_IDS, themeFor } from "../../../themes.js";
 import { FILE_ICON_THEME_IDS, fileIconThemeFor } from "../../../file-icon-themes.js";
 import TreeTypographySettings from "./TreeTypographySettings.vue";
+import WindowZoomSettings from "./WindowZoomSettings.vue";
 
 const props = defineProps<{ store: EditorSettingsStore }>();
 const emit = defineEmits<{ saved: [success: boolean] }>();
@@ -82,6 +83,7 @@ async function reset(): Promise<void> {
       <span v-for="(color, token) in activeTheme.workbench" :key="token" :style="{ backgroundColor: color }" />
     </div>
 
+    <WindowZoomSettings :store="store" @saved="emit('saved', $event)" />
     <TreeTypographySettings :store="store" @saved="emit('saved', $event)" />
   </section>
 </template>

--- a/packages/app/src/renderer/src/components/ZoomControl.test.ts
+++ b/packages/app/src/renderer/src/components/ZoomControl.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { ZOOM_LEVEL_MAX, ZOOM_LEVEL_MIN } from "../../../zoom.js";
+import ZoomControl from "./ZoomControl.vue";
+
+describe("ZoomControl", () => {
+  it("shows the effective percentage and exposes named toolbar actions", () => {
+    const wrapper = mount(ZoomControl, { props: { level: 0.5 } });
+
+    expect(wrapper.get(".zoom-trigger").text()).toBe("110%");
+    expect(wrapper.get(".zoom-trigger").attributes("aria-label")).toBe("Zoom: 110%");
+    expect(wrapper.get("button[aria-label='Zoom out']").attributes("title")).toBe("Zoom out");
+    expect(wrapper.get("button[aria-label='Zoom in']").attributes("title")).toBe("Zoom in");
+    expect(wrapper.get("button[aria-label='Reset zoom to 100%']").text()).toContain("Reset");
+  });
+
+  it("emits increment, decrement, and reset levels", async () => {
+    const wrapper = mount(ZoomControl, { props: { level: 1 } });
+
+    await wrapper.get("button[aria-label='Zoom out']").trigger("click");
+    await wrapper.get("button[aria-label='Zoom in']").trigger("click");
+    await wrapper.get("button[aria-label='Reset zoom to 100%']").trigger("click");
+
+    expect(wrapper.emitted("change")).toEqual([[0.5], [1.5], [0]]);
+  });
+
+  it("disables only the action that would exceed a limit", async () => {
+    const wrapper = mount(ZoomControl, { props: { level: ZOOM_LEVEL_MIN } });
+    expect(wrapper.get("button[aria-label='Zoom out']").attributes("disabled")).toBeDefined();
+    expect(wrapper.get("button[aria-label='Zoom in']").attributes("disabled")).toBeUndefined();
+
+    await wrapper.setProps({ level: ZOOM_LEVEL_MAX });
+    expect(wrapper.get("button[aria-label='Zoom out']").attributes("disabled")).toBeUndefined();
+    expect(wrapper.get("button[aria-label='Zoom in']").attributes("disabled")).toBeDefined();
+  });
+});

--- a/packages/app/src/renderer/src/components/ZoomControl.vue
+++ b/packages/app/src/renderer/src/components/ZoomControl.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Minus, Plus, Settings2, ZoomIn } from "lucide-vue-next";
+import {
+  DEFAULT_ZOOM_LEVEL,
+  ZOOM_LEVEL_MAX,
+  ZOOM_LEVEL_MIN,
+  ZOOM_LEVEL_STEP,
+  zoomPercentage,
+} from "../../../zoom.js";
+
+const props = defineProps<{ level: number }>();
+const emit = defineEmits<{
+  change: [level: number];
+  openSettings: [];
+}>();
+
+const percentage = computed(() => zoomPercentage(props.level));
+const atMinimum = computed(() => props.level <= ZOOM_LEVEL_MIN);
+const atMaximum = computed(() => props.level >= ZOOM_LEVEL_MAX);
+
+function zoomOut(): void {
+  emit("change", props.level - ZOOM_LEVEL_STEP);
+}
+
+function zoomIn(): void {
+  emit("change", props.level + ZOOM_LEVEL_STEP);
+}
+
+function reset(): void {
+  emit("change", DEFAULT_ZOOM_LEVEL);
+}
+</script>
+
+<template>
+  <div class="zoom-control">
+    <button
+      class="zoom-trigger"
+      type="button"
+      popovertarget="zoom-toolbar"
+      :aria-label="`Zoom: ${percentage}%`"
+      :title="`Zoom: ${percentage}%`"
+    >
+      <ZoomIn :size="13" aria-hidden="true" />
+      <span class="percentage">{{ percentage }}%</span>
+    </button>
+
+    <div id="zoom-toolbar" class="zoom-toolbar" popover="auto" role="group" aria-label="Window zoom controls">
+      <button
+        type="button"
+        aria-label="Zoom out"
+        title="Zoom out"
+        :disabled="atMinimum"
+        @click="zoomOut"
+      >
+        <Minus :size="16" aria-hidden="true" />
+      </button>
+      <button
+        class="reset"
+        type="button"
+        aria-label="Reset zoom to 100%"
+        title="Reset zoom to 100%"
+        :disabled="level === DEFAULT_ZOOM_LEVEL"
+        @click="reset"
+      >
+        {{ percentage }}%
+        <span>Reset</span>
+      </button>
+      <button
+        type="button"
+        aria-label="Zoom in"
+        title="Zoom in"
+        :disabled="atMaximum"
+        @click="zoomIn"
+      >
+        <Plus :size="16" aria-hidden="true" />
+      </button>
+      <span class="divider" aria-hidden="true" />
+      <button
+        type="button"
+        popovertarget="zoom-toolbar"
+        popovertargetaction="hide"
+        aria-label="Open window zoom settings"
+        title="Open window zoom settings"
+        @click="emit('openSettings')"
+      >
+        <Settings2 :size="15" aria-hidden="true" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.zoom-control { display: flex; align-items: center; }
+.zoom-trigger {
+  anchor-name: --zoom-trigger;
+  display: flex; align-items: center; gap: 4px; height: 22px; padding: 0 4px;
+  border: 0; border-radius: 3px; background: transparent; color: var(--faint-foreground);
+  cursor: pointer; font: inherit; font-variant-numeric: tabular-nums;
+}
+.zoom-trigger:hover, .zoom-trigger:focus-visible { background: var(--hover-background); color: var(--workbench-foreground); }
+.zoom-trigger:focus-visible, .zoom-toolbar button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.percentage { min-width: 3.25ch; text-align: end; }
+.zoom-toolbar {
+  position: fixed; position-anchor: --zoom-trigger; position-area: block-start span-inline-start;
+  margin: 0 0 7px; padding: 5px; border: 1px solid var(--workbench-border); border-radius: 7px;
+  background: var(--elevated-background); color: var(--workbench-foreground);
+  box-shadow: 0 6px 18px var(--workbench-shadow);
+}
+.zoom-toolbar:popover-open { display: flex; align-items: center; gap: 2px; }
+.zoom-toolbar::before {
+  content: ""; position: absolute; inset-block-end: -5px; inset-inline-end: 22px;
+  width: 8px; height: 8px; rotate: 45deg;
+  border-inline-end: 1px solid var(--workbench-border); border-block-end: 1px solid var(--workbench-border);
+  background: var(--elevated-background);
+}
+.zoom-toolbar button {
+  position: relative; display: flex; align-items: center; justify-content: center; gap: 6px;
+  min-width: 28px; height: 28px; padding: 0 7px; border: 0; border-radius: 4px;
+  background: transparent; color: var(--workbench-foreground); cursor: pointer; font: inherit;
+}
+.zoom-toolbar button:hover:not(:disabled) { background: var(--hover-background); }
+.zoom-toolbar button:disabled { color: var(--faint-foreground); cursor: default; opacity: .55; }
+.zoom-toolbar .reset { min-width: 94px; font-variant-numeric: tabular-nums; }
+.reset span { color: var(--muted-foreground); }
+.divider { width: 1px; height: 18px; margin: 0 2px; background: var(--workbench-border); }
+@supports not (position-area: block-start) {
+  .zoom-toolbar { inset: auto 8px 30px auto; }
+}
+</style>

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -42,10 +42,14 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     deleteQuestion: async () => prView(),
     getSettings: async () => ({
       editor: { fontFamily: "monospace", fontSize: 16 },
+      window: DEFAULT_APP_SETTINGS.window,
       workbench: DEFAULT_APP_SETTINGS.workbench,
     }),
     updateSettings: async (settings) => settings,
     onOpenSettings: () => () => {},
+    getZoomLevel: async () => 0,
+    setZoomLevel: async (level) => level,
+    onZoomChanged: () => () => {},
     ...overrides,
   };
 }

--- a/packages/app/src/settings.test.ts
+++ b/packages/app/src/settings.test.ts
@@ -17,6 +17,7 @@ describe("application settings", () => {
         fontFamily: "'JetBrainsMono NF', 'FiraCode NF', 'Jetbrains Mono', 'Fira Code', Consolas, 'Courier New', monospace",
         fontSize: 16,
       },
+      window: { zoomLevel: 0 },
       workbench: {
         colorTheme: "Catppuccin Mocha",
         iconTheme: "catppuccin-mocha",
@@ -35,6 +36,7 @@ describe("application settings", () => {
     expect(parseAppSettings({ editor: { fontFamily: "Fira Code, monospace", fontSize: 15.5 } }))
       .toEqual({
         editor: { fontFamily: "Fira Code, monospace", fontSize: 15.5 },
+        window: DEFAULT_APP_SETTINGS.window,
         workbench: DEFAULT_APP_SETTINGS.workbench,
       });
   });
@@ -42,6 +44,7 @@ describe("application settings", () => {
   it("normalizes Vue settings proxies into data Electron can clone", () => {
     const reactiveSettings = reactive({
       editor: { ...DEFAULT_APP_SETTINGS.editor },
+      window: { ...DEFAULT_APP_SETTINGS.window },
       workbench: { colorTheme: "Gander Dark" as const, iconTheme: "catppuccin-mocha" as const },
     });
     const parsed = parseAppSettings(reactiveSettings);
@@ -49,6 +52,7 @@ describe("application settings", () => {
     expect(() => structuredClone(parsed)).not.toThrow();
     expect(parsed).not.toBe(reactiveSettings);
     expect(parsed.editor).not.toBe(reactiveSettings.editor);
+    expect(parsed.window).not.toBe(reactiveSettings.window);
     expect(parsed.workbench).not.toBe(reactiveSettings.workbench);
   });
 
@@ -57,6 +61,8 @@ describe("application settings", () => {
     [{ editor: { fontFamily: "monospace", fontSize: 5 } }, "fontSize"],
     [{ editor: { fontFamily: "monospace", fontSize: 101 } }, "fontSize"],
     [{ editor: { fontFamily: "monospace", fontSize: Number.NaN } }, "fontSize"],
+    [{ ...DEFAULT_APP_SETTINGS, window: { zoomLevel: -4 } }, "zoomLevel"],
+    [{ ...DEFAULT_APP_SETTINGS, window: { zoomLevel: 7 } }, "zoomLevel"],
     [{ editor: { fontFamily: "monospace", fontSize: 16 }, workbench: { colorTheme: "Unknown" } }, "colorTheme"],
     [{ editor: { fontFamily: "monospace", fontSize: 16 }, workbench: { colorTheme: "Catppuccin Mocha", iconTheme: "Unknown" } }, "iconTheme"],
     [{ ...DEFAULT_APP_SETTINGS, workbench: { ...DEFAULT_APP_SETTINGS.workbench, tree: { fontFamily: "", fontSize: 13, inheritEditorTypography: false } } }, "fontFamily"],
@@ -71,6 +77,7 @@ describe("application settings", () => {
     expect(JSON.parse(source)).toEqual({
       "editor.fontFamily": DEFAULT_EDITOR_FONT_FAMILY,
       "editor.fontSize": 16,
+      "window.zoomLevel": 0,
       "workbench.colorTheme": "Catppuccin Mocha",
       "workbench.iconTheme": "catppuccin-mocha",
       "workbench.tree.fontFamily": DEFAULT_TREE_FONT_FAMILY,
@@ -86,6 +93,7 @@ describe("application settings", () => {
     expect(settingsFromJson(JSON.stringify({
       "editor.fontFamily": "Consolas, monospace",
       "editor.fontSize": 18,
+      "window.zoomLevel": 0.5,
       "workbench.colorTheme": "Gander Dark",
       "workbench.iconTheme": "catppuccin-mocha",
       "workbench.tree.fontFamily": "system-ui, sans-serif",
@@ -94,6 +102,7 @@ describe("application settings", () => {
     }), current)).toEqual({
       futureSetting: true,
       editor: { fontFamily: "Consolas, monospace", fontSize: 18 },
+      window: { zoomLevel: 0.5 },
       workbench: {
         colorTheme: "Gander Dark",
         iconTheme: "catppuccin-mocha",
@@ -109,9 +118,9 @@ describe("application settings", () => {
   it.each([
     ["{", /Invalid settings JSON/],
     [JSON.stringify({ "editor.fontFamily": "monospace" }), /editor\.fontSize/],
-    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, "workbench.colorTheme": "Unknown", "workbench.iconTheme": "catppuccin-mocha", "workbench.tree.fontFamily": DEFAULT_TREE_FONT_FAMILY, "workbench.tree.fontSize": 13, "workbench.tree.inheritEditorTypography": false }), /workbench\.colorTheme/],
-    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, "workbench.colorTheme": "Catppuccin Mocha", "workbench.iconTheme": "Unknown", "workbench.tree.fontFamily": DEFAULT_TREE_FONT_FAMILY, "workbench.tree.fontSize": 13, "workbench.tree.inheritEditorTypography": false }), /workbench\.iconTheme/],
-    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, "workbench.colorTheme": "Catppuccin Mocha", "workbench.iconTheme": "catppuccin-mocha", "workbench.tree.fontFamily": DEFAULT_TREE_FONT_FAMILY, "workbench.tree.fontSize": 13, "workbench.tree.inheritEditorTypography": false, serviceToken: "nope" }), /Unrecognized key/],
+    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, "window.zoomLevel": 0, "workbench.colorTheme": "Unknown", "workbench.iconTheme": "catppuccin-mocha", "workbench.tree.fontFamily": DEFAULT_TREE_FONT_FAMILY, "workbench.tree.fontSize": 13, "workbench.tree.inheritEditorTypography": false }), /workbench\.colorTheme/],
+    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, "window.zoomLevel": 0, "workbench.colorTheme": "Catppuccin Mocha", "workbench.iconTheme": "Unknown", "workbench.tree.fontFamily": DEFAULT_TREE_FONT_FAMILY, "workbench.tree.fontSize": 13, "workbench.tree.inheritEditorTypography": false }), /workbench\.iconTheme/],
+    [JSON.stringify({ "editor.fontFamily": "monospace", "editor.fontSize": 16, "window.zoomLevel": 0, "workbench.colorTheme": "Catppuccin Mocha", "workbench.iconTheme": "catppuccin-mocha", "workbench.tree.fontFamily": DEFAULT_TREE_FONT_FAMILY, "workbench.tree.fontSize": 13, "workbench.tree.inheritEditorTypography": false, serviceToken: "nope" }), /Unrecognized key/],
   ])("rejects invalid or non-public settings JSON", (source, message) => {
     expect(() => settingsFromJson(source, DEFAULT_APP_SETTINGS)).toThrow(message);
   });
@@ -122,6 +131,7 @@ describe("application settings", () => {
       workbench: { colorTheme: "Gander Dark" },
     })).toEqual({
       editor: { fontFamily: "Consolas, monospace", fontSize: 18 },
+      window: DEFAULT_APP_SETTINGS.window,
       workbench: {
         colorTheme: "Gander Dark",
         iconTheme: "catppuccin-mocha",

--- a/packages/app/src/settings.ts
+++ b/packages/app/src/settings.ts
@@ -5,6 +5,7 @@ import {
   FILE_ICON_THEME_IDS,
   type FileIconThemeId,
 } from "./file-icon-themes.js";
+import { DEFAULT_ZOOM_LEVEL, ZoomLevelSchema } from "./zoom.js";
 
 export const DEFAULT_EDITOR_FONT_FAMILY =
   "'JetBrainsMono NF', 'FiraCode NF', 'Jetbrains Mono', 'Fira Code', Consolas, 'Courier New', monospace";
@@ -25,6 +26,14 @@ export const TreeTypographySettingsSchema = z.object({
   fontFamily: z.string().trim().min(1),
   fontSize: z.number().finite().min(6).max(100),
   inheritEditorTypography: z.boolean(),
+});
+
+export const WindowSettingsSchema = z.object({
+  zoomLevel: ZoomLevelSchema.default(DEFAULT_ZOOM_LEVEL),
+});
+
+export const DEFAULT_WINDOW_SETTINGS: Readonly<WindowSettings> = Object.freeze({
+  zoomLevel: DEFAULT_ZOOM_LEVEL,
 });
 
 export const DEFAULT_TREE_TYPOGRAPHY_SETTINGS: Readonly<TreeTypographySettings> = Object.freeze({
@@ -51,6 +60,7 @@ export const DEFAULT_WORKBENCH_SETTINGS: Readonly<WorkbenchSettings> = Object.fr
 
 export const AppSettingsSchema = z.object({
   editor: EditorSettingsSchema,
+  window: WindowSettingsSchema.default(DEFAULT_WINDOW_SETTINGS),
   // Existing config files predate workbench settings. Preserve their editor choices
   // while adding the bundled default instead of rejecting the whole settings object.
   workbench: WorkbenchSettingsSchema.default(DEFAULT_WORKBENCH_SETTINGS),
@@ -59,6 +69,7 @@ export const AppSettingsSchema = z.object({
 export const SettingsJsonSchema = z.object({
   "editor.fontFamily": EditorSettingsSchema.shape.fontFamily,
   "editor.fontSize": EditorSettingsSchema.shape.fontSize,
+  "window.zoomLevel": ZoomLevelSchema,
   "workbench.colorTheme": ThemeIdSchema,
   "workbench.iconTheme": FileIconThemeIdSchema,
   "workbench.tree.fontFamily": TreeTypographySettingsSchema.shape.fontFamily,
@@ -67,6 +78,7 @@ export const SettingsJsonSchema = z.object({
 }).strict();
 
 export type EditorSettings = z.infer<typeof EditorSettingsSchema>;
+export type WindowSettings = z.infer<typeof WindowSettingsSchema>;
 export type TreeTypographySettings = z.infer<typeof TreeTypographySettingsSchema>;
 export type EffectiveTreeTypography = Pick<TreeTypographySettings, "fontFamily" | "fontSize">;
 export type WorkbenchSettings = z.infer<typeof WorkbenchSettingsSchema>;
@@ -80,6 +92,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = Object.freeze({
     fontFamily: DEFAULT_EDITOR_FONT_FAMILY,
     fontSize: 16,
   }),
+  window: DEFAULT_WINDOW_SETTINGS,
   workbench: DEFAULT_WORKBENCH_SETTINGS,
 });
 
@@ -96,6 +109,7 @@ export function settingsToJson(settings: AppSettings): string {
   const publicSettings: SettingsJson = {
     "editor.fontFamily": settings.editor.fontFamily,
     "editor.fontSize": settings.editor.fontSize,
+    "window.zoomLevel": settings.window.zoomLevel,
     "workbench.colorTheme": settings.workbench.colorTheme,
     "workbench.iconTheme": settings.workbench.iconTheme,
     "workbench.tree.fontFamily": settings.workbench.tree.fontFamily,
@@ -126,6 +140,9 @@ export function settingsFromJson(source: string, current: AppSettings): AppSetti
     editor: {
       fontFamily: parsed.data["editor.fontFamily"],
       fontSize: parsed.data["editor.fontSize"],
+    },
+    window: {
+      zoomLevel: parsed.data["window.zoomLevel"],
     },
     workbench: {
       colorTheme: parsed.data["workbench.colorTheme"],

--- a/packages/app/src/zoom.test.ts
+++ b/packages/app/src/zoom.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ZOOM_LEVEL,
+  ZOOM_LEVEL_MAX,
+  ZOOM_LEVEL_MIN,
+  clampZoomLevel,
+  zoomPercentage,
+} from "./zoom.js";
+
+describe("window zoom", () => {
+  it("converts Electron zoom levels to effective percentages", () => {
+    expect(zoomPercentage(DEFAULT_ZOOM_LEVEL)).toBe(100);
+    expect(zoomPercentage(0.5)).toBe(110);
+    expect(zoomPercentage(1)).toBe(120);
+    expect(zoomPercentage(-1)).toBe(83);
+  });
+
+  it("clamps controls to the supported limits", () => {
+    expect(clampZoomLevel(-100)).toBe(ZOOM_LEVEL_MIN);
+    expect(clampZoomLevel(100)).toBe(ZOOM_LEVEL_MAX);
+    expect(() => clampZoomLevel(Number.NaN)).toThrow(/finite/);
+  });
+});

--- a/packages/app/src/zoom.ts
+++ b/packages/app/src/zoom.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const ZOOM_LEVEL_MIN = -3;
+export const ZOOM_LEVEL_MAX = 6;
+export const ZOOM_LEVEL_STEP = 0.5;
+export const DEFAULT_ZOOM_LEVEL = 0;
+
+export const ZoomLevelSchema = z.number().finite().min(ZOOM_LEVEL_MIN).max(ZOOM_LEVEL_MAX);
+
+export function clampZoomLevel(level: number): number {
+  if (!Number.isFinite(level)) throw new Error("Zoom level must be a finite number");
+  return Math.min(ZOOM_LEVEL_MAX, Math.max(ZOOM_LEVEL_MIN, level));
+}
+
+/** Electron zoom levels use a 1.2 scale factor, where level 0 is 100%. */
+export function zoomPercentage(level: number): number {
+  return Math.round(100 * (1.2 ** clampZoomLevel(level)));
+}


### PR DESCRIPTION
## Summary

- show the effective zoom percentage in the status bar with a compact zoom out, reset, zoom in, and settings toolbar
- unify View menu shortcuts, renderer controls, and settings behind one persisted main-process zoom controller
- add the public `window.zoomLevel` setting and migrate the previous top-level persisted value

## Impact

Reviewers can see and adjust the current window scale without opening the View menu. Zoom remains synchronized when changed from the menu, keyboard shortcuts, status bar, or settings, and survives restart.

## Validation

- `pnpm test` (239 tests)
- `pnpm typecheck`
- `pnpm test:e2e` (8 tests)
- Impeccable UI detector (clean)

Closes #41
