### PR TITLE
Add hosted development app mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ in code, comments, commits, or issues.
 |------|---------|
 | First run after a clone | `bin/setup` |
 | Start service + app | `bin/dev` (`-D` headless, `stop`, `status`, `logs service`) |
+| Start app against hosted service | `bin/dev --hosted` (add `-D` for headless) |
 | Unit tests | `pnpm test` |
 | One test file | `pnpm vitest run packages/service/src/storage.test.ts` |
 | One test by name | `pnpm vitest run -t "un-check retains the snapshot"` |

--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -1,7 +1,8 @@
 # Gander dev stack
 
 Two processes — the review service and the Electron app — supervised by
-process-compose, with ports allocated by outport.
+process-compose, with ports allocated by outport. Hosted mode runs only the app
+while preserving the checkout's process and config isolation.
 
 ## Commands
 
@@ -10,6 +11,7 @@ process-compose, with ports allocated by outport.
 | First run after a clone | `bin/setup` |
 | Start (TUI) | `bin/dev` |
 | Start (headless, for agents) | `bin/dev -D` |
+| Start app against hosted service | `bin/dev --hosted` (add `-D` for headless) |
 | Stop | `bin/dev stop` |
 | Status | `bin/dev status` (add `--json` for machine-readable) |
 | Logs | `bin/dev logs service` |
@@ -57,6 +59,37 @@ checkout.
 
 `service` is probed with `curl -sf $GANDER_SERVICE_URL/healthz`. `app` is set to
 `restart: "no"` — closing the Electron window is a quit, not a crash.
+
+## Reviewing against a hosted service
+
+Use the checkout-local service while developing service behavior. When this
+checkout is being used to review other work, start only its Electron app:
+
+```bash
+bin/dev --hosted
+```
+
+On the first hosted run, open **Settings → Connection**, enter the hosted URL
+and token, then test and save the connection. Gander stores them in this
+worktree's gitignored `.gander/config.json`; saving applies owner-only
+permissions. Keep the token out of shell history and committed files. Future
+hosted runs reuse the saved connection. `bin/dev --hosted -D` provides the same
+mode without the process-compose TUI.
+
+The mode is deliberately config-driven. `bin/dev --hosted` loads `.pc_env` only
+for this worktree's process-compose and app sockets, removes
+`GANDER_SERVICE_URL` and `GANDER_TOKEN` from the child environment, disables
+process-compose's `.env` loading, and starts `app` without its `service`
+dependency. The existing connection-time resolver therefore uses
+`.gander/config.json`. Caller-exported service values do not override it.
+
+Ordinary `bin/dev` is unchanged: it starts both processes and the generated
+values in `.pc_env` override the saved connection at connection time. This
+keeps local development, worktrees, and test fixtures isolated. `bin/dev stop`,
+`status`, and `bin/gander` continue to use the same per-worktree sockets in
+either mode. `bin/mcp` remains a tool for the checkout-local service; register
+agents directly against the hosted MCP endpoint as described in
+`docs/deploy.md`.
 
 ## Where state lives
 
@@ -183,6 +216,8 @@ re-reviewing the file in the app.
 
 ## Config precedence
 
-`GANDER_SERVICE_URL` and `GANDER_TOKEN` from `.env` override the URL and token in
-`.gander/config.json`. The override is applied at connection time, not at load
-time, so registering a repo cannot write an allocated port back into the file.
+For ordinary `bin/dev`, `GANDER_SERVICE_URL` and `GANDER_TOKEN` generated in
+`.pc_env` override the URL and token in `.gander/config.json`. The override is
+applied at connection time, not at load time, so registering a repo cannot
+write an allocated port back into the file. Hosted mode deliberately removes
+both variables so the saved connection wins as a complete URL-and-token pair.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ bin/dev
 
 `bin/setup` installs dependencies, allocates a port, and generates a local
 service token. `bin/dev` starts the review service and the app together.
+`bin/dev --hosted` starts only the app and uses the hosted connection saved in
+this checkout's settings; see `DEVSTACK.md` for the setup and precedence rules.
 
 Reviewing a pull request needs a GitHub token — `gh auth login` is enough.
 

--- a/bin/dev
+++ b/bin/dev
@@ -9,12 +9,11 @@ main() {
   load_worktree_env
 
   case "${1:-}" in
-    -D)        shift; process-compose up --config "$SCRIPT_ROOT/process-compose.yml" -D "$@" ;;
     stop)      process-compose down ;;
     status)    show_status "${2:-}" ;;
     logs)      process-compose process logs "${2:?specify a service}" ;;
     restart)   process-compose process restart "${2:?specify a service}" ;;
-    *)         process-compose up --config "$SCRIPT_ROOT/process-compose.yml" "$@" ;;
+    *)         start_dev "$@" ;;
   esac
 }
 
@@ -36,6 +35,32 @@ load_worktree_env() {
   set +a
 
   [[ -n "${PC_SOCKET_PATH:-}" ]] || fail "PC_SOCKET_PATH is missing from $PC_ENV_FILE. Run bin/setup first."
+}
+
+start_dev() {
+  local hosted=false
+  local arg
+  local -a process_args=()
+
+  for arg in "$@"; do
+    if [[ "$arg" == "--hosted" ]]; then
+      hosted=true
+    else
+      process_args+=("$arg")
+    fi
+  done
+
+  if [[ "$hosted" == false ]]; then
+    process-compose up --config "$SCRIPT_ROOT/process-compose.yml" "${process_args[@]}"
+    return
+  fi
+
+  # Hosted mode deliberately makes the repo-local config the connection source.
+  # Remove both inherited and generated values, then prevent process-compose from
+  # reading .env back in. The socket and config path remain scoped to this worktree.
+  unset GANDER_SERVICE_URL GANDER_TOKEN
+  process-compose up --config "$SCRIPT_ROOT/process-compose.yml" \
+    --disable-dotenv --no-deps "${process_args[@]}" app
 }
 
 show_status() {

--- a/bin/dev.test.ts
+++ b/bin/dev.test.ts
@@ -44,6 +44,9 @@ beforeEach(() => {
 
   writeFileSync(join(repo, ".pc_env"), [
     "GANDER_PORT=4321",
+    "GANDER_SERVICE_URL=http://127.0.0.1:4321",
+    "GANDER_TOKEN=checkout-token",
+    "GANDER_APP_SOCKET=/tmp/gander-app-gander-test.sock",
     "PC_SOCKET_PATH=/tmp/process-compose-gander-test.sock",
     "",
   ].join("\n"));
@@ -51,8 +54,9 @@ beforeEach(() => {
   writeExecutable(join(fakeBin, "process-compose"), `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$@" > "$DEV_TEST_ARGS_FILE"
-printf 'GANDER_PORT=%s\nPC_SOCKET_PATH=%s\n' \
-  "\${GANDER_PORT:-}" "\${PC_SOCKET_PATH:-}" > "$DEV_TEST_ENV_FILE"
+printf 'GANDER_PORT=%s\nGANDER_SERVICE_URL=%s\nGANDER_TOKEN=%s\nGANDER_APP_SOCKET=%s\nPC_SOCKET_PATH=%s\n' \
+  "\${GANDER_PORT:-}" "\${GANDER_SERVICE_URL:-}" "\${GANDER_TOKEN:-}" \
+  "\${GANDER_APP_SOCKET:-}" "\${PC_SOCKET_PATH:-}" > "$DEV_TEST_ENV_FILE"
 
 case "\${DEV_TEST_MODE:-success}" in
   success)
@@ -98,6 +102,52 @@ describe.skipIf(platform === "win32")("bin/dev", () => {
     ].join("\n"));
   });
 
+  it("starts only the app against the hosted connection saved in the worktree config", () => {
+    env = {
+      ...env,
+      GANDER_SERVICE_URL: "https://caller.example.test",
+      GANDER_TOKEN: "caller-token",
+    };
+
+    const result = run("--hosted", "-D");
+
+    expect(result.status, result.output).toBe(0);
+    expect(readFileSync(argsFile, "utf8")).toBe([
+      "up",
+      "--config",
+      join(realpathSync(repo), "process-compose.yml"),
+      "--disable-dotenv",
+      "--no-deps",
+      "-D",
+      "app",
+      "",
+    ].join("\n"));
+    expect(readFileSync(envFile, "utf8")).toBe([
+      "GANDER_PORT=4321",
+      "GANDER_SERVICE_URL=",
+      "GANDER_TOKEN=",
+      "GANDER_APP_SOCKET=/tmp/gander-app-gander-test.sock",
+      "PC_SOCKET_PATH=/tmp/process-compose-gander-test.sock",
+      "",
+    ].join("\n"));
+  });
+
+  it("keeps ordinary startup on the generated worktree service connection", () => {
+    env = {
+      ...env,
+      GANDER_SERVICE_URL: "https://caller.example.test",
+      GANDER_TOKEN: "caller-token",
+    };
+
+    const result = run("-D");
+
+    expect(result.status, result.output).toBe(0);
+    expect(readFileSync(envFile, "utf8")).toContain([
+      "GANDER_SERVICE_URL=http://127.0.0.1:4321",
+      "GANDER_TOKEN=checkout-token",
+    ].join("\n"));
+  });
+
   it("loads the worktree environment and returns JSON status", () => {
     const result = run("status", "--json");
 
@@ -106,6 +156,9 @@ describe.skipIf(platform === "win32")("bin/dev", () => {
     expect(readFileSync(argsFile, "utf8")).toBe("process\nlist\n--output\njson\n");
     expect(readFileSync(envFile, "utf8")).toBe([
       "GANDER_PORT=4321",
+      "GANDER_SERVICE_URL=http://127.0.0.1:4321",
+      "GANDER_TOKEN=checkout-token",
+      "GANDER_APP_SOCKET=/tmp/gander-app-gander-test.sock",
       "PC_SOCKET_PATH=/tmp/process-compose-gander-test.sock",
       "",
     ].join("\n"));

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -53,14 +53,15 @@ the dedicated MCP reply tool.
 Each opened pull request records its own branch, which is how the service maps an
 agent's working branch to a pull request without holding GitHub credentials.
 
+A development checkout can run only its Electron app against the hosted service
+with `bin/dev --hosted`; ordinary `bin/dev` keeps its isolated local service for
+development.
+
 ## Still open
 
 - Local branch/worktree viewer (stateless, no review state)
 - Packaging: signing, notarization, and the Homebrew cask. Gander runs only from
   a development checkout.
-- The service still runs as a local development process. The design puts it on
-  one host on the network, which is what makes a review readable from any
-  machine and reachable by agents with no GUI running.
 
 Interface work and the agent reply channel are tracked as GitHub issues.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -39,13 +39,22 @@ To update: `git pull && docker compose up -d --build`.
 
 ## Point the app at it
 
-The app reads `GANDER_SERVICE_URL` and `GANDER_TOKEN` from the environment,
-falling back to `serviceUrl` and `serviceToken` in its config file. Either works;
-the environment wins.
+In the installed app, open **Settings → Connection**, enter the hosted URL and
+token, then test and save the connection.
+
+From a development checkout, use the checkout-local settings and start the app
+without its local service:
 
 ```bash
-GANDER_SERVICE_URL=https://gander.example.internal GANDER_TOKEN=… bin/dev
+bin/dev --hosted
 ```
+
+On the first run, enter and save the same connection under **Settings →
+Connection**. It is stored in the gitignored `.gander/config.json` with
+owner-only permissions. Hosted mode does not accept the URL or token on its
+command line or from exported variables, which keeps the pair out of shell
+history and makes their source unambiguous. Ordinary `bin/dev` continues to
+override the saved connection with its generated checkout-local values.
 
 ## Point an agent at it
 


### PR DESCRIPTION
## Summary

- add `bin/dev --hosted` to run the development Electron app without its checkout-local service
- make the hosted connection source explicit by removing service environment overrides, disabling dotenv loading, and retaining per-worktree config and sockets
- document the credential-safe operator workflow and precedence rules
- cover hosted and ordinary startup behavior with launcher regression tests

## Readiness

- simplify: clean
- code review: clean, with no critical findings
- finalize: typecheck, tests, shell syntax, ShellCheck, and process-compose validation pass
- adversarial review: skipped; secret handling and worktree isolation were reviewed in the normal code-review gate

## Test plan

- `pnpm vitest run bin/dev.test.ts packages/app/src/main/config.test.ts`
- `bash -n bin/dev`
- `shellcheck bin/dev`
- `bin/dev --hosted --dry-run`
- `pnpm typecheck`
- `pnpm test`

Closes #45
