### PR TITLE
Add discoverable controls for review questions

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -281,15 +281,35 @@ describe("Gander end to end", () => {
       style.fontFamily.includes("Courier New") && style.fontSize === "18.5px" && style.rowHeight === 22,
     )).toBe(true);
 
+    const persistentAdd = await $("button[aria-label='Add question (N)']");
+    await expect(persistentAdd).toBeDisplayed();
+    await expect(persistentAdd).toHaveAttribute("title", "Add question (N)");
+
+    const lineAdd = await $(".gander-line-question");
+    await lineAdd.waitForDisplayed();
+    const lineLabel = await lineAdd.getAttribute("aria-label");
+    const anchoredLine = lineLabel?.match(/line (\d+)/)?.[1];
+    expect(anchoredLine).toBeDefined();
+    await lineAdd.click();
+    await expect($("#question-target")).toHaveText(expect.stringContaining(`a.rb · line ${anchoredLine}`));
+    const anchoredQuestion = await $("textarea[placeholder='What needs answering or changing here?']");
+    await anchoredQuestion.setValue("Keep this on the first line.");
+    await browser.keys("Enter");
+    await $("button[aria-label='Questions']").click();
+    await expect($(".message.original .text")).toHaveText("Keep this on the first line.");
+    await expect($(".row .file")).toHaveText(`a.rb:${anchoredLine}`);
+    await expect($(".drawer button[aria-label='Add question (N)']")).toBeDisplayed();
+    await $("button[aria-label='Close questions']").click();
+
     await browser.keys("n");
     const question = await $("textarea[placeholder='What needs answering or changing here?']");
     await question.waitForDisplayed();
     await question.setValue("Why does this need to happen here?");
     await browser.keys("Enter");
     await $("button[aria-label='Questions']").click();
-    await expect($(".message.original .text")).toHaveText("Why does this need to happen here?");
+    await expect($(".drawer li:last-child .message.original .text")).toHaveText("Why does this need to happen here?");
 
-    const reply = await $(".reply-form input");
+    const reply = await $(".drawer li:last-child .reply-form input");
     await reply.setValue("Because both callers share this path.");
     await browser.keys("Enter");
     await expect($(".message.reply .author")).toHaveText("REVIEWER");

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -14,6 +14,8 @@ import { questionsDock, questionsHeight, questionsWidth, treeWidth } from "./lay
 import { X } from "lucide-vue-next";
 import { createEditorSettingsStore } from "./editor-settings-store.js";
 import { effectiveTreeTypography } from "../../settings.js";
+import { currentLine } from "./selection.js";
+import type { QuestionTarget } from "./selection.js";
 import "./theme.css";
 
 const store = createStore(api);
@@ -37,7 +39,7 @@ onMounted(async () => {
 });
 
 const unconfigured = ref(false);
-const capturing = ref(false);
+const questionTarget = shallowRef<QuestionTarget | null>(null);
 const drawerOpen = ref(false);
 const treeVisible = ref(true);
 const activeSurface = shallowRef<"review" | "settings">("review");
@@ -86,6 +88,14 @@ const questionsSize = computed({
 });
 const questionCount = computed(() => store.view?.questions.length ?? 0);
 
+function openQuestion(target?: QuestionTarget): void {
+  if (!store.view) return;
+  questionTarget.value = target ?? {
+    path: store.selectedPath,
+    line: store.selectedPath === null ? null : currentLine.value,
+  };
+}
+
 // Monaco takes keyboard input through a hidden textarea, so clicking a line to position
 // the cursor makes the diff the focused "text field" — and a naive typing check hands it
 // every keystroke, including the one that opens capture. Every editor in this app is
@@ -112,7 +122,7 @@ function onKey(e: KeyboardEvent): void {
     e.preventDefault();
     // Monaco would otherwise still handle it and flash "Cannot edit in read-only editor".
     e.stopPropagation();
-    capturing.value = true;
+    openQuestion();
   }
 }
 window.addEventListener("keydown", onKey, true);
@@ -155,6 +165,7 @@ onBeforeUnmount(() => {
       :integrated-title-bar="integratedTitleBar"
       @toggle-questions="drawerOpen = !drawerOpen"
       @toggle-settings="toggleSettings"
+      @add-question="openQuestion()"
     />
     <div v-if="store.error" class="error-banner">
       <span>{{ store.error }}</span>
@@ -197,7 +208,12 @@ onBeforeUnmount(() => {
           <!-- Docked right, questions sit beside the diff; docked bottom, under both the
                diff and the tree, which is what gives the diff the full window width. -->
           <div class="workspace" :class="questionsDock">
-            <DiffPane :store="store" :editor-settings="editorSettings.settings.editor" class="diff" />
+            <DiffPane
+              :store="store"
+              :editor-settings="editorSettings.settings.editor"
+              class="diff"
+              @add-question="openQuestion"
+            />
             <template v-if="drawerOpen">
               <Splitter
                 v-model="questionsSize"
@@ -215,6 +231,7 @@ onBeforeUnmount(() => {
                   ? { width: `${questionsWidth}px` }
                   : { height: `${questionsHeight}px` }"
                 @close="drawerOpen = false"
+                @add-question="openQuestion()"
               />
             </template>
           </div>
@@ -228,7 +245,7 @@ onBeforeUnmount(() => {
       :worktree-label="api.initialWindowState.worktreeLabel"
       @toggle-tree="treeVisible = !treeVisible"
     />
-    <QuestionCapture :store="store" :open="capturing" @close="capturing = false" />
+    <QuestionCapture :store="store" :target="questionTarget" @close="questionTarget = null" />
   </div>
 </template>
 

--- a/packages/app/src/renderer/src/components/DiffPane.vue
+++ b/packages/app/src/renderer/src/components/DiffPane.vue
@@ -7,9 +7,11 @@ import { codeEditorOptions, diffEditorOptions, editorFontOptions } from "../edit
 import type { Store } from "../store.js";
 import type { EditorSettings } from "../../../settings.js";
 import { currentLine, pendingReveal } from "../selection.js";
+import type { QuestionTarget } from "../selection.js";
 import { Check, FileClock, FileDiff, FileText, TriangleAlert } from "lucide-vue-next";
 
 const props = defineProps<{ store: Store; editorSettings: EditorSettings }>();
+const emit = defineEmits<{ addQuestion: [target: QuestionTarget] }>();
 const host = ref<HTMLElement | null>(null);
 const view = ref<"diff" | "full" | "since">("diff");
 
@@ -23,6 +25,8 @@ const snapshotFor = ref<string | null>(null);
 const canShowDelta = computed(() => current.value?.changedSince === true);
 let editor: monaco.editor.IStandaloneDiffEditor | monaco.editor.IStandaloneCodeEditor | null = null;
 let models: monaco.editor.ITextModel[] = [];
+let lineAction: HTMLButtonElement | null = null;
+let lineActionLine: number | null = null;
 
 const current = computed(
   () => props.store.view?.files.find((f) => f.path === props.store.selectedPath) ?? null,
@@ -55,12 +59,59 @@ function trackCursor(): void {
   const ed = headEditor();
   if (!ed) return;
   currentLine.value = ed.getPosition()?.lineNumber ?? null;
-  ed.onDidChangeCursorPosition((e) => { currentLine.value = e.position.lineNumber; });
+  installLineAction(ed);
+  ed.onDidChangeCursorPosition((e) => {
+    currentLine.value = e.position.lineNumber;
+    showLineAction(ed, e.position.lineNumber);
+  });
+}
+
+function showLineAction(ed: monaco.editor.ICodeEditor, line: number): void {
+  if (!lineAction) return;
+  const position = ed.getScrolledVisiblePosition({ lineNumber: line, column: 1 });
+  if (!position) {
+    lineAction.hidden = true;
+    return;
+  }
+  lineActionLine = line;
+  lineAction.hidden = false;
+  lineAction.style.top = `${position.top + Math.max(0, (position.height - 18) / 2)}px`;
+  lineAction.style.left = `${ed.getLayoutInfo().glyphMarginLeft + 2}px`;
+  lineAction.setAttribute("aria-label", `Add question on line ${line} (N)`);
+  lineAction.title = `Add question on line ${line} (N)`;
+}
+
+function installLineAction(ed: monaco.editor.ICodeEditor): void {
+  const dom = ed.getDomNode();
+  if (!dom) return;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "gander-line-question";
+  button.textContent = "+";
+  button.addEventListener("click", () => {
+    const path = current.value?.path;
+    if (path && lineActionLine !== null) emit("addQuestion", { path, line: lineActionLine });
+  });
+  dom.append(button);
+  lineAction = button;
+  const initialLine = ed.getPosition()?.lineNumber ?? 1;
+  showLineAction(ed, initialLine);
+  ed.onMouseMove((event) => {
+    if (event.target.position) showLineAction(ed, event.target.position.lineNumber);
+  });
+  ed.onDidScrollChange(() => {
+    if (lineActionLine !== null) showLineAction(ed, lineActionLine);
+  });
+  ed.onDidLayoutChange(() => {
+    if (lineActionLine !== null) showLineAction(ed, lineActionLine);
+  });
 }
 
 function dispose(): void {
   editor?.dispose();
   editor = null;
+  lineAction = null;
+  lineActionLine = null;
   // A line number from a file that is no longer on screen would stamp the next
   // question with a line the reader never looked at.
   currentLine.value = null;
@@ -324,5 +375,29 @@ onBeforeUnmount(dispose);
   justify-content: center;
   color: var(--faint-foreground);
   font-size: 13px;
+}
+:deep(.gander-line-question) {
+  position: absolute;
+  z-index: 10;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px;
+  border: 1px solid var(--workbench-border);
+  border-radius: 4px;
+  background: var(--elevated-background);
+  color: var(--workbench-foreground);
+  font: 700 16px/1 var(--mono);
+  cursor: pointer;
+}
+:deep(.gander-line-question:hover) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+:deep(.gander-line-question:focus-visible) {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }
 </style>

--- a/packages/app/src/renderer/src/components/QuestionCapture.test.ts
+++ b/packages/app/src/renderer/src/components/QuestionCapture.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { Store } from "../store.js";
+import QuestionCapture from "./QuestionCapture.vue";
+
+describe("QuestionCapture", () => {
+  it("submits the explicit file and line even if the store selection moves", async () => {
+    const addQuestion = vi.fn(async () => {});
+    const store = {
+      selectedPath: "new-selection.ts",
+      addQuestion,
+    } as unknown as Store;
+    const wrapper = mount(QuestionCapture, {
+      props: {
+        store,
+        target: { path: "reviewed-file.ts", line: 17 },
+      },
+    });
+
+    expect(wrapper.get("label").text()).toContain("reviewed-file.ts · line 17");
+    await wrapper.get("textarea").setValue("Keep this anchor");
+    await wrapper.get("form").trigger("submit");
+
+    expect(addQuestion).toHaveBeenCalledWith("Keep this anchor", "reviewed-file.ts", 17);
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+
+  it("supports a pull-request-level target", async () => {
+    const addQuestion = vi.fn(async () => {});
+    const store = { addQuestion } as unknown as Store;
+    const wrapper = mount(QuestionCapture, {
+      props: { store, target: { path: null, line: null } },
+    });
+
+    await wrapper.get("textarea").setValue("Across the whole PR");
+    await wrapper.get("form").trigger("submit");
+
+    expect(addQuestion).toHaveBeenCalledWith("Across the whole PR", null, null);
+  });
+});

--- a/packages/app/src/renderer/src/components/QuestionCapture.vue
+++ b/packages/app/src/renderer/src/components/QuestionCapture.vue
@@ -1,20 +1,16 @@
 <script setup lang="ts">
 import { nextTick, ref, watch } from "vue";
 import type { Store } from "../store.js";
-import { currentLine } from "../selection.js";
+import type { QuestionTarget } from "../selection.js";
 
-const props = defineProps<{ store: Store; open: boolean }>();
+const props = defineProps<{ store: Store; target: QuestionTarget | null }>();
 const emit = defineEmits<{ close: [] }>();
 
 const text = ref("");
 const box = ref<HTMLTextAreaElement | null>(null);
-// Held at the moment the box opens: focusing the textarea takes the cursor out of the
-// editor, and the line the reader was on is the one the question is about.
-const capturedLine = ref<number | null>(null);
 
-watch(() => props.open, async (open) => {
-  if (!open) return;
-  capturedLine.value = props.store.selectedPath === null ? null : currentLine.value;
+watch(() => props.target, async (target) => {
+  if (target === null) return;
   text.value = "";
   await nextTick();
   box.value?.focus();
@@ -23,24 +19,25 @@ watch(() => props.open, async (open) => {
 async function submit(): Promise<void> {
   const body = text.value.trim();
   if (!body) return;
-  // Captured against the file being read. A question with no file selected is a
-  // note about the pull request as a whole.
-  await props.store.addQuestion(body, props.store.selectedPath, capturedLine.value);
+  // The target is fixed before the textarea takes focus. In particular, a gutter click
+  // must keep the line it named even if Monaco's cursor or the selected file moves.
+  await props.store.addQuestion(body, props.target?.path ?? null, props.target?.line ?? null);
   emit("close");
 }
 </script>
 
 <template>
-  <div v-if="open" class="capture" @click.self="$emit('close')">
-    <form class="panel" @submit.prevent="submit">
-      <label>
+  <div v-if="target" class="capture" @click.self="$emit('close')">
+    <form class="panel" role="dialog" aria-modal="true" aria-labelledby="question-target" @submit.prevent="submit">
+      <label id="question-target" for="question-text">
         Question on
-        <b>{{ store.selectedPath ?? "this pull request" }}</b>
-        <template v-if="capturedLine !== null"> · line {{ capturedLine }}</template>
+        <b>{{ target.path ?? "this pull request" }}</b>
+        <template v-if="target.line !== null"> · line {{ target.line }}</template>
       </label>
       <!-- Enter submits, Shift+Enter breaks the line: capture must cost one keystroke. -->
       <textarea
         ref="box"
+        id="question-text"
         v-model="text"
         rows="3"
         placeholder="What needs answering or changing here?"

--- a/packages/app/src/renderer/src/components/QuestionsDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/QuestionsDrawer.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import type { PrView } from "@gander/shared";
+import type { Store } from "../store.js";
+import QuestionsDrawer from "./QuestionsDrawer.vue";
+
+const view = (questions: PrView["questions"]): PrView => ({
+  pr: { number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" },
+  files: [],
+  questions,
+});
+
+function store(questions: PrView["questions"]): Store {
+  return {
+    view: view(questions),
+    selectedPath: null,
+    async addReviewerReply() {},
+    async deleteQuestion() {},
+  } as unknown as Store;
+}
+
+describe("QuestionsDrawer", () => {
+  it("offers add actions in the empty state", async () => {
+    const wrapper = mount(QuestionsDrawer, { props: { store: store([]), dock: "right" } });
+
+    const actions = wrapper.findAll("button[aria-label='Add question (N)'], .empty button");
+    expect(actions).toHaveLength(2);
+    await actions[1]!.trigger("click");
+
+    expect(wrapper.emitted("addQuestion")).toHaveLength(1);
+  });
+
+  it("keeps the header add action when questions are populated", async () => {
+    const wrapper = mount(QuestionsDrawer, {
+      props: {
+        store: store([{
+          id: 1,
+          path: "a.ts",
+          line: 3,
+          text: "Why?",
+          state: "open",
+          headSha: "b",
+          commitRef: null,
+          note: null,
+          createdAt: "2026-08-18T00:00:00.000Z",
+          replies: [],
+        }]),
+        dock: "right",
+      },
+    });
+
+    expect(wrapper.find(".empty").exists()).toBe(false);
+    await wrapper.get("button[aria-label='Add question (N)']").trigger("click");
+
+    expect(wrapper.emitted("addQuestion")).toHaveLength(1);
+  });
+});

--- a/packages/app/src/renderer/src/components/QuestionsDrawer.vue
+++ b/packages/app/src/renderer/src/components/QuestionsDrawer.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed, reactive } from "vue";
-import { MessageSquare, PanelBottom, PanelRight, Trash2, X } from "lucide-vue-next";
+import { MessageSquare, PanelBottom, PanelRight, Plus, Trash2, X } from "lucide-vue-next";
 import type { Store } from "../store.js";
 import { revealLine } from "../selection.js";
 
 const props = defineProps<{ store: Store; dock: "right" | "bottom" }>();
-defineEmits<{ close: []; dock: ["right" | "bottom"] }>();
+const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addQuestion: [] }>();
 
 const questions = computed(() => props.store.view?.questions ?? []);
 const drafts = reactive<Record<number, string>>({});
@@ -44,6 +44,15 @@ async function reply(questionId: number): Promise<void> {
       <span class="title">Questions</span>
       <span class="count">{{ questions.length }}</span>
       <button
+        class="add"
+        aria-label="Add question (N)"
+        title="Add question (N)"
+        @click="emit('addQuestion')"
+      >
+        <Plus :size="14" aria-hidden="true" />
+        <span>Add</span>
+      </button>
+      <button
         class="close dockbtn"
         :aria-label="dock === 'right' ? 'Dock questions below the diff' : 'Dock questions beside the diff'"
         :title="dock === 'right' ? 'Dock below the diff' : 'Dock beside the diff'"
@@ -56,9 +65,13 @@ async function reply(questionId: number): Promise<void> {
       </button>
     </header>
 
-    <p v-if="questions.length === 0" class="empty">
-      Press <kbd>n</kbd> while a file is selected to capture a question against it.
-    </p>
+    <div v-if="questions.length === 0" class="empty">
+      <p>Capture a question about the selected file or line.</p>
+      <button type="button" @click="emit('addQuestion')">
+        <Plus :size="14" aria-hidden="true" />
+        Add question <kbd>N</kbd>
+      </button>
+    </div>
 
     <ul v-else>
       <li v-for="q in questions" :key="q.id" :class="{ current: q.path === store.selectedPath }">
@@ -102,12 +115,28 @@ async function reply(questionId: number): Promise<void> {
 header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--workbench-border); color: var(--muted-foreground); flex: none; }
 .title { font-size: 12px; font-weight: 600; letter-spacing: .3px; text-transform: uppercase; }
 .count { font: 11px var(--mono); background: var(--badge-background); border-radius: 9px; padding: 1px 7px; }
-.dockbtn { margin-left: auto; }
+.add {
+  margin-left: auto; display: flex; align-items: center; gap: 4px;
+  background: none; border: 1px solid var(--workbench-border); border-radius: 5px;
+  color: var(--workbench-foreground); padding: 3px 7px; font: inherit; font-size: 11px; cursor: pointer;
+}
+.add:hover { border-color: var(--accent); color: var(--accent); }
+.dockbtn { margin-left: 0; }
 .dockbtn + .close { margin-left: 0; }
 .close { margin-left: auto; background: none; border: none; color: var(--faint-foreground); cursor: pointer; display: flex; }
 .close:hover { color: var(--workbench-foreground); }
 
 .empty { color: var(--faint-foreground); font-size: 12px; padding: 16px 12px; line-height: 1.6; }
+.empty p { margin-bottom: 10px; }
+.empty button {
+  display: flex; align-items: center; gap: 6px;
+  background: var(--accent); border: 1px solid var(--accent); border-radius: 6px;
+  color: var(--accent-foreground); padding: 5px 9px; font: inherit; font-size: 12px; font-weight: 600; cursor: pointer;
+}
+.empty button kbd { color: var(--workbench-foreground); }
+.add:focus-visible, .empty button:focus-visible, .close:focus-visible, .del:focus-visible, .file:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
 kbd { font: 11px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: 4px; padding: 1px 5px; }
 
 ul { list-style: none; margin: 0; padding: 0; }

--- a/packages/app/src/renderer/src/components/TopBar.vue
+++ b/packages/app/src/renderer/src/components/TopBar.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
   settingsActive: boolean;
   integratedTitleBar: boolean;
 }>();
-const emit = defineEmits<{ toggleQuestions: []; toggleSettings: [] }>();
+const emit = defineEmits<{ toggleQuestions: []; toggleSettings: []; addQuestion: [] }>();
 
 const repoOpen = ref(false);
 const reviewOpen = ref(false);
@@ -128,6 +128,16 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
     <div class="spacer" />
     <div class="right">
       <button
+        v-if="store.view"
+        class="add-question"
+        aria-label="Add question (N)"
+        title="Add question (N)"
+        @click="emit('addQuestion')"
+      >
+        <Plus :size="15" aria-hidden="true" />
+        <span>Question</span>
+      </button>
+      <button
         class="fetch"
         :class="{ active: settingsActive }"
         aria-label="Editor settings"
@@ -242,6 +252,16 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
 .right { display: flex; align-items: center; gap: 10px; padding: 0 12px; }
 .progress { font-size: 12px; color: var(--muted-foreground); background: var(--badge-background); border-radius: 10px; padding: 2px 10px; white-space: nowrap; }
 .progress b { color: var(--success); }
+.add-question {
+  display: flex; align-items: center; gap: 5px;
+  min-height: 28px; padding: 0 9px;
+  background: var(--accent); border: 1px solid var(--accent); border-radius: 6px;
+  color: var(--accent-foreground); font: inherit; font-size: 12px; font-weight: 600; cursor: pointer;
+}
+.add-question:hover { filter: brightness(1.08); }
+.add-question:focus-visible, .fetch:focus-visible {
+  outline: 2px solid var(--workbench-foreground); outline-offset: 2px;
+}
 /* Icon-only, sized to stay a comfortable pointer target at any zoom level. */
 .fetch {
   display: flex; align-items: center; justify-content: center;

--- a/packages/app/src/renderer/src/editor-options.ts
+++ b/packages/app/src/renderer/src/editor-options.ts
@@ -12,6 +12,7 @@ export function diffEditorOptions(settings: EditorSettings): editor.IStandaloneD
   return {
     renderSideBySide: false,
     readOnly: true,
+    glyphMargin: true,
     automaticLayout: true,
     hideUnchangedRegions: { enabled: true },
     ...editorFontOptions(settings),
@@ -21,6 +22,7 @@ export function diffEditorOptions(settings: EditorSettings): editor.IStandaloneD
 export function codeEditorOptions(settings: EditorSettings): editor.IStandaloneEditorConstructionOptions {
   return {
     readOnly: true,
+    glyphMargin: true,
     automaticLayout: true,
     ...editorFontOptions(settings),
   };

--- a/packages/app/src/renderer/src/selection.ts
+++ b/packages/app/src/renderer/src/selection.ts
@@ -1,5 +1,10 @@
 import { ref } from "vue";
 
+export interface QuestionTarget {
+  path: string | null;
+  line: number | null;
+}
+
 /**
  * Where the reader's cursor is in the diff, and where they want to go next.
  *


### PR DESCRIPTION
## Summary

- add a persistent question action to the review toolbar
- add question actions to both empty and populated Questions drawer states
- add a focusable Monaco gutter action that targets the hovered or current line
- freeze the selected file and line before capture takes focus so saved questions retain their intended anchor
- keep the existing `n` keyboard shortcut and expose it in tooltips and accessible labels

## Why

Creating a review question was effectively hidden behind the `n` shortcut. These controls make the core workflow visible where reviewers already work while preserving the fast keyboard path.

## Validation

- `pnpm typecheck`
- `pnpm test` — 230 tests passed
- `pnpm test:e2e` — 7 scenarios passed
- `git diff --check`

Closes #8
