### PR TITLE
Improve the Questions drawer with collapsible threads

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -333,8 +333,30 @@ describe("Gander end to end", () => {
     await anchoredQuestion.setValue("Keep this on the first line.");
     await browser.keys("Enter");
     await $("button[aria-label='Questions']").click();
-    await expect($(".message.original .text")).toHaveText("Keep this on the first line.");
-    await expect($(".row .file")).toHaveText(`a.rb:${anchoredLine}`);
+    const firstThread = await $(".drawer [data-question-id]:first-child");
+    await expect(firstThread.$(".question-message .message-text")).toHaveText("Keep this on the first line.");
+    await expect(firstThread.$("button[data-question-location]")).toHaveText(`a.rb:${anchoredLine}`);
+    const copyThread = await firstThread.$("button[aria-label^='Copy question']");
+    await copyThread.click();
+    await expect(copyThread).toHaveText("Copied");
+    const firstDisclosure = await firstThread.$("button[aria-expanded='true']");
+    await firstDisclosure.click();
+    await expect(firstDisclosure).toHaveAttribute("aria-expanded", "false");
+    await expect(firstThread.$("[data-question-body]")).not.toBeDisplayed();
+    await expect(firstThread.$(".preview")).toHaveText("Keep this on the first line.");
+    await firstDisclosure.click();
+    await expect(firstThread.$("[data-question-body]")).toBeDisplayed();
+
+    await $("button[aria-label='Dock questions below the diff']").click();
+    await expect($(".workspace.bottom .drawer")).toBeDisplayed();
+    expect(await browser.execute(() => {
+      const workspace = document.querySelector<HTMLElement>(".workspace.bottom");
+      const drawer = workspace?.querySelector<HTMLElement>(".drawer");
+      if (!workspace || !drawer) return null;
+      return Math.abs(workspace.getBoundingClientRect().width - drawer.getBoundingClientRect().width);
+    })).toBeLessThan(2);
+    await $("button[aria-label='Dock questions beside the diff']").click();
+    await expect($(".workspace.right .drawer")).toBeDisplayed();
     await expect($(".drawer button[aria-label='Add question (N)']")).toBeDisplayed();
     await $("button[aria-label='Close questions']").click();
 
@@ -347,13 +369,13 @@ describe("Gander end to end", () => {
     await question.setValue("Why does this need to happen here?");
     await browser.keys("Enter");
     await $("button[aria-label='Questions']").click();
-    await expect($(".drawer li:last-child .message.original .text")).toHaveText("Why does this need to happen here?");
+    await expect($(".drawer [data-question-id]:last-child .question-message .message-text")).toHaveText("Why does this need to happen here?");
 
-    const reply = await $(".drawer li:last-child .reply-form input");
+    const reply = await $(".drawer [data-question-id]:last-child .reply-form input");
     await reply.setValue("Because both callers share this path.");
     await browser.keys("Enter");
-    await expect($(".message.reply .author")).toHaveText("REVIEWER");
-    await expect($(".message.reply .text")).toHaveText("Because both callers share this path.");
+    await expect($(".reply .author")).toHaveText("REVIEWER");
+    await expect($(".reply .message-text")).toHaveText("Because both callers share this path.");
 
     const checkbox = await fileCheckbox("a.rb");
     await checkbox.click();
@@ -371,7 +393,7 @@ describe("Gander end to end", () => {
       style.fontFamily.includes("Courier New") && style.fontSize === "18.5px" && style.rowHeight === 22,
     )).toBe(true);
     await $("button[aria-label='Questions']").click();
-    await expect($(".message.reply .text")).toHaveText("Because both callers share this path.");
+    await expect($(".reply .message-text")).toHaveText("Because both callers share this path.");
   });
 
   it("shows the overflowing file-tree scrollbar only while the tree is hovered", async () => {

--- a/packages/app/src/renderer/src/components/QuestionThread.vue
+++ b/packages/app/src/renderer/src/components/QuestionThread.vue
@@ -1,0 +1,216 @@
+<script setup lang="ts">
+import { computed, shallowRef } from "vue";
+import type { Question } from "@gander/shared";
+import {
+  Check,
+  CheckCheck,
+  ChevronDown,
+  CircleHelp,
+  Copy,
+  MessageSquare,
+  Trash2,
+} from "lucide-vue-next";
+
+const props = defineProps<{
+  question: Question;
+  current: boolean;
+  submitting: boolean;
+  copied: boolean;
+}>();
+const emit = defineEmits<{
+  navigate: [question: Question];
+  reply: [questionId: number];
+  copy: [question: Question];
+  delete: [questionId: number];
+}>();
+const draft = defineModel<string>({ default: "" });
+
+// A keyed thread instance survives service refreshes, so a reviewer's disclosure
+// choice remains stable even when a reply replaces the Question object.
+const expanded = shallowRef(props.question.state === "open");
+const bodyId = computed(() => `question-body-${props.question.id}`);
+const titleId = computed(() => `question-title-${props.question.id}`);
+const replyCount = computed(() => props.question.replies.length);
+const replyCountLabel = computed(() => `${replyCount.value} ${replyCount.value === 1 ? "reply" : "replies"}`);
+const location = computed(() => {
+  if (props.question.path === null) return "This pull request";
+  const name = props.question.path.split("/").pop() ?? props.question.path;
+  return props.question.line === null ? name : `${name}:${props.question.line}`;
+});
+
+const timestamp = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" });
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.valueOf()) ? value : timestamp.format(date);
+}
+</script>
+
+<template>
+  <li
+    class="thread"
+    :class="[{ current }, `state-${question.state}`]"
+    :data-question-id="question.id"
+    :aria-labelledby="titleId"
+  >
+    <div class="thread-header">
+      <div class="identity">
+        <button
+          class="location"
+          data-question-location
+          :disabled="question.path === null"
+          :title="question.path ?? undefined"
+          @click="emit('navigate', question)"
+        >
+          {{ location }}
+        </button>
+        <span class="state" :class="question.state">
+          <CircleHelp v-if="question.state === 'open'" :size="12" aria-hidden="true" />
+          <Check v-else-if="question.state === 'addressed'" :size="12" aria-hidden="true" />
+          <CheckCheck v-else :size="12" aria-hidden="true" />
+          {{ question.state }}
+        </span>
+      </div>
+      <button
+        class="disclosure"
+        type="button"
+        :aria-expanded="expanded"
+        :aria-controls="bodyId"
+        :aria-label="`${expanded ? 'Collapse' : 'Expand'} question ${question.id}`"
+        @click="expanded = !expanded"
+      >
+        <span :id="titleId" class="preview">{{ question.text }}</span>
+        <span class="reply-count">
+          <MessageSquare :size="12" aria-hidden="true" />
+          {{ replyCountLabel }}
+        </span>
+        <ChevronDown class="chevron" :class="{ expanded }" :size="15" aria-hidden="true" />
+      </button>
+    </div>
+
+    <section v-show="expanded" :id="bodyId" class="thread-body" data-question-body>
+      <div class="question-message">
+        <div class="message-heading">
+          <h3>Question</h3>
+          <time :datetime="question.createdAt">{{ formatTimestamp(question.createdAt) }}</time>
+        </div>
+        <p class="message-text">{{ question.text }}</p>
+      </div>
+
+      <section v-if="question.note || question.commitRef" class="agent-update" aria-label="Agent update">
+        <div class="message-heading">
+          <h3>Agent update</h3>
+          <code v-if="question.commitRef">{{ question.commitRef }}</code>
+        </div>
+        <p v-if="question.note" class="message-text">{{ question.note }}</p>
+      </section>
+
+      <section v-if="question.replies.length > 0" class="replies" aria-label="Replies">
+        <h3>Replies</h3>
+        <ol>
+          <li v-for="reply in question.replies" :key="reply.id" class="reply">
+            <div class="message-heading">
+              <span class="author" :class="reply.author">
+                {{ reply.author === "reviewer" ? "Reviewer" : "Agent" }}
+              </span>
+              <time :datetime="reply.createdAt">{{ formatTimestamp(reply.createdAt) }}</time>
+            </div>
+            <p class="message-text">{{ reply.text }}</p>
+          </li>
+        </ol>
+      </section>
+
+      <form class="reply-form" @submit.prevent="emit('reply', question.id)">
+        <label :for="`question-reply-${question.id}`">Reply</label>
+        <input
+          :id="`question-reply-${question.id}`"
+          v-model="draft"
+          data-app-typing="true"
+          :aria-label="`Reply to question ${question.id}`"
+          placeholder="Reply…"
+          :disabled="submitting"
+        />
+      </form>
+
+      <div class="thread-actions">
+        <button
+          type="button"
+          :aria-label="`Copy question ${question.id} thread`"
+          @click="emit('copy', question)"
+        >
+          <Copy :size="13" aria-hidden="true" />
+          {{ copied ? "Copied" : "Copy thread" }}
+        </button>
+        <button
+          class="delete"
+          type="button"
+          :aria-label="`Delete question ${question.id}`"
+          @click="emit('delete', question.id)"
+        >
+          <Trash2 :size="13" aria-hidden="true" />
+          Delete
+        </button>
+      </div>
+    </section>
+  </li>
+</template>
+
+<style scoped>
+.thread {
+  border-bottom: 1px solid var(--workbench-border);
+  border-left: 1px solid transparent;
+  min-width: 0;
+}
+.thread.state-open { border-left-color: var(--accent); }
+.thread.current { background: var(--selection-background); }
+.thread-header { display: flex; flex-direction: column; gap: 5px; padding: 9px 10px 8px; min-width: 0; }
+.identity { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.location {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  background: none; border: none; padding: 0; color: var(--accent); font: inherit; font-size: 11.5px; cursor: pointer;
+}
+.location:disabled { color: var(--faint-foreground); cursor: default; }
+.state {
+  display: inline-flex; align-items: center; gap: 3px; flex: none;
+  border: 1px solid var(--workbench-border); border-radius: 999px; padding: 1px 5px;
+  color: var(--faint-foreground); font: 600 9px var(--mono); letter-spacing: .35px; text-transform: uppercase;
+}
+.state.open { color: var(--accent); }
+.state.addressed { color: var(--warning); }
+.state.resolved { color: var(--success); }
+.disclosure {
+  display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 8px;
+  width: 100%; min-width: 0; padding: 2px 0; border: 0; background: none; color: inherit; cursor: pointer; text-align: left;
+}
+.preview { min-width: 0; overflow: hidden; color: var(--workbench-foreground); font-size: 12.5px; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
+.reply-count { display: inline-flex; align-items: center; gap: 4px; color: var(--faint-foreground); font: 10px var(--mono); white-space: nowrap; }
+.chevron { color: var(--faint-foreground); transition: transform 120ms ease; }
+.chevron.expanded { transform: rotate(180deg); }
+.thread-body { padding: 1px 10px 11px; }
+.question-message, .agent-update, .replies { min-width: 0; border-radius: 6px; }
+.question-message { padding: 9px 10px; background: var(--input-background); border: 1px solid var(--workbench-border); }
+.agent-update, .replies { margin: 8px 0 0 12px; padding: 9px 10px; border-left: 1px solid var(--accent); background: color-mix(in srgb, var(--accent) 6%, transparent); }
+.replies { border-left-color: var(--workbench-border); background: transparent; }
+.message-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; min-width: 0; }
+.message-heading h3, .replies > h3, .author { margin: 0; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
+.agent-update .message-heading h3, .author.agent { color: var(--accent); }
+.message-heading time { min-width: 0; color: var(--faint-foreground); font-size: 9.5px; text-align: right; }
+.message-heading code { overflow: hidden; max-width: 45%; padding: 1px 5px; border-radius: 4px; background: var(--badge-background); color: var(--muted-foreground); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.message-text { margin: 4px 0 0; min-width: 0; color: var(--workbench-foreground); font-size: 12.5px; line-height: 1.5; overflow-wrap: anywhere; white-space: pre-wrap; }
+.replies ol { list-style: none; margin: 7px 0 0; padding: 0; }
+.reply { padding: 8px 0; border-top: 1px solid var(--workbench-border); }
+.reply:last-child { padding-bottom: 0; }
+.reply-form { margin-top: 9px; }
+.reply-form label { display: block; margin-bottom: 4px; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
+.reply-form input { width: 100%; background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 6px; color: var(--workbench-foreground); font: inherit; font-size: 12px; padding: 6px 8px; }
+.reply-form input:focus { outline: none; border-color: var(--accent); }
+.reply-form input:disabled { color: var(--faint-foreground); }
+.thread-actions { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
+.thread-actions button { display: inline-flex; align-items: center; gap: 5px; border: 0; padding: 2px 0; background: none; color: var(--muted-foreground); font: inherit; font-size: 10.5px; cursor: pointer; }
+.thread-actions .delete { margin-left: auto; color: var(--faint-foreground); }
+.thread-actions .delete:hover { color: var(--danger); }
+.location:focus-visible, .disclosure:focus-visible, .thread-actions button:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) { .chevron { transition: none; } }
+</style>

--- a/packages/app/src/renderer/src/components/QuestionsDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/QuestionsDrawer.test.ts
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
-import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { reactive } from "vue";
 import type { PrView } from "@gander/shared";
 import type { Store } from "../store.js";
+import { pendingReveal } from "../selection.js";
 import QuestionsDrawer from "./QuestionsDrawer.vue";
 
 const view = (questions: PrView["questions"]): PrView => ({
@@ -11,16 +13,52 @@ const view = (questions: PrView["questions"]): PrView => ({
   questions,
 });
 
-function store(questions: PrView["questions"]): Store {
+function store(questions: PrView["questions"], overrides: Partial<Store> = {}): Store {
   return {
     view: view(questions),
     selectedPath: null,
     async addReviewerReply() {},
     async deleteQuestion() {},
+    select() {},
+    ...overrides,
   } as unknown as Store;
 }
 
+const questions: PrView["questions"] = [
+  {
+    id: 1,
+    path: "src/a-very-long-file-name.ts",
+    line: 37,
+    text: "Why does this branch need to handle the shared path this way?",
+    state: "open",
+    headSha: "b",
+    commitRef: null,
+    note: null,
+    createdAt: "2026-08-18T00:00:00.000Z",
+    replies: [],
+  },
+  {
+    id: 2,
+    path: "src/addressed.ts",
+    line: 9,
+    text: "Could this preserve the existing caller contract?",
+    state: "addressed",
+    headSha: "b",
+    commitRef: "abc1234",
+    note: "Kept the contract and added coverage.",
+    createdAt: "2026-08-18T01:00:00.000Z",
+    replies: [
+      { id: 3, author: "agent", text: "The regression test now covers both callers.", createdAt: "2026-08-18T02:00:00.000Z" },
+      { id: 4, author: "reviewer", text: "That covers my concern.", createdAt: "2026-08-18T03:00:00.000Z" },
+    ],
+  },
+];
+
 describe("QuestionsDrawer", () => {
+  beforeEach(() => {
+    pendingReveal.value = null;
+  });
+
   it("offers add actions in the empty state", async () => {
     const wrapper = mount(QuestionsDrawer, { props: { store: store([]), dock: "right" } });
 
@@ -54,5 +92,92 @@ describe("QuestionsDrawer", () => {
     await wrapper.get("button[aria-label='Add question (N)']").trigger("click");
 
     expect(wrapper.emitted("addQuestion")).toHaveLength(1);
+  });
+
+  it("opens new questions and collapses addressed threads without losing their identity", () => {
+    const wrapper = mount(QuestionsDrawer, { props: { store: store(questions), dock: "right" } });
+
+    const toggles = wrapper.findAll("button[aria-expanded]");
+    expect(toggles).toHaveLength(2);
+    expect(toggles[0]!.attributes("aria-expanded")).toBe("true");
+    expect(toggles[1]!.attributes("aria-expanded")).toBe("false");
+
+    const addressed = wrapper.get("[data-question-id='2']");
+    expect(addressed.text()).toContain("addressed.ts:9");
+    expect(addressed.get(".state").text()).toBe("addressed");
+    expect(addressed.text()).toContain("Could this preserve the existing caller contract?");
+    expect(addressed.text()).toContain("2 replies");
+    expect(addressed.find("[data-question-body]").isVisible()).toBe(false);
+  });
+
+  it("exposes a keyboard-operable disclosure and a labeled reply hierarchy", async () => {
+    const wrapper = mount(QuestionsDrawer, { props: { store: store(questions), dock: "bottom" } });
+    const addressed = wrapper.get("[data-question-id='2']");
+    const toggle = addressed.get("button[aria-expanded='false']");
+
+    await toggle.trigger("click");
+
+    expect(toggle.attributes("aria-expanded")).toBe("true");
+    expect(toggle.attributes("aria-controls")).toBe("question-body-2");
+    expect(toggle.attributes("aria-label")).toBe("Collapse question 2");
+    expect(addressed.get("[data-question-body]").isVisible()).toBe(true);
+    expect(addressed.get("[aria-label='Agent update']").text()).toContain("Kept the contract and added coverage.");
+    expect(addressed.get("[aria-label='Agent update'] code").text()).toBe("abc1234");
+    expect(addressed.get("[aria-label='Replies']").text()).toContain("Agent");
+    expect(addressed.get("[aria-label='Replies']").text()).toContain("Reviewer");
+  });
+
+  it("preserves navigation, delete, and reply actions inside an expanded thread", async () => {
+    const select = vi.fn();
+    const deleteQuestion = vi.fn(async () => {});
+    const addReviewerReply = vi.fn(async () => {});
+    const drawerStore = store(questions, { select, deleteQuestion, addReviewerReply });
+    const wrapper = mount(QuestionsDrawer, { props: { store: drawerStore, dock: "right" } });
+    const open = wrapper.get("[data-question-id='1']");
+
+    await open.get("button[data-question-location]").trigger("click");
+    expect(select).toHaveBeenCalledWith("src/a-very-long-file-name.ts");
+    expect(pendingReveal.value).toBe(37);
+
+    await open.get("input[aria-label='Reply to question 1']").setValue("A reviewer follow-up");
+    await open.get("form").trigger("submit");
+    expect(addReviewerReply).toHaveBeenCalledWith(1, "A reviewer follow-up");
+
+    await open.get("button[aria-label='Delete question 1']").trigger("click");
+    expect(deleteQuestion).toHaveBeenCalledWith(1);
+  });
+
+  it("preserves an explicit disclosure choice when a reply refreshes the question", async () => {
+    const drawerStore = reactive(store(questions)) as Store;
+    drawerStore.addReviewerReply = async (id, text) => {
+      drawerStore.view = view(questions.map((question) => question.id === id
+        ? { ...question, replies: [...question.replies, { id: 5, author: "reviewer", text, createdAt: "2026-08-18T04:00:00.000Z" }] }
+        : question));
+    };
+    const wrapper = mount(QuestionsDrawer, { props: { store: drawerStore, dock: "right" } });
+    const addressed = wrapper.get("[data-question-id='2']");
+    await addressed.get("button[aria-expanded='false']").trigger("click");
+    await addressed.get("input").setValue("One more thought");
+    await addressed.get("form").trigger("submit");
+    await flushPromises();
+
+    expect(addressed.get("button[aria-expanded]").attributes("aria-expanded")).toBe("true");
+    expect(addressed.get("[aria-label='Replies']").text()).toContain("One more thought");
+  });
+
+  it("copies a complete question thread and all threads as markdown", async () => {
+    const writeText = vi.fn(async () => {});
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    const wrapper = mount(QuestionsDrawer, { props: { store: store(questions), dock: "right" } });
+    const addressed = wrapper.get("[data-question-id='2']");
+    await addressed.get("button[aria-expanded='false']").trigger("click");
+
+    await addressed.get("button[aria-label='Copy question 2 thread']").trigger("click");
+    expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("Agent update (abc1234): Kept the contract"));
+    expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("Agent: The regression test now covers both callers."));
+
+    await wrapper.get("button[aria-label='Copy all question threads']").trigger("click");
+    expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("### src/a-very-long-file-name.ts:37 — open"));
+    expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("### src/addressed.ts:9 — addressed"));
   });
 });

--- a/packages/app/src/renderer/src/components/QuestionsDrawer.vue
+++ b/packages/app/src/renderer/src/components/QuestionsDrawer.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed, reactive } from "vue";
-import { MessageSquare, PanelBottom, PanelRight, Plus, Trash2, X } from "lucide-vue-next";
+import { computed, reactive, shallowRef } from "vue";
+import type { Question } from "@gander/shared";
+import { Copy, MessageSquare, PanelBottom, PanelRight, Plus, X } from "lucide-vue-next";
 import type { Store } from "../store.js";
 import { revealLine } from "../selection.js";
+import QuestionThread from "./QuestionThread.vue";
 
 const props = defineProps<{ store: Store; dock: "right" | "bottom" }>();
 const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addQuestion: [] }>();
@@ -10,11 +12,8 @@ const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addQuestion: [
 const questions = computed(() => props.store.view?.questions ?? []);
 const drafts = reactive<Record<number, string>>({});
 const submitting = reactive(new Set<number>());
-
-function fileName(path: string | null): string {
-  if (path === null) return "This pull request";
-  return path.split("/").pop() ?? path;
-}
+const copiedQuestionId = shallowRef<number | null>(null);
+const copiedAll = shallowRef(false);
 
 function goTo(q: { path: string | null; line: number | null }): void {
   if (q.path === null) return;
@@ -35,14 +34,62 @@ async function reply(questionId: number): Promise<void> {
     submitting.delete(questionId);
   }
 }
+
+function questionMarkdown(question: Question): string {
+  const location = question.path === null
+    ? "Pull request"
+    : `${question.path}${question.line === null ? "" : `:${question.line}`}`;
+  const parts = [
+    `### ${location} — ${question.state}`,
+    "",
+    `Reviewer: ${question.text}`,
+  ];
+  if (question.note || question.commitRef) {
+    const commit = question.commitRef ? ` (${question.commitRef})` : "";
+    parts.push("", `Agent update${commit}: ${question.note ?? "Addressed"}`);
+  }
+  for (const threadReply of question.replies) {
+    parts.push("", `${threadReply.author === "reviewer" ? "Reviewer" : "Agent"}: ${threadReply.text}`);
+  }
+  return parts.join("\n");
+}
+
+async function copyText(text: string, questionId: number | null): Promise<void> {
+  try {
+    if (!navigator.clipboard) throw new Error("Clipboard access is unavailable");
+    await navigator.clipboard.writeText(text);
+    copiedQuestionId.value = questionId;
+    copiedAll.value = questionId === null;
+  } catch (error) {
+    props.store.error = (error as Error).message;
+  }
+}
+
+async function copyQuestion(question: Question): Promise<void> {
+  await copyText(questionMarkdown(question), question.id);
+}
+
+async function copyAll(): Promise<void> {
+  await copyText(questions.value.map(questionMarkdown).join("\n\n"), null);
+}
 </script>
 
 <template>
-  <aside class="drawer">
+  <aside class="drawer" aria-label="Questions">
     <header>
       <MessageSquare :size="15" />
-      <span class="title">Questions</span>
+      <h2 class="title">Questions</h2>
       <span class="count">{{ questions.length }}</span>
+      <button
+        v-if="questions.length > 0"
+        class="copy-all"
+        aria-label="Copy all question threads"
+        title="Copy all question threads"
+        @click="copyAll"
+      >
+        <Copy :size="13" aria-hidden="true" />
+        <span>{{ copiedAll ? "Copied" : "Copy all" }}</span>
+      </button>
       <button
         class="add"
         aria-label="Add question (N)"
@@ -73,54 +120,37 @@ async function reply(questionId: number): Promise<void> {
       </button>
     </div>
 
-    <ul v-else>
-      <li v-for="q in questions" :key="q.id" :class="{ current: q.path === store.selectedPath }">
-        <div class="row">
-          <button class="file" :disabled="q.path === null" @click="goTo(q)">
-            {{ fileName(q.path) }}<span v-if="q.line !== null" class="line">:{{ q.line }}</span>
-          </button>
-          <span class="state" :class="q.state">{{ q.state }}</span>
-          <button class="del" aria-label="Delete question" title="Delete question" @click="store.deleteQuestion(q.id)">
-            <Trash2 :size="13" />
-          </button>
-        </div>
-        <div class="message original">
-          <span class="author">Reviewer</span>
-          <p class="text">{{ q.text }}</p>
-        </div>
-        <div v-for="reply in q.replies" :key="reply.id" class="message reply">
-          <span class="author" :class="reply.author">{{ reply.author === "reviewer" ? "Reviewer" : "Agent" }}</span>
-          <p class="text">{{ reply.text }}</p>
-        </div>
-        <p v-if="q.note || q.commitRef" class="answer">
-          <span v-if="q.note">{{ q.note }}</span>
-          <code v-if="q.commitRef">{{ q.commitRef }}</code>
-        </p>
-        <form class="reply-form" @submit.prevent="reply(q.id)">
-          <input
-            v-model="drafts[q.id]"
-            data-app-typing="true"
-            :aria-label="`Reply to question ${q.id}`"
-            placeholder="Reply…"
-            :disabled="submitting.has(q.id)"
-          />
-        </form>
-      </li>
+    <ul v-else aria-label="Review questions">
+      <QuestionThread
+        v-for="question in questions"
+        :key="question.id"
+        v-model="drafts[question.id]"
+        :question="question"
+        :current="question.path === store.selectedPath"
+        :submitting="submitting.has(question.id)"
+        :copied="copiedQuestionId === question.id"
+        @navigate="goTo"
+        @reply="reply"
+        @copy="copyQuestion"
+        @delete="store.deleteQuestion"
+      />
     </ul>
   </aside>
 </template>
 
 <style scoped>
-.drawer { display: flex; flex-direction: column; background: var(--panel-background); border-left: 1px solid var(--workbench-border); overflow: hidden auto; }
+.drawer { container: questions / inline-size; display: flex; flex-direction: column; background: var(--panel-background); border-left: 1px solid var(--workbench-border); overflow: hidden auto; }
 header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--workbench-border); color: var(--muted-foreground); flex: none; }
-.title { font-size: 12px; font-weight: 600; letter-spacing: .3px; text-transform: uppercase; }
+.title { margin: 0; font-size: 12px; font-weight: 600; letter-spacing: .3px; text-transform: uppercase; }
 .count { font: 11px var(--mono); background: var(--badge-background); border-radius: 9px; padding: 1px 7px; }
-.add {
-  margin-left: auto; display: flex; align-items: center; gap: 4px;
+.add, .copy-all {
+  display: flex; align-items: center; gap: 4px;
   background: none; border: 1px solid var(--workbench-border); border-radius: 5px;
   color: var(--workbench-foreground); padding: 3px 7px; font: inherit; font-size: 11px; cursor: pointer;
 }
-.add:hover { border-color: var(--accent); color: var(--accent); }
+.copy-all { margin-left: auto; }
+.add:first-of-type { margin-left: auto; }
+.add:hover, .copy-all:hover { border-color: var(--accent); color: var(--accent); }
 .dockbtn { margin-left: 0; }
 .dockbtn + .close { margin-left: 0; }
 .close { margin-left: auto; background: none; border: none; color: var(--faint-foreground); cursor: pointer; display: flex; }
@@ -134,32 +164,13 @@ header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; borde
   color: var(--accent-foreground); padding: 5px 9px; font: inherit; font-size: 12px; font-weight: 600; cursor: pointer;
 }
 .empty button kbd { color: var(--workbench-foreground); }
-.add:focus-visible, .empty button:focus-visible, .close:focus-visible, .del:focus-visible, .file:focus-visible {
+.add:focus-visible, .copy-all:focus-visible, .empty button:focus-visible, .close:focus-visible {
   outline: 2px solid var(--accent); outline-offset: 2px;
 }
 kbd { font: 11px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: 4px; padding: 1px 5px; }
 
 ul { list-style: none; margin: 0; padding: 0; }
-li { padding: 10px 12px; border-bottom: 1px solid var(--workbench-border); }
-li.current { background: var(--selection-background); }
-.row { display: flex; align-items: center; gap: 8px; }
-.file { background: none; border: none; padding: 0; color: var(--accent); font: inherit; font-size: 12px; cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.file:disabled { color: var(--faint-foreground); cursor: default; }
-.state { font: 10px var(--mono); color: var(--faint-foreground); text-transform: uppercase; letter-spacing: .4px; }
-.state.addressed { color: var(--warning); }
-.state.resolved { color: var(--success); }
-.del { margin-left: auto; background: none; border: none; color: var(--faint-foreground); cursor: pointer; display: flex; flex: none; }
-.del:hover { color: var(--danger); }
-.line { color: var(--faint-foreground); }
-.message { margin-top: 8px; padding-left: 9px; border-left: 2px solid var(--workbench-border); }
-.message.reply { margin-left: 8px; }
-.author { display: block; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
-.author.agent { color: var(--accent); }
-.answer { margin: 8px 0 0 10px; display: flex; align-items: baseline; gap: 7px; font-size: 11.5px; color: var(--faint-foreground); }
-.answer code { font: 10.5px var(--mono); background: var(--badge-background); border-radius: 4px; padding: 1px 5px; flex: none; }
-.text { margin: 3px 0 0; font-size: 12.5px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere; }
-.reply-form { margin-top: 9px; }
-.reply-form input { width: 100%; background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 6px; color: var(--workbench-foreground); font: inherit; font-size: 12px; padding: 6px 8px; }
-.reply-form input:focus { outline: none; border-color: var(--accent); }
-.reply-form input:disabled { color: var(--faint-foreground); }
+@container questions (max-width: 330px) {
+  .copy-all span, .add span { display: none; }
+}
 </style>


### PR DESCRIPTION
## Summary

- turn each review question into an accessible, keyboard-operable collapsible thread with location, lifecycle state, preview, and reply count preserved in the compact header
- give reviewer text, agent update metadata, commit references, and real reviewer-agent replies a clear nested hierarchy with timestamps and long-content wrapping
- preserve navigation, reply, delete, per-thread copy, copy-all, lifecycle behavior, and both right and bottom drawer docking
- add focused component coverage plus Electron coverage for disclosure, clipboard feedback, replies, persistence, and both docking orientations

## Readiness

- Simplify: clean
- Code review: clean, 0 critical findings
- Accessibility/UI audit: clean after reducing side accents to the incumbent 1px chrome; semantic headings, labeled regions, visible focus, reduced motion, and text-plus-icon states are covered
- Adversarial review: skipped for low-risk drawer-only UI work
- Shared E2E harness fix `0ea8723` integrated from master with no duplicate feature-branch implementation

## Test plan

- `pnpm typecheck`
- `pnpm test` (38 files, 260 tests)
- `pnpm test:e2e` (9 scenarios passed)

Closes #10
