### PR TITLE
Show stacked pull requests together

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -250,7 +250,17 @@ describe("Gander end to end", () => {
 
   it("registers a repository and keeps a reviewed file checked after restart", async () => {
     await registerAndSelect(requiredEnv("GANDER_E2E_PERSISTENCE_URL"), "persistence");
-    await openPullRequest("Persist reviewed files");
+    await $(".seg-review").click();
+    await expect($(".stack-group")).toBeDisplayed();
+    expect(await browser.execute(() => [...document.querySelectorAll(".stack-group .stack-member")]
+      .map((member) => member.textContent?.replace(/\s+/g, " ").trim()))).toEqual([
+        "1/2 #2 Prepare review state",
+        "2/2 #1 Persist reviewed files",
+      ]);
+    await expect($(".standalone-item")).toHaveText(expect.stringContaining("Independent cleanup"));
+    await $(`//div[@role='option'][contains(normalize-space(.), 'Persist reviewed files')]`).click();
+    await expect($(".header-stack-position")).toHaveText("2/2");
+    await expect($(".header-stack-position")).toHaveAttribute("aria-label", "Stack position 2 of 2");
 
     const fileTreeTypography = async () => browser.execute(() => {
       const tree = document.querySelector<HTMLElement>(".tree.root");

--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -253,9 +253,13 @@ describe("Gander end to end", () => {
     await $(".seg-review").click();
     await expect($(".stack-group")).toBeDisplayed();
     expect(await browser.execute(() => [...document.querySelectorAll(".stack-group .stack-member")]
-      .map((member) => member.textContent?.replace(/\s+/g, " ").trim()))).toEqual([
-        "1/2 #2 Prepare review state",
-        "2/2 #1 Persist reviewed files",
+      .map((member) => ({
+        position: member.querySelector(".member-stack-position")?.textContent,
+        number: member.querySelector(".num")?.textContent,
+        title: member.querySelector(".nm")?.textContent,
+      })))).toEqual([
+        { position: "1/2", number: "#2", title: "Prepare review state" },
+        { position: "2/2", number: "#1", title: "Persist reviewed files" },
       ]);
     await expect($(".standalone-item")).toHaveText(expect.stringContaining("Independent cleanup"));
     await $(`//div[@role='option'][contains(normalize-space(.), 'Persist reviewed files')]`).click();

--- a/packages/app/e2e/run.ts
+++ b/packages/app/e2e/run.ts
@@ -118,14 +118,32 @@ async function main(): Promise<void> {
         }
       }
 
-      return [{
+      const pullRequest = {
         number: 1,
         title: fixture.title,
         body: "End-to-end fixture",
         draft: false,
         base: { ref: "main", sha: fixture.baseSha },
         head: { ref: "feature", sha: fixture.headSha },
-      }];
+      };
+      if (fixture !== persistence) return [pullRequest];
+
+      return [
+        { ...pullRequest, stack: { id: 7, size: 2, position: 2 } },
+        {
+          ...pullRequest,
+          number: 3,
+          title: "Independent cleanup",
+          head: { ref: "cleanup", sha: fixture.headSha },
+        },
+        {
+          ...pullRequest,
+          number: 2,
+          title: "Prepare review state",
+          head: { ref: "review-state", sha: fixture.headSha },
+          stack: { id: 7, size: 2, position: 1 },
+        },
+      ];
     },
   );
 

--- a/packages/app/src/renderer/src/components/ReviewingList.vue
+++ b/packages/app/src/renderer/src/components/ReviewingList.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { PrSummary } from "@gander/shared";
+import { Layers3 } from "lucide-vue-next";
+import StackPosition from "./StackPosition.vue";
+
+const props = defineProps<{ prs: PrSummary[] }>();
+const emit = defineEmits<{ select: [prNumber: number] }>();
+
+type ReviewGroup =
+  | { kind: "standalone"; pr: PrSummary }
+  | { kind: "stack"; id: number; size: number; prs: PrSummary[] };
+
+const groups = computed<ReviewGroup[]>(() => {
+  const seenStacks = new Set<number>();
+  const result: ReviewGroup[] = [];
+
+  for (const pr of props.prs) {
+    if (pr.stack === null) {
+      result.push({ kind: "standalone", pr });
+      continue;
+    }
+    if (seenStacks.has(pr.stack.id)) continue;
+
+    seenStacks.add(pr.stack.id);
+    result.push({
+      kind: "stack",
+      id: pr.stack.id,
+      size: pr.stack.size,
+      prs: props.prs
+        .filter((candidate) => candidate.stack?.id === pr.stack?.id)
+        .sort((left, right) => (left.stack?.position ?? 0) - (right.stack?.position ?? 0)),
+    });
+  }
+
+  return result;
+});
+
+function select(prNumber: number): void {
+  emit("select", prNumber);
+}
+</script>
+
+<template>
+  <div class="reviewing-list" role="listbox" aria-label="Open pull requests">
+    <template v-for="group in groups" :key="group.kind === 'stack' ? `stack-${group.id}` : `pr-${group.pr.number}`">
+      <div
+        v-if="group.kind === 'stack'"
+        class="stack-group"
+        role="group"
+        :aria-label="`Stack of ${group.size} pull requests`"
+      >
+        <div class="stack-heading" aria-hidden="true">
+          <Layers3 :size="13" />
+          <span>Stack</span>
+          <span class="stack-size">{{ group.size }} pull requests</span>
+        </div>
+        <div
+          v-for="pr in group.prs"
+          :key="pr.number"
+          class="sw-item stack-member"
+          role="option"
+          tabindex="0"
+          @click="select(pr.number)"
+          @keydown.enter.space.prevent="select(pr.number)"
+        >
+          <StackPosition
+            v-if="pr.stack"
+            class="member-stack-position"
+            :position="pr.stack.position"
+            :size="pr.stack.size"
+          />
+          <span class="dot" :class="pr.draft ? 'draft' : 'open'" />
+          <span class="num">#{{ pr.number }}</span>
+          <span class="nm">{{ pr.title }}</span>
+        </div>
+      </div>
+      <div
+        v-else
+        class="sw-item standalone-item"
+        role="option"
+        tabindex="0"
+        @click="select(group.pr.number)"
+        @keydown.enter.space.prevent="select(group.pr.number)"
+      >
+        <span class="dot" :class="group.pr.draft ? 'draft' : 'open'" />
+        <span class="num">#{{ group.pr.number }}</span>
+        <span class="nm">{{ group.pr.title }}</span>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.stack-group {
+  margin: 5px 8px;
+  padding: 4px 0;
+  border: 1px solid var(--workbench-border);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--badge-background) 45%, transparent);
+}
+.stack-heading {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 10px 5px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+}
+.stack-size {
+  margin-left: auto;
+  color: var(--faint-foreground);
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.sw-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+.stack-group .sw-item { padding-inline: 10px; }
+.sw-item:hover { background: var(--selection-background); }
+.sw-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.sw-item .num { font: 12px var(--mono); color: var(--muted-foreground); }
+.sw-item .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.member-stack-position { width: 35px; }
+.dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+.dot.draft { background: var(--warning); }
+.dot.open { background: var(--success); }
+</style>

--- a/packages/app/src/renderer/src/components/StackPosition.vue
+++ b/packages/app/src/renderer/src/components/StackPosition.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { Layers3 } from "lucide-vue-next";
+
+const props = defineProps<{ position: number; size: number }>();
+</script>
+
+<template>
+  <span class="stack-position" role="img" :aria-label="`Stack position ${props.position} of ${props.size}`">
+    <Layers3 :size="13" aria-hidden="true" />
+    <span aria-hidden="true">{{ props.position }}/{{ props.size }}</span>
+  </span>
+</template>
+
+<style scoped>
+.stack-position {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex: none;
+  color: var(--muted-foreground);
+  font: 11px var(--mono);
+  white-space: nowrap;
+}
+</style>

--- a/packages/app/src/renderer/src/components/TopBar.test.ts
+++ b/packages/app/src/renderer/src/components/TopBar.test.ts
@@ -1,20 +1,40 @@
 // @vitest-environment jsdom
 
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { PrSummary } from "@gander/shared";
 import type { Store } from "../store.js";
 import TopBar from "./TopBar.vue";
 
-function storeWithProgress(done: number, total: number): Store {
+function pr(number: number, title: string, stack: PrSummary["stack"] = null): PrSummary {
+  return {
+    number,
+    title,
+    body: "",
+    draft: false,
+    baseRef: "main",
+    headRef: `feature-${number}`,
+    baseSha: "base",
+    headSha: `head-${number}`,
+    stack,
+  };
+}
+
+function storeWithProgress(done: number, total: number, options: {
+  prs?: PrSummary[];
+  currentPr?: PrSummary;
+  openPr?: Store["openPr"];
+} = {}): Store {
   return {
     repos: [],
     githubRepos: [],
     githubReposBusy: false,
     githubReposError: null,
-    prs: [],
+    prs: options.prs ?? [],
     currentRepoId: null,
-    view: null,
+    view: options.currentPr ? { pr: options.currentPr, files: [], questions: [] } : null,
     busy: false,
+    openPr: options.openPr ?? vi.fn(),
     progress: () => ({ done, total }),
   } as unknown as Store;
 }
@@ -38,6 +58,77 @@ describe("TopBar", () => {
     expect(progress.text()).toBe(`${done}/${total} reviewed`);
     expect(progress.classes()).toContain(state);
     expect(progress.find("b").exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("shows the current pull request's GitHub stack position beside its number", () => {
+    const currentPr = pr(22, "Add the renderer", { id: 7, size: 3, position: 2 });
+    const wrapper = mount(TopBar, {
+      props: {
+        store: storeWithProgress(0, 0, { currentPr }),
+        questions: 0,
+        settingsActive: false,
+        integratedTitleBar: false,
+      },
+    });
+
+    expect(wrapper.get(".chip").text()).toBe("#22");
+    expect(wrapper.get(".header-stack-position").text()).toContain("2/3");
+    expect(wrapper.get(".header-stack-position").attributes("aria-label")).toBe("Stack position 2 of 3");
+
+    wrapper.unmount();
+  });
+
+  it("leaves a standalone pull request header unchanged", () => {
+    const wrapper = mount(TopBar, {
+      props: {
+        store: storeWithProgress(0, 0, { currentPr: pr(30, "Independent change") }),
+        questions: 0,
+        settingsActive: false,
+        integratedTitleBar: false,
+      },
+    });
+
+    expect(wrapper.get(".chip").text()).toBe("#30");
+    expect(wrapper.find(".header-stack-position").exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("groups stack members in position order while keeping standalone pull requests independent", async () => {
+    const openPr = vi.fn<Store["openPr"]>().mockResolvedValue(undefined);
+    const stack = { id: 7, size: 2 };
+    const wrapper = mount(TopBar, {
+      props: {
+        store: storeWithProgress(0, 0, {
+          prs: [
+            pr(22, "Add the renderer", { ...stack, position: 2 }),
+            pr(30, "Independent change"),
+            pr(21, "Add the service", { ...stack, position: 1 }),
+          ],
+          openPr,
+        }),
+        questions: 0,
+        settingsActive: false,
+        integratedTitleBar: false,
+      },
+      global: { stubs: { Teleport: true } },
+    });
+
+    await wrapper.get(".seg-review").trigger("click");
+
+    expect(wrapper.findAll(".stack-group")).toHaveLength(1);
+    expect(wrapper.findAll(".stack-group .sw-item").map((item) => item.text())).toEqual([
+      "1/2#21Add the service",
+      "2/2#22Add the renderer",
+    ]);
+    expect(wrapper.findAll(".standalone-item").map((item) => item.text())).toEqual([
+      "#30Independent change",
+    ]);
+
+    await wrapper.findAll(".stack-group .sw-item")[1]!.trigger("keydown", { key: "Enter" });
+    expect(openPr).toHaveBeenCalledWith(22);
 
     wrapper.unmount();
   });

--- a/packages/app/src/renderer/src/components/TopBar.vue
+++ b/packages/app/src/renderer/src/components/TopBar.vue
@@ -4,6 +4,8 @@ import type { Store } from "../store.js";
 import { ChevronDown, FolderGit2, GitPullRequest, MessageSquare, Plus, RefreshCw, Settings } from "lucide-vue-next";
 import SwitcherDropdown from "./SwitcherDropdown.vue";
 import RepositoryPicker from "./RepositoryPicker.vue";
+import ReviewingList from "./ReviewingList.vue";
+import StackPosition from "./StackPosition.vue";
 
 const props = defineProps<{
   store: Store;
@@ -117,6 +119,12 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
         <span class="val">
           <template v-if="currentPr">
             <span class="chip" :class="{ draft: currentPr.draft }">{{ currentPr.draft ? "Draft " : "" }}#{{ currentPr.number }}</span>
+            <StackPosition
+              v-if="currentPr.stack"
+              class="header-stack-position"
+              :position="currentPr.stack.position"
+              :size="currentPr.stack.size"
+            />
             {{ currentPr.title }}
           </template>
           <template v-else>Select a pull request</template>
@@ -200,19 +208,7 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
   <SwitcherDropdown :open="reviewOpen" :left="190 + titleBarInset" :width="460" @close="closeAll">
     <div class="sw-h">OPEN PULL REQUESTS</div>
     <div v-if="store.prs.length === 0" class="sw-empty">No open pull requests</div>
-    <div
-      v-for="pr in store.prs"
-      :key="pr.number"
-      class="sw-item"
-      role="option"
-      tabindex="0"
-      @click="pickPr(pr.number)"
-      @keydown.enter.space.prevent="pickPr(pr.number)"
-    >
-      <span class="dot" :class="pr.draft ? 'draft' : 'open'" />
-      <span class="num">#{{ pr.number }}</span>
-      <span class="nm">{{ pr.title }}</span>
-    </div>
+    <ReviewingList v-else :prs="store.prs" @select="pickPr" />
   </SwitcherDropdown>
 
   <RepositoryPicker :open="repositoryPickerOpen" :store="store" @close="repositoryPickerOpen = false" />
@@ -290,9 +286,5 @@ const titleBarInset = computed(() => props.integratedTitleBar ? TITLE_BAR_INSET 
 .sw-item .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sw-item .nm.add { color: var(--accent); }
 .sw-item .meta { margin-left: auto; font: 11px var(--mono); color: var(--faint-foreground); }
-
-.dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
-.dot.draft { background: var(--warning); }
-.dot.open { background: var(--success); }
 
 </style>


### PR DESCRIPTION
## Summary

- group pull requests by GitHub's native stack identity and order members by their reported position
- show an accessible stack icon and layer position in the Reviewing dropdown and current review header
- preserve standalone pull request presentation and keyboard selection behavior
- cover grouped, ordered, standalone, header, and Electron fixture behavior

## Readiness

- Simplify: clean
- Code review: clean, with no unresolved findings
- UI audit and polish: clean; the Impeccable detector reported no issues
- Adversarial review: skipped (low-risk renderer-only change)
- Shared E2E harness fix `0ea8723` integrated from master

## Test plan

- `pnpm typecheck` — passed after integration
- `pnpm test` — passed, 258 tests
- `pnpm test:e2e` — passed, all 9 Electron scenarios

Closes #14
