### PR TITLE
Browse repositories instead of pasting a URL

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -14,15 +14,23 @@ function requiredEnv(name: string): string {
   return value;
 }
 
-async function registerAndSelect(url: string, repoName: string): Promise<void> {
+async function registerAndSelect(url: string, repoName: string, source: "github" | "url" = "github"): Promise<void> {
   await $(".seg-repo").click();
   await $("//div[@role='button'][.//span[contains(normalize-space(.), 'Add repository')]]").click();
-  const input = await $("input[placeholder='https://github.com/owner/repo']");
-  await input.setValue(url);
-  await browser.keys("Enter");
-  const option = await $(`//div[@role='option'][.//span[contains(@class, 'nm') and normalize-space()='${repoName}']]`);
-  await option.waitForDisplayed();
-  await option.click();
+  if (source === "url") {
+    await $("#repository-url-tab").click();
+    const input = await $("input[placeholder='https://github.com/owner/repo']");
+    await input.setValue(url);
+    await browser.keys("Enter");
+  } else {
+    const filter = await $("#repository-filter");
+    await filter.waitForDisplayed();
+    await filter.setValue(repoName);
+    const option = await $(`//ul[@aria-label='Available repositories']//button[.//span[contains(@class, 'repo-name') and normalize-space()='${repoName}']]`);
+    await option.waitForDisplayed();
+    await option.click();
+  }
+  await expect($(".seg-repo .val")).toHaveText(expect.stringContaining(repoName));
 }
 
 async function openPullRequest(title: string, twice = false): Promise<void> {
@@ -315,7 +323,7 @@ describe("Gander end to end", () => {
   });
 
   it("opens a pull request twice quickly with one valid clone", async () => {
-    await registerAndSelect(requiredEnv("GANDER_E2E_RACE_URL"), "race");
+    await registerAndSelect(requiredEnv("GANDER_E2E_RACE_URL"), "race", "url");
     await openPullRequest("Open without corrupting the clone", true);
     await expect($(".progress")).toHaveText("0/2 reviewed");
     await expect($(".error-banner")).not.toBeDisplayed();

--- a/packages/app/e2e/run.ts
+++ b/packages/app/e2e/run.ts
@@ -64,6 +64,27 @@ async function main(): Promise<void> {
   const raceRequestsReady = new Promise<void>((resolve) => { releaseRaceRequests = resolve; });
   let raceRequestCount = 0;
 
+  github.get<{ Querystring: { page?: string } }>("/user/repos", async (request, reply) => {
+    if (request.headers.authorization !== `Bearer ${GITHUB_TOKEN}`) {
+      return reply.code(401).send({ message: "wrong test token" });
+    }
+    if (request.query.page && request.query.page !== "1") return [];
+    return [
+      ...fixtures.map((fixture, index) => ({
+        full_name: fixture.repoId,
+        html_url: fixture.url,
+        private: index === 0,
+        archived: false,
+      })),
+      {
+        full_name: "acme/archived-example",
+        html_url: "https://github.com/acme/archived-example",
+        private: false,
+        archived: true,
+      },
+    ];
+  });
+
   github.get<{ Params: { owner: string; repo: string }; Querystring: { page?: string } }>(
     "/repos/:owner/:repo/pulls",
     async (request, reply) => {

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -10,6 +10,12 @@ export const DEVELOPMENT_ARGUMENT = "--gander-development";
 export const WORKTREE_LABEL_ARGUMENT = "--gander-worktree-label=";
 export type GithubTokenCheck = { ok: true; login: string } | { ok: false; reason: string };
 
+export interface GithubRepository {
+  repoId: string;
+  url: string;
+  private: boolean;
+}
+
 export interface InitialWindowState {
   windowStyle: WindowStyle;
   colorTheme: ThemeId;
@@ -23,6 +29,8 @@ export interface GanderApi {
   /** Fixed by the main process when the window is created; renderer code cannot change it. */
   initialWindowState: InitialWindowState;
   listRepos(): Promise<RepoEntry[]>;
+  /** All non-archived repositories visible to the current GitHub credential. */
+  listGithubRepos(): Promise<GithubRepository[]>;
   addRepo(url: string): Promise<RepoEntry>;
   listPrs(repoId: string): Promise<PrSummary[]>;
   lastReview(): Promise<{ repoId: string; prNumber: number } | null>;

--- a/packages/app/src/main/github.test.ts
+++ b/packages/app/src/main/github.test.ts
@@ -1,10 +1,47 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { listOpenPrs, resolveGithubToken } from "./github.js";
+import { listGithubRepositories, listOpenPrs, resolveGithubToken } from "./github.js";
 
 const ghPr = {
   number: 987, title: "Late-fee automation", body: "Adds calculator", draft: true,
   base: { ref: "main", sha: "aaa111" }, head: { sha: "bbb222" },
 };
+
+describe("listGithubRepositories", () => {
+  it("lists every page by recent activity and excludes archived repositories", async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+      full_name: `acme/repo-${i}`,
+      html_url: `https://github.com/acme/repo-${i}`,
+      private: i % 2 === 0,
+      archived: i === 3,
+    }));
+    const requestedUrls: string[] = [];
+    const fakeFetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      requestedUrls.push(String(url));
+      expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer tok");
+      return new Response(JSON.stringify(requestedUrls.length === 1 ? fullPage : [{
+        full_name: "steve/gander",
+        html_url: "https://github.com/steve/gander",
+        private: false,
+        archived: false,
+      }]), { status: 200 });
+    }) as typeof fetch;
+
+    const repos = await listGithubRepositories("tok", fakeFetch);
+
+    expect(repos).toHaveLength(100);
+    expect(repos).not.toContainEqual(expect.objectContaining({ repoId: "acme/repo-3" }));
+    expect(repos.at(-1)).toEqual({ repoId: "steve/gander", url: "https://github.com/steve/gander", private: false });
+    expect(requestedUrls).toEqual([
+      "https://api.github.com/user/repos?visibility=all&affiliation=owner%2Ccollaborator%2Corganization_member&sort=updated&direction=desc&per_page=100&page=1",
+      "https://api.github.com/user/repos?visibility=all&affiliation=owner%2Ccollaborator%2Corganization_member&sort=updated&direction=desc&per_page=100&page=2",
+    ]);
+  });
+
+  it("surfaces repository-list errors with their response body", async () => {
+    const fakeFetch = (async () => new Response("token lacks access", { status: 403 })) as typeof fetch;
+    await expect(listGithubRepositories("tok", fakeFetch)).rejects.toThrow(/403.*token lacks access/s);
+  });
+});
 
 describe("listOpenPrs", () => {
   const originalApiUrl = process.env.GANDER_GITHUB_API_URL;

--- a/packages/app/src/main/github.ts
+++ b/packages/app/src/main/github.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { PrSummary } from "@gander/shared";
+import type { GithubRepository } from "../api.js";
 
 type ExecFileFn = (file: string, args: readonly string[]) => Promise<{ stdout: string }>;
 
@@ -14,11 +15,41 @@ interface GhPr {
   stack?: { id: number; size: number; position: number } | null;
 }
 
+interface GhRepository {
+  full_name: string;
+  html_url: string;
+  private: boolean;
+  archived: boolean;
+}
+
 const PER_PAGE = 100;
 const DEFAULT_API_URL = "https://api.github.com";
 
+function githubHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" };
+}
+
+export async function listGithubRepositories(token: string, fetchImpl: typeof fetch = fetch): Promise<GithubRepository[]> {
+  const apiUrl = (process.env.GANDER_GITHUB_API_URL ?? DEFAULT_API_URL).replace(/\/+$/, "");
+  const all: GhRepository[] = [];
+  let page = 1;
+  for (;;) {
+    const res = await fetchImpl(`${apiUrl}/user/repos?visibility=all&affiliation=owner%2Ccollaborator%2Corganization_member&sort=updated&direction=desc&per_page=${PER_PAGE}&page=${page}`, {
+      headers: githubHeaders(token),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} while listing repositories: ${await res.text()}`);
+    const repos = (await res.json()) as GhRepository[];
+    all.push(...repos);
+    if (repos.length < PER_PAGE) break;
+    page += 1;
+  }
+  return all
+    .filter((repo) => !repo.archived)
+    .map((repo) => ({ repoId: repo.full_name, url: repo.html_url, private: repo.private }));
+}
+
 export async function listOpenPrs(repoId: string, token: string, fetchImpl: typeof fetch = fetch): Promise<PrSummary[]> {
-  const headers = { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" };
+  const headers = githubHeaders(token);
   const apiUrl = (process.env.GANDER_GITHUB_API_URL ?? DEFAULT_API_URL).replace(/\/+$/, "");
   const all: GhPr[] = [];
   let page = 1;

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -6,7 +6,7 @@ import { connectionIsFromEnvironment, loadConfig, resolveServiceConnection, save
 import { checkConnection } from "./connection.js";
 import { parseOpenTarget } from "./cli.js";
 import { createGitEngine } from "./git.js";
-import { checkGithubToken, listOpenPrs, resolveGithubToken } from "./github.js";
+import { checkGithubToken, listGithubRepositories, listOpenPrs, resolveGithubToken } from "./github.js";
 import { startOpenServer } from "./open-socket.js";
 import { createReviewer } from "./review.js";
 import { createServiceClient } from "./service-client.js";
@@ -38,6 +38,7 @@ async function bootstrap(): Promise<GanderConfig> {
   });
 
   ipcMain.handle("gander:listRepos", async () => cfg.repos);
+  ipcMain.handle("gander:listGithubRepos", async () => listGithubRepositories(await githubToken()));
   ipcMain.handle("gander:addRepo", async (_e, url: string): Promise<RepoEntry> => {
     const entry = { repoId: repoIdFromUrl(url), url };
     if (!cfg.repos.some((r) => r.repoId === entry.repoId)) { cfg.repos.push(entry); saveConfig(cfg); }

--- a/packages/app/src/preload/api.ts
+++ b/packages/app/src/preload/api.ts
@@ -61,6 +61,7 @@ export function createGanderApi(
   return {
     initialWindowState,
     listRepos: () => call("listRepos"),
+    listGithubRepos: () => call("listGithubRepos"),
     addRepo: (url) => call("addRepo", url),
     listPrs: (repoId) => call("listPrs", repoId),
     lastReview: () => call("lastReview"),

--- a/packages/app/src/renderer/src/api.ts
+++ b/packages/app/src/renderer/src/api.ts
@@ -1,3 +1,3 @@
 import type { GanderApi } from "../../api.js";
-export type { ConnectionCheck, GanderApi, GithubTokenCheck } from "../../api.js";
+export type { ConnectionCheck, GanderApi, GithubRepository, GithubTokenCheck } from "../../api.js";
 export const api = (window as unknown as { gander: GanderApi }).gander;

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -26,6 +26,9 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
   const calls: Calls = { setChecked: [], setCheckedMany: [] };
   const store: Store = reactive({
     repos: [],
+    githubRepos: [],
+    githubReposBusy: false,
+    githubReposError: null,
     prs: [],
     currentRepoId: "acme/atlas",
     view,
@@ -35,6 +38,7 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
     lastFetchAt: null,
     busy: false,
     async loadRepos() {},
+    async loadGithubRepos() {},
     async restoreLastReview() {},
     async checkService() {},
     dismissError() {},

--- a/packages/app/src/renderer/src/components/RepositoryPicker.test.ts
+++ b/packages/app/src/renderer/src/components/RepositoryPicker.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { flushPromises, mount } from "@vue/test-utils";
+import { reactive } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Store } from "../store.js";
+import RepositoryPicker from "./RepositoryPicker.vue";
+
+function fakeStore(overrides: Partial<Store> = {}): Store {
+  return reactive({
+    repos: [{ repoId: "acme/atlas", url: "https://github.com/acme/atlas" }],
+    githubRepos: [],
+    githubReposBusy: false,
+    githubReposError: null,
+    busy: false,
+    error: null,
+    async loadGithubRepos() {
+      store.githubRepos = [
+        { repoId: "acme/atlas", url: "https://github.com/acme/atlas", private: true },
+        { repoId: "steve/gander", url: "https://github.com/steve/gander", private: false },
+      ];
+    },
+    async selectRepo() {},
+    async addRepo() {},
+    ...overrides,
+  } as unknown as Store);
+}
+
+let store: Store;
+
+beforeEach(() => {
+  store = fakeStore();
+  HTMLDialogElement.prototype.showModal = function showModal() { this.open = true; };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+    this.dispatchEvent(new Event("close"));
+  };
+});
+
+describe("RepositoryPicker", () => {
+  it("loads, filters, and distinguishes repositories already added", async () => {
+    const wrapper = mount(RepositoryPicker, { props: { open: false, store } });
+    await wrapper.setProps({ open: true });
+    await flushPromises();
+
+    expect(wrapper.get("dialog").attributes("open")).toBeDefined();
+    expect(wrapper.get(".repository-list").text()).toContain("atlas");
+    expect(wrapper.get(".repository-list").text()).toContain("Added");
+    expect(wrapper.get(".repository-list").text()).toContain("Private");
+
+    const filter = wrapper.get("#repository-filter");
+    (filter.element as HTMLInputElement).value = "gander";
+    await filter.trigger("input");
+    expect(wrapper.get(".repository-list").text()).not.toContain("atlas");
+    expect(wrapper.get(".repository-list").text()).toContain("gander");
+  });
+
+  it("registers a GitHub repository and closes after it becomes selected", async () => {
+    const addRepo = vi.fn(async () => {});
+    store = fakeStore({ addRepo });
+    const wrapper = mount(RepositoryPicker, { props: { open: false, store } });
+    await wrapper.setProps({ open: true });
+    await flushPromises();
+
+    await wrapper.findAll(".repository-list button")[1]!.trigger("click");
+    await flushPromises();
+
+    expect(addRepo).toHaveBeenCalledWith("https://github.com/steve/gander");
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+
+  it("keeps URL entry as a fallback", async () => {
+    const addRepo = vi.fn(async () => {});
+    store = fakeStore({ addRepo });
+    const wrapper = mount(RepositoryPicker, { props: { open: false, store } });
+    await wrapper.setProps({ open: true });
+    await flushPromises();
+
+    await wrapper.get("#repository-url-tab").trigger("click");
+    await wrapper.get("#repository-url").setValue("https://github.com/acme/hidden");
+    await wrapper.get(".url-panel form").trigger("submit");
+    await flushPromises();
+
+    expect(addRepo).toHaveBeenCalledWith("https://github.com/acme/hidden");
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+
+  it("moves between tabs with the standard arrow, Home, and End keys", async () => {
+    const wrapper = mount(RepositoryPicker, { props: { open: false, store } });
+    await wrapper.setProps({ open: true });
+    await flushPromises();
+
+    await wrapper.get("#github-repositories-tab").trigger("keydown", { key: "End" });
+    expect(wrapper.get("#repository-url-tab").attributes("aria-selected")).toBe("true");
+    await wrapper.get("#repository-url-tab").trigger("keydown", { key: "Home" });
+    expect(wrapper.get("#github-repositories-tab").attributes("aria-selected")).toBe("true");
+  });
+
+  it("keeps the picker open and names a failed registration", async () => {
+    store = fakeStore({
+      async addRepo() { store.error = "GitHub API 403: repository unavailable"; },
+    });
+    const wrapper = mount(RepositoryPicker, { props: { open: false, store } });
+    await wrapper.setProps({ open: true });
+    await flushPromises();
+
+    await wrapper.findAll(".repository-list button")[1]!.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get(".github-action-error").text()).toContain("403");
+    expect(wrapper.emitted("close")).toBeUndefined();
+  });
+});

--- a/packages/app/src/renderer/src/components/RepositoryPicker.vue
+++ b/packages/app/src/renderer/src/components/RepositoryPicker.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import { Check, FolderGit2, LockKeyhole, Search as SearchIcon, X } from "lucide-vue-next";
+import type { GithubRepository } from "../api.js";
+import type { Store } from "../store.js";
+
+const props = defineProps<{ open: boolean; store: Store }>();
+const emit = defineEmits<{ close: [] }>();
+
+const dialog = ref<HTMLDialogElement | null>(null);
+const searchInput = ref<HTMLInputElement | null>(null);
+const urlInput = ref<HTMLInputElement | null>(null);
+const activeTab = ref<"github" | "url">("github");
+const query = ref("");
+const url = ref("");
+const actionError = ref<string | null>(null);
+
+const registeredIds = computed(() => new Set(props.store.repos.map((repo) => repo.repoId)));
+const filteredRepos = computed(() => {
+  const needle = query.value.trim().toLocaleLowerCase();
+  if (needle === "") return props.store.githubRepos;
+  return props.store.githubRepos.filter((repo) => repo.repoId.toLocaleLowerCase().includes(needle));
+});
+
+watch(() => props.open, async (open) => {
+  if (!open) {
+    if (dialog.value?.open) dialog.value.close();
+    return;
+  }
+  activeTab.value = "github";
+  query.value = "";
+  url.value = "";
+  actionError.value = null;
+  await nextTick();
+  dialog.value?.showModal();
+  await props.store.loadGithubRepos();
+  await nextTick();
+  searchInput.value?.focus();
+});
+
+function close(): void {
+  dialog.value?.close();
+}
+
+function onClosed(): void {
+  emit("close");
+}
+
+function onBackdropClick(event: MouseEvent): void {
+  if (event.target === dialog.value) close();
+}
+
+async function showTab(tab: "github" | "url"): Promise<void> {
+  activeTab.value = tab;
+  actionError.value = null;
+  await nextTick();
+  (tab === "github" ? searchInput.value : urlInput.value)?.focus();
+}
+
+async function choose(repo: GithubRepository): Promise<void> {
+  actionError.value = null;
+  if (registeredIds.value.has(repo.repoId)) await props.store.selectRepo(repo.repoId);
+  else await props.store.addRepo(repo.url);
+  if (props.store.error) {
+    actionError.value = props.store.error;
+    return;
+  }
+  close();
+}
+
+async function submitUrl(): Promise<void> {
+  const value = url.value.trim();
+  if (value === "") return;
+  actionError.value = null;
+  await props.store.addRepo(value);
+  if (props.store.error) {
+    actionError.value = props.store.error;
+    return;
+  }
+  close();
+}
+
+function repoName(repoId: string): string {
+  return repoId.split("/").pop() ?? repoId;
+}
+
+function repoOwner(repoId: string): string {
+  return repoId.split("/").slice(0, -1).join("/");
+}
+</script>
+
+<template>
+  <dialog ref="dialog" class="repository-picker" aria-labelledby="repository-picker-title" @close="onClosed" @click="onBackdropClick">
+    <header class="picker-header">
+      <div>
+        <h1 id="repository-picker-title">Add a repository</h1>
+        <p>Choose from GitHub, or enter a repository URL.</p>
+      </div>
+      <button class="icon-button" type="button" aria-label="Close repository picker" @click="close">
+        <X :size="17" aria-hidden="true" />
+      </button>
+    </header>
+
+    <div class="tabs" role="tablist" aria-label="Repository source">
+      <button
+        id="github-repositories-tab"
+        type="button"
+        role="tab"
+        :aria-selected="activeTab === 'github'"
+        :tabindex="activeTab === 'github' ? 0 : -1"
+        @click="showTab('github')"
+        @keydown.right.prevent="showTab('url')"
+        @keydown.end.prevent="showTab('url')"
+      >GitHub</button>
+      <button
+        id="repository-url-tab"
+        type="button"
+        role="tab"
+        :aria-selected="activeTab === 'url'"
+        :tabindex="activeTab === 'url' ? 0 : -1"
+        @click="showTab('url')"
+        @keydown.left.prevent="showTab('github')"
+        @keydown.home.prevent="showTab('github')"
+      >URL</button>
+    </div>
+
+    <section
+      v-if="activeTab === 'github'"
+      class="picker-body github-panel"
+      role="tabpanel"
+      aria-labelledby="github-repositories-tab"
+    >
+      <search class="repository-search">
+        <SearchIcon :size="15" aria-hidden="true" />
+        <label class="sr-only" for="repository-filter">Filter repositories</label>
+        <input
+          id="repository-filter"
+          ref="searchInput"
+          v-model="query"
+          type="search"
+          placeholder="Filter repositories…"
+        />
+      </search>
+
+      <p v-if="actionError" class="inline-error github-action-error" role="alert">{{ actionError }}</p>
+      <p v-if="store.githubReposBusy" class="picker-state"><span class="spinner" />Loading repositories…</p>
+      <div v-else-if="store.githubReposError" class="picker-error" role="alert">
+        <p>{{ store.githubReposError }}</p>
+        <button type="button" @click="store.loadGithubRepos()">Try again</button>
+      </div>
+      <p v-else-if="filteredRepos.length === 0" class="picker-state">
+        {{ query.trim() ? "No repositories match that filter." : "No active repositories are available to this GitHub account." }}
+      </p>
+      <ul v-else class="repository-list" aria-label="Available repositories">
+        <li v-for="repo in filteredRepos" :key="repo.repoId">
+          <button type="button" :disabled="store.busy" @click="choose(repo)">
+            <FolderGit2 :size="17" aria-hidden="true" />
+            <span class="repo-identity">
+              <span class="repo-name">{{ repoName(repo.repoId) }}</span>
+              <span class="repo-owner">{{ repoOwner(repo.repoId) }}</span>
+            </span>
+            <span v-if="repo.private" class="repo-private"><LockKeyhole :size="12" aria-hidden="true" />Private</span>
+            <span v-if="registeredIds.has(repo.repoId)" class="repo-added"><Check :size="13" aria-hidden="true" />Added</span>
+          </button>
+        </li>
+      </ul>
+    </section>
+
+    <section v-else class="picker-body url-panel" role="tabpanel" aria-labelledby="repository-url-tab">
+      <form @submit.prevent="submitUrl">
+        <label for="repository-url">GitHub repository URL</label>
+        <div class="url-row">
+          <input
+            id="repository-url"
+            ref="urlInput"
+            v-model="url"
+            type="url"
+            placeholder="https://github.com/owner/repo"
+            required
+          />
+          <button class="primary-button" type="submit" :disabled="store.busy || url.trim() === ''">
+            {{ store.busy ? "Adding…" : "Add repository" }}
+          </button>
+        </div>
+        <p class="url-help">Use this when a repository does not appear in your GitHub list.</p>
+      </form>
+      <p v-if="actionError" class="inline-error" role="alert">{{ actionError }}</p>
+    </section>
+  </dialog>
+</template>
+
+<style scoped>
+.repository-picker {
+  width: min(620px, calc(100vw - 48px));
+  max-height: min(620px, calc(100vh - 72px));
+  margin: auto;
+  padding: 0;
+  overflow: hidden;
+  color: var(--workbench-foreground);
+  background: var(--panel-background);
+  border: 1px solid var(--workbench-border);
+  border-radius: 12px;
+  box-shadow: 0 24px 70px var(--workbench-shadow);
+}
+.repository-picker::backdrop { background: var(--overlay-background); }
+.picker-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; padding: 20px 22px 16px; }
+.picker-header h1 { font-size: 18px; line-height: 1.3; font-weight: 650; }
+.picker-header p { margin-top: 3px; color: var(--muted-foreground); font-size: 12px; }
+.icon-button { display: grid; place-items: center; width: 30px; height: 30px; flex: none; color: var(--muted-foreground); background: none; border: 0; border-radius: 6px; cursor: pointer; }
+.icon-button:hover { color: var(--workbench-foreground); background: var(--hover-background); }
+.tabs { display: flex; gap: 18px; padding: 0 22px; border-bottom: 1px solid var(--workbench-border); }
+.tabs button { position: relative; padding: 8px 1px 10px; color: var(--muted-foreground); background: none; border: 0; font: inherit; cursor: pointer; }
+.tabs button[aria-selected="true"] { color: var(--workbench-foreground); }
+.tabs button[aria-selected="true"]::after { content: ""; position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; background: var(--accent); }
+.github-panel { display: flex; min-height: 0; max-height: min(488px, calc(100vh - 184px)); flex-direction: column; }
+.repository-search { display: flex; align-items: center; gap: 8px; margin: 14px 16px 8px; padding: 0 10px; color: var(--faint-foreground); background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 7px; }
+.repository-search:focus-within { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
+.repository-search input { width: 100%; height: 34px; color: var(--workbench-foreground); background: transparent; border: 0; outline: 0; font: inherit; }
+.repository-search input::placeholder, .url-row input::placeholder { color: var(--faint-foreground); }
+.repository-list { min-height: 0; margin: 0; padding: 4px 8px 12px; overflow-y: auto; list-style: none; }
+.repository-list button { display: flex; width: 100%; min-height: 44px; align-items: center; gap: 10px; padding: 7px 10px; color: var(--workbench-foreground); text-align: left; background: transparent; border: 0; border-radius: 7px; cursor: pointer; }
+.repository-list button:hover:not(:disabled), .repository-list button:focus-visible { background: var(--selection-background); }
+.repository-list button:disabled { cursor: wait; opacity: .65; }
+.repository-list svg { flex: none; color: var(--muted-foreground); }
+.repo-identity { display: flex; min-width: 0; flex: 1; flex-direction: column; line-height: 1.25; }
+.repo-name { overflow: hidden; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+.repo-owner { overflow: hidden; color: var(--faint-foreground); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.repo-private, .repo-added { display: inline-flex; align-items: center; gap: 4px; color: var(--faint-foreground); font-size: 10.5px; }
+.repo-added { color: var(--success); }
+.repo-added svg { color: currentColor; }
+.picker-state { display: flex; min-height: 150px; align-items: center; justify-content: center; gap: 8px; padding: 30px; color: var(--muted-foreground); text-align: center; }
+.spinner { width: 14px; height: 14px; border: 2px solid var(--workbench-border); border-top-color: var(--accent); border-radius: 50%; animation: spin .8s linear infinite; }
+.picker-error { margin: 18px; padding: 12px 14px; color: var(--danger); background: var(--danger-background); border-radius: 7px; }
+.picker-error button { margin-top: 8px; color: var(--workbench-foreground); background: none; border: 0; text-decoration: underline; text-underline-offset: 3px; cursor: pointer; }
+.url-panel { padding: 22px; }
+.url-panel label { display: block; margin-bottom: 7px; font-weight: 600; }
+.url-row { display: flex; gap: 8px; }
+.url-row input { min-width: 0; flex: 1; height: 36px; padding: 0 10px; color: var(--workbench-foreground); background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 7px; outline: 0; font: inherit; }
+.url-row input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
+.primary-button { min-width: 112px; padding: 0 14px; color: var(--accent-foreground); background: var(--accent); border: 0; border-radius: 7px; font: inherit; font-weight: 650; cursor: pointer; }
+.primary-button:disabled { cursor: default; opacity: .55; }
+.url-help { margin-top: 7px; color: var(--faint-foreground); font-size: 11.5px; }
+.inline-error { margin-top: 16px; color: var(--danger); }
+.github-action-error { margin: 4px 18px 6px; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
+</style>

--- a/packages/app/src/renderer/src/components/TopBar.vue
+++ b/packages/app/src/renderer/src/components/TopBar.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 import type { Store } from "../store.js";
 import { ChevronDown, FolderGit2, GitPullRequest, MessageSquare, Plus, RefreshCw, Settings } from "lucide-vue-next";
 import SwitcherDropdown from "./SwitcherDropdown.vue";
+import RepositoryPicker from "./RepositoryPicker.vue";
 
 const props = defineProps<{
   store: Store;
@@ -14,13 +15,11 @@ const emit = defineEmits<{ toggleQuestions: []; toggleSettings: [] }>();
 
 const repoOpen = ref(false);
 const reviewOpen = ref(false);
-const addingRepo = ref(false);
-const newRepoUrl = ref("");
+const repositoryPickerOpen = ref(false);
 
 function toggleRepo() {
   reviewOpen.value = false;
   repoOpen.value = !repoOpen.value;
-  if (!repoOpen.value) addingRepo.value = false;
 }
 
 function toggleReview() {
@@ -36,7 +35,6 @@ function toggleSettings(): void {
 function closeAll() {
   repoOpen.value = false;
   reviewOpen.value = false;
-  addingRepo.value = false;
 }
 
 async function pickRepo(repoId: string) {
@@ -44,12 +42,9 @@ async function pickRepo(repoId: string) {
   closeAll();
 }
 
-async function submitAddRepo() {
-  const url = newRepoUrl.value.trim();
-  if (!url) return;
-  await props.store.addRepo(url);
-  newRepoUrl.value = "";
-  addingRepo.value = false;
+function openRepositoryPicker(): void {
+  closeAll();
+  repositoryPickerOpen.value = true;
 }
 
 async function pickPr(prNumber: number) {
@@ -177,19 +172,15 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
       <span v-if="repoOwner(repo.repoId)" class="meta">{{ repoOwner(repo.repoId) }}</span>
     </div>
     <div
-      v-if="!addingRepo"
       class="sw-item"
       role="button"
       tabindex="0"
-      @click.stop="addingRepo = true"
-      @keydown.enter.space.prevent="addingRepo = true"
+      @click.stop="openRepositoryPicker"
+      @keydown.enter.space.prevent="openRepositoryPicker"
     >
       <Plus class="ic" :size="16" />
       <span class="nm add">Add repository…</span>
     </div>
-    <form v-else class="add-row" @submit.prevent="submitAddRepo">
-      <input v-model="newRepoUrl" placeholder="https://github.com/owner/repo" autofocus @click.stop />
-    </form>
   </SwitcherDropdown>
 
   <SwitcherDropdown :open="reviewOpen" :left="190 + titleBarInset" :width="460" @close="closeAll">
@@ -209,6 +200,8 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
       <span class="nm">{{ pr.title }}</span>
     </div>
   </SwitcherDropdown>
+
+  <RepositoryPicker :open="repositoryPickerOpen" :store="store" @close="repositoryPickerOpen = false" />
 
 </template>
 
@@ -277,7 +270,4 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
 .dot.draft { background: var(--warning); }
 .dot.open { background: var(--success); }
 
-.add-row { padding: 10px 12px; }
-.add-row input { width: 100%; background: var(--secondary-panel-background); border: 1px solid var(--workbench-border); border-radius: 7px; color: var(--workbench-foreground); font-size: 13px; padding: 7px 10px; outline: none; }
-.add-row input:focus { border-color: var(--accent); }
 </style>

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -22,6 +22,7 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
       worktreeLabel: null,
     },
     listRepos: async () => [{ repoId: "acme/atlas", url: "u" }],
+    listGithubRepos: async () => [{ repoId: "acme/atlas", url: "https://github.com/acme/atlas", private: true }],
     addRepo: async (url) => ({ repoId: "acme/new", url }),
     listPrs: async () => [{ number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" }],
     openPr: async () => prView(),
@@ -92,6 +93,23 @@ describe("store", () => {
     expect(store.progress()).toEqual({ done: 0, total: 2 });
     await store.setChecked("a.rb", true);
     expect(store.progress()).toEqual({ done: 1, total: 2 });
+  });
+
+  it("loads GitHub repositories separately from registered repositories", async () => {
+    const store = createStore(fakeApi());
+    await store.loadGithubRepos();
+    expect(store.githubRepos).toEqual([{ repoId: "acme/atlas", url: "https://github.com/acme/atlas", private: true }]);
+    expect(store.githubReposError).toBeNull();
+  });
+
+  it("registers and selects a repository in one action", async () => {
+    const store = createStore(fakeApi({
+      addRepo: async (url) => ({ repoId: "acme/new", url }),
+      listRepos: async () => [{ repoId: "acme/new", url: "https://github.com/acme/new" }],
+    }));
+    await store.addRepo("https://github.com/acme/new");
+    expect(store.currentRepoId).toBe("acme/new");
+    expect(store.prs).toHaveLength(1);
   });
 
   it("captures errors into store.error instead of throwing", async () => {

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -1,9 +1,12 @@
 import { reactive } from "vue";
 import type { OpenTarget, PrSummary, PrView, RepoEntry } from "@gander/shared";
-import type { GanderApi } from "./api.js";
+import type { GanderApi, GithubRepository } from "./api.js";
 
 export interface Store {
   repos: RepoEntry[];
+  githubRepos: GithubRepository[];
+  githubReposBusy: boolean;
+  githubReposError: string | null;
   prs: PrSummary[];
   currentRepoId: string | null;
   view: PrView | null;
@@ -16,6 +19,7 @@ export interface Store {
   /** True while a long-running main-process action (openPr, refresh, addRepo, selectRepo) is in flight. Not for setChecked/setCheckedMany — those are near-instant and shouldn't flicker a "busy" indicator. */
   busy: boolean;
   loadRepos(): Promise<void>;
+  loadGithubRepos(): Promise<void>;
   checkService(): Promise<void>;
   dismissError(): void;
   /** Reopen the pull request that was open when the app last closed. */
@@ -41,6 +45,9 @@ export interface Store {
 export function createStore(api: GanderApi): Store {
   const store: Store = reactive({
     repos: [],
+    githubRepos: [],
+    githubReposBusy: false,
+    githubReposError: null,
     prs: [],
     currentRepoId: null,
     view: null,
@@ -54,6 +61,17 @@ export function createStore(api: GanderApi): Store {
       await guard(async () => {
         store.repos = await api.listRepos();
       });
+    },
+    async loadGithubRepos() {
+      store.githubReposBusy = true;
+      store.githubReposError = null;
+      try {
+        store.githubRepos = await api.listGithubRepos();
+      } catch (err) {
+        store.githubReposError = (err as Error).message;
+      } finally {
+        store.githubReposBusy = false;
+      }
     },
     async checkService() {
       store.serviceReachable = await api.serviceHealthy();
@@ -75,8 +93,12 @@ export function createStore(api: GanderApi): Store {
     },
     async addRepo(url: string) {
       await userAction(() => withBusy(() => guard(async () => {
-        await api.addRepo(url);
+        const entry = await api.addRepo(url);
         store.repos = await api.listRepos();
+        store.prs = await api.listPrs(entry.repoId);
+        store.currentRepoId = entry.repoId;
+        store.view = null;
+        store.selectedPath = null;
       })));
     },
     async openTarget(target: OpenTarget) {


### PR DESCRIPTION
## What changed

- add a GitHub-backed repository picker with client-side filtering
- paginate through every repository visible to the authenticated account
- exclude archived repositories and identify private or already-added repositories
- keep URL entry as a fallback
- register and select a chosen repository in one action
- cover GitHub browsing and URL fallback through the Electron test harness

## Why

Registering a repository previously required leaving Gander to find and paste its full GitHub URL. The app already has a GitHub credential, so it can present the repositories that credential can access directly.

## Impact

Reviewers can add an active repository without leaving the app. The existing registered-repository switcher remains the fast path, and repositories outside the API result can still be entered by URL.

Closes #13.

## Validation

- `pnpm test` — 235 passing
- `pnpm typecheck`
- `pnpm test:e2e` — 7 passing
- interface design detector — no findings
- finish review — ship
