### PR TITLE
Enlarge question capture canvas

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -309,6 +309,9 @@ describe("Gander end to end", () => {
     await browser.keys("n");
     const question = await $("textarea[placeholder='What needs answering or changing here?']");
     await question.waitForDisplayed();
+    const questionSize = await question.getSize();
+    expect(questionSize.width).toBeGreaterThanOrEqual(900);
+    expect(questionSize.height).toBeGreaterThanOrEqual(350);
     await question.setValue("Why does this need to happen here?");
     await browser.keys("Enter");
     await $("button[aria-label='Questions']").click();

--- a/packages/app/src/renderer/src/components/QuestionCapture.test.ts
+++ b/packages/app/src/renderer/src/components/QuestionCapture.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { Store } from "../store.js";
+import QuestionCapture from "./QuestionCapture.vue";
+
+describe("QuestionCapture", () => {
+  it("opens as a substantial, described writing surface", () => {
+    const store = {
+      selectedPath: "src/review.ts",
+      addQuestion: vi.fn(),
+    } as unknown as Store;
+    const wrapper = mount(QuestionCapture, { props: { store, open: true } });
+
+    const question = wrapper.get("textarea");
+    expect(question.attributes("rows")).toBe("12");
+    expect(question.attributes("aria-describedby")).toBe("question-capture-hint");
+    expect(wrapper.get("label").attributes("for")).toBe(question.attributes("id"));
+
+    wrapper.unmount();
+  });
+});

--- a/packages/app/src/renderer/src/components/QuestionCapture.vue
+++ b/packages/app/src/renderer/src/components/QuestionCapture.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from "vue";
+import { nextTick, shallowRef, useTemplateRef, watch } from "vue";
 import type { Store } from "../store.js";
 import { currentLine } from "../selection.js";
 
 const props = defineProps<{ store: Store; open: boolean }>();
 const emit = defineEmits<{ close: [] }>();
 
-const text = ref("");
-const box = ref<HTMLTextAreaElement | null>(null);
+const text = shallowRef("");
+const box = useTemplateRef<HTMLTextAreaElement>("box");
 // Held at the moment the box opens: focusing the textarea takes the cursor out of the
 // editor, and the line the reader was on is the one the question is about.
-const capturedLine = ref<number | null>(null);
+const capturedLine = shallowRef<number | null>(null);
 
 watch(() => props.open, async (open) => {
   if (!open) return;
@@ -33,21 +33,24 @@ async function submit(): Promise<void> {
 <template>
   <div v-if="open" class="capture" @click.self="$emit('close')">
     <form class="panel" @submit.prevent="submit">
-      <label>
+      <label class="context" for="question-capture">
         Question on
         <b>{{ store.selectedPath ?? "this pull request" }}</b>
         <template v-if="capturedLine !== null"> · line {{ capturedLine }}</template>
       </label>
       <!-- Enter submits, Shift+Enter breaks the line: capture must cost one keystroke. -->
       <textarea
+        id="question-capture"
         ref="box"
         v-model="text"
-        rows="3"
+        class="question"
+        rows="12"
+        aria-describedby="question-capture-hint"
         placeholder="What needs answering or changing here?"
         @keydown.enter.exact.prevent="submit"
         @keydown.esc.prevent="$emit('close')"
       />
-      <div class="hint">
+      <div id="question-capture-hint" class="hint">
         <kbd>Enter</kbd> to save · <kbd>Shift</kbd>+<kbd>Enter</kbd> for a new line · <kbd>Esc</kbd> to cancel
       </div>
     </form>
@@ -55,12 +58,13 @@ async function submit(): Promise<void> {
 </template>
 
 <style scoped>
-.capture { position: fixed; inset: 0; background: var(--overlay-background); display: flex; align-items: flex-start; justify-content: center; padding-top: 14vh; z-index: 50; }
-.panel { width: min(620px, 90vw); background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: 10px; padding: 14px; display: flex; flex-direction: column; gap: 10px; box-shadow: 0 18px 50px var(--workbench-shadow); }
-label { font-size: 12px; color: var(--faint-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-label b { color: var(--workbench-foreground); font-weight: 600; }
-textarea { background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 7px; color: var(--workbench-foreground); font: inherit; font-size: 13px; padding: 9px 11px; resize: vertical; }
-textarea:focus { outline: none; border-color: var(--accent); }
+.capture { position: fixed; inset: 0; background: var(--overlay-background); display: flex; align-items: center; justify-content: center; padding: clamp(16px, 8vh, 72px) clamp(16px, 5vw, 72px); z-index: 50; }
+.panel { width: min(960px, 100%); max-height: 100%; background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: 10px; padding: 20px; display: flex; flex-direction: column; gap: 14px; box-shadow: 0 18px 50px var(--workbench-shadow); }
+.context { font-size: 13px; color: var(--faint-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.context b { color: var(--workbench-foreground); font-weight: 600; }
+.question { width: 100%; height: clamp(180px, 42vh, 420px); min-height: 120px; max-height: calc(100vh - 160px); background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 7px; color: var(--workbench-foreground); caret-color: var(--accent); font: inherit; font-size: 14px; line-height: 1.6; padding: 14px 16px; resize: vertical; }
+.question::selection { background: var(--selection-background); }
+.question:focus { outline: 2px solid var(--focus-ring); outline-offset: 1px; border-color: var(--accent); }
 .hint { font-size: 11px; color: var(--faint-foreground); }
 kbd { font: 10.5px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: 4px; padding: 1px 5px; }
 </style>


### PR DESCRIPTION
## What changed

- Expand question capture from a compact prompt into a responsive 12-row writing canvas.
- Preserve manual vertical resizing while bounding the panel for narrow and short windows.
- Improve the textarea's focus treatment and accessible label/help associations.
- Add unit and Electron E2E regression coverage for the larger default surface.

## Why

Question capture is a primary Gander review workflow, but the previous 620px, three-row input presented it like a small transient prompt. The larger canvas gives review notes appropriate space without changing the existing one-keystroke save flow.

## Validation

- `pnpm test` — 242 tests passed.
- `pnpm typecheck` — passed across all packages.
- `git diff --check` — passed.
- Impeccable layout detector — no findings.

The Electron E2E assertion was added, but the local E2E suite could not complete because Electron repeatedly failed to create a WebDriver session (`chrome not reachable`). The retry loop was stopped and left no processes from this worktree running.
