### PR TITLE
Preview changed images in reviews

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -3,7 +3,7 @@ import { connect } from "node:net";
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { $, browser, expect } from "@wdio/globals";
+import { $, $$, browser, expect } from "@wdio/globals";
 import "@wdio/electron-service";
 
 const run = promisify(execFile);
@@ -372,6 +372,29 @@ describe("Gander end to end", () => {
     )).toBe(true);
     await $("button[aria-label='Questions']").click();
     await expect($(".message.reply .text")).toHaveText("Because both callers share this path.");
+  });
+
+  it("renders both sides of a changed image from bounded blob URLs", async () => {
+    await registerAndSelect(requiredEnv("GANDER_E2E_IMAGES_URL"), "images");
+    await openPullRequest("Preview changed images");
+    await treeRow("logo.png").click();
+
+    await $(".image-diff").waitForDisplayed();
+    await browser.waitUntil(async () => browser.execute(() => {
+      const images = [...document.querySelectorAll<HTMLImageElement>(".image-diff img")];
+      return images.length === 2 && images.every((image) => image.complete && image.naturalWidth > 0);
+    }), { timeoutMsg: "both base and head image blobs did not decode" });
+
+    expect(await $$(".image-diff img")).toHaveLength(2);
+    expect(await browser.execute(() => [...document.querySelectorAll<HTMLImageElement>(".image-diff img")]
+      .map((image) => ({ src: image.src, width: image.naturalWidth, height: image.naturalHeight }))
+    )).toEqual([
+      expect.objectContaining({ src: expect.stringMatching(/^blob:/), width: expect.any(Number), height: expect.any(Number) }),
+      expect.objectContaining({ src: expect.stringMatching(/^blob:/), width: expect.any(Number), height: expect.any(Number) }),
+    ]);
+    await expect($("button=Actual size")).toHaveAttribute("aria-pressed", "false");
+    await $("button=Actual size").click();
+    await expect($("button=Actual size")).toHaveAttribute("aria-pressed", "true");
   });
 
   it("shows the overflowing file-tree scrollbar only while the tree is hovered", async () => {

--- a/packages/app/e2e/run.ts
+++ b/packages/app/e2e/run.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -22,8 +22,13 @@ interface RepoFixture {
   headSha: string;
 }
 
-async function repoFixture(repoId: string, title: string, featureFiles: Record<string, string> = {}): Promise<RepoFixture> {
-  const fixture = await makeFixtureRepo(featureFiles);
+async function repoFixture(
+  repoId: string,
+  title: string,
+  featureFiles: Record<string, string | Uint8Array> = {},
+  baseFiles: Record<string, string | Uint8Array> = {},
+): Promise<RepoFixture> {
+  const fixture = await makeFixtureRepo(featureFiles, baseFiles);
   return {
     repoId,
     url: `https://github.com/${repoId}`,
@@ -40,7 +45,9 @@ async function main(): Promise<void> {
   const databasePath = join(root, "gander.db");
   const userDataPath = join(root, "user-data");
   const raceMarkerPath = join(root, "concurrent-race-requests");
-  const [persistence, race, launcher, icons, scrollbar] = await Promise.all([
+  const baseImage = readFileSync(join(import.meta.dirname, "../resources/icon.png"));
+  const headImage = readFileSync(join(import.meta.dirname, "../resources/icon-dev.png"));
+  const [persistence, race, launcher, icons, scrollbar, images] = await Promise.all([
     repoFixture("acme/persistence", "Persist reviewed files"),
     repoFixture("acme/race", "Open without corrupting the clone"),
     repoFixture("acme/launcher", "Open from the command line"),
@@ -62,8 +69,14 @@ async function main(): Promise<void> {
         `export const value${index + 1} = ${index + 1};\n`,
       ])),
     ),
+    repoFixture(
+      "acme/images",
+      "Preview changed images",
+      { "assets/logo.png": headImage },
+      { "assets/logo.png": baseImage },
+    ),
   ]);
-  const fixtures = [persistence, race, launcher, icons, scrollbar];
+  const fixtures = [persistence, race, launcher, icons, scrollbar, images];
   const storage = openStorage(databasePath);
   const service = buildServer({ storage, token: SERVICE_TOKEN, version: "e2e" });
   const github = Fastify({ logger: false });
@@ -147,6 +160,7 @@ async function main(): Promise<void> {
       GANDER_E2E_LAUNCHER_REPO: launcher.repoId,
       GANDER_E2E_ICONS_URL: icons.url,
       GANDER_E2E_SCROLLBAR_URL: scrollbar.url,
+      GANDER_E2E_IMAGES_URL: images.url,
       // Where the app listens with no allocated socket in the environment: beside the
       // suite's own user data, so this run cannot reach a development app.
       GANDER_E2E_APP_SOCKET: join(userDataPath, "app.sock"),

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -2,6 +2,9 @@ import type { NewQuestion, OpenTarget, PrSummary, PrView, RepoEntry } from "@gan
 import type { AppSettings } from "./settings.js";
 import type { ThemeId } from "./themes.js";
 import type { ConnectionCheck } from "./main/connection.js";
+import type { ImagePreview } from "./image-preview.js";
+
+export type { ImagePreview, ImageSide } from "./image-preview.js";
 
 export type WindowStyle = "native-titlebar" | "integrated-titlebar";
 export const WINDOW_STYLE_ARGUMENT = "--gander-window-style=";
@@ -51,6 +54,7 @@ export interface GanderApi {
   setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView>;
   refreshPr(repoId: string, prNumber: number): Promise<PrView>;
   reviewedSnapshot(repoId: string, prNumber: number, path: string): Promise<string | null>;
+  imagePreview(repoId: string, prNumber: number, path: string): Promise<ImagePreview>;
   addQuestion(repoId: string, prNumber: number, input: Omit<NewQuestion, "headSha">): Promise<PrView>;
   addReviewerReply(repoId: string, prNumber: number, id: number, text: string): Promise<PrView>;
   deleteQuestion(repoId: string, prNumber: number, id: number): Promise<PrView>;

--- a/packages/app/src/image-preview.test.ts
+++ b/packages/app/src/image-preview.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { imageMediaType } from "./image-preview.js";
+
+describe("image media detection", () => {
+  it("uses blob signatures instead of filenames", () => {
+    expect(imageMediaType(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toBe("image/png");
+    expect(imageMediaType(new TextEncoder().encode("not an image.png"))).toBeNull();
+  });
+
+  it("does not mistake arbitrary text beginning with BM for a bitmap", () => {
+    expect(imageMediaType(new TextEncoder().encode("BM is ordinary text"))).toBeNull();
+  });
+});

--- a/packages/app/src/image-preview.ts
+++ b/packages/app/src/image-preview.ts
@@ -1,0 +1,44 @@
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+export type ImageMediaType = "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/bmp" | "image/avif";
+
+export type ImageSide =
+  | { kind: "absent" }
+  | { kind: "unsupported"; size: number }
+  | { kind: "too-large"; size: number; limit: number }
+  | { kind: "image"; mediaType: ImageMediaType; size: number; bytes: Uint8Array };
+
+export interface ImagePreview {
+  base: ImageSide;
+  head: ImageSide;
+}
+
+function startsWith(bytes: Uint8Array, signature: readonly number[]): boolean {
+  return signature.every((byte, index) => bytes[index] === byte);
+}
+
+function ascii(bytes: Uint8Array, start: number, length: number): string {
+  return String.fromCharCode(...bytes.slice(start, start + length));
+}
+
+function uint32le(bytes: Uint8Array, start: number): number {
+  return ((bytes[start] ?? 0)
+    | ((bytes[start + 1] ?? 0) << 8)
+    | ((bytes[start + 2] ?? 0) << 16)
+    | ((bytes[start + 3] ?? 0) << 24)) >>> 0;
+}
+
+/** Detect only formats Chromium accepts in an img element; never trust the repository path. */
+export function imageMediaType(bytes: Uint8Array): ImageMediaType | null {
+  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (ascii(bytes, 0, 6) === "GIF87a" || ascii(bytes, 0, 6) === "GIF89a") return "image/gif";
+  if (ascii(bytes, 0, 4) === "RIFF" && ascii(bytes, 8, 4) === "WEBP") return "image/webp";
+  const dibHeaderSize = uint32le(bytes, 14);
+  if (bytes.length >= 26
+    && ascii(bytes, 0, 2) === "BM"
+    && uint32le(bytes, 10) >= 26
+    && [12, 40, 52, 56, 108, 124].includes(dibHeaderSize)) return "image/bmp";
+  if (ascii(bytes, 4, 4) === "ftyp" && ["avif", "avis"].includes(ascii(bytes, 8, 4))) return "image/avif";
+  return null;
+}

--- a/packages/app/src/main/fixtures.ts
+++ b/packages/app/src/main/fixtures.ts
@@ -9,7 +9,12 @@ const run = promisify(execFile);
 export interface FixtureRepo { dir: string; git(args: string[]): Promise<string>; }
 
 /** Real repo: main (a.rb, unchanged.txt), feature branch editing a.rb + adding b.rb, refs/pull/1/head -> feature. */
-export async function makeFixtureRepo(featureFiles: Record<string, string> = {}): Promise<FixtureRepo> {
+type FixtureContent = string | Uint8Array;
+
+export async function makeFixtureRepo(
+  featureFiles: Record<string, FixtureContent> = {},
+  baseFiles: Record<string, FixtureContent> = {},
+): Promise<FixtureRepo> {
   const dir = mkdtempSync(join(tmpdir(), "gander-fixture-"));
   const git = async (args: string[]): Promise<string> =>
     (await run("git", ["-C", dir, ...args], { env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" } })).stdout.trim();
@@ -17,6 +22,11 @@ export async function makeFixtureRepo(featureFiles: Record<string, string> = {})
   await git(["init", "-b", "main"]);
   writeFileSync(join(dir, "a.rb"), "class A\nend\n");
   writeFileSync(join(dir, "unchanged.txt"), "same\n");
+  for (const [path, content] of Object.entries(baseFiles)) {
+    const destination = join(dir, path);
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, content);
+  }
   await git(["add", "-A"]); await git(["commit", "-m", "initial"]);
   await git(["checkout", "-b", "feature"]);
   writeFileSync(join(dir, "a.rb"), "class A\n  def go; end\nend\n");

--- a/packages/app/src/main/git.test.ts
+++ b/packages/app/src/main/git.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createGitEngine, type GitEngine } from "./git.js";
 import { makeFixtureRepo, type FixtureRepo } from "./fixtures.js";
+import { MAX_IMAGE_BYTES } from "../image-preview.js";
 
 let fixture: FixtureRepo; let clonesRoot: string; let engine: GitEngine;
 
@@ -106,6 +107,35 @@ describe("git engine", () => {
     expect(atBase.content).toBeNull();
     expect(atBase.hash).toBeNull(); // absent at base — same content-shape as binary, different hash-shape
     expect(atBase.binary).toBe(false);
+  });
+
+  it("showImage transports only signature-detected, bounded image bytes", async () => {
+    const png = readFileSync(join(import.meta.dirname, "../../resources/icon.png"));
+    await fixture.git(["checkout", "feature"]);
+    writeFileSync(join(fixture.dir, "real-image.dat"), png);
+    writeFileSync(join(fixture.dir, "ordinary.bin"), Buffer.from([0, 1, 2, 3, 4]));
+    writeFileSync(join(fixture.dir, "corrupt.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    const oversized = Buffer.alloc(MAX_IMAGE_BYTES + 1);
+    png.copy(oversized, 0, 0, 16);
+    writeFileSync(join(fixture.dir, "oversized.bin"), oversized);
+    await fixture.git(["add", "-A"]);
+    await fixture.git(["commit", "-m", "add image cases"]);
+    await fixture.git(["update-ref", "refs/pull/1/head", await fixture.git(["rev-parse", "HEAD"])]);
+    await fixture.git(["checkout", "main"]);
+
+    const clone = await engine.ensureClone("acme/atlas", fixture.dir);
+    await engine.fetchPr(clone, 1, "main");
+    const head = await engine.resolveRef(clone, "refs/gander/pr/1");
+
+    const image = await engine.showImage(clone, head, "real-image.dat");
+    expect(image).toMatchObject({ kind: "image", mediaType: "image/png", size: png.length });
+    expect(image.kind === "image" && Buffer.from(image.bytes).equals(png)).toBe(true);
+    await expect(engine.showImage(clone, head, "ordinary.bin")).resolves.toEqual({ kind: "unsupported", size: 5 });
+    await expect(engine.showImage(clone, head, "corrupt.png")).resolves.toMatchObject({ kind: "image", mediaType: "image/png" });
+    await expect(engine.showImage(clone, head, "oversized.bin")).resolves.toEqual({
+      kind: "too-large", size: MAX_IMAGE_BYTES + 1, limit: MAX_IMAGE_BYTES,
+    });
+    expect((await engine.showFile(clone, head, "corrupt.png")).binary).toBe(true);
   });
 
   it("showFile throws (does not swallow) when the revision itself is bad", async () => {

--- a/packages/app/src/main/git.ts
+++ b/packages/app/src/main/git.ts
@@ -1,9 +1,10 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import type { FileStatus } from "@gander/shared";
+import { imageMediaType, MAX_IMAGE_BYTES, type ImageSide } from "../image-preview.js";
 
 const FILE_STATUSES: readonly FileStatus[] = ["A", "M", "D", "R"];
 
@@ -46,7 +47,41 @@ export interface GitEngine {
   mergeBase(cloneDir: string, a: string, b: string): Promise<string>;
   diffFiles(cloneDir: string, base: string, head: string): Promise<Array<{ path: string; status: FileStatus }>>;
   showFile(cloneDir: string, rev: string, path: string): Promise<ShowFileResult>;
+  showImage(cloneDir: string, rev: string, path: string): Promise<ImageSide>;
   resolveRef(cloneDir: string, ref: string): Promise<string>;
+}
+
+async function gitPrefix(cloneDir: string, rev: string, path: string, length: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const args = ["cat-file", "blob", `${rev}:${path}`];
+    const child = spawn("git", ["-C", cloneDir, ...args], { env: GIT_ENV, stdio: ["ignore", "pipe", "pipe"] });
+    const chunks: Buffer[] = [];
+    const errors: Buffer[] = [];
+    let byteCount = 0;
+    let enough = false;
+    const timer = setTimeout(() => child.kill(), DEFAULT_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (enough) return;
+      const remaining = length - byteCount;
+      chunks.push(chunk.subarray(0, remaining));
+      byteCount += Math.min(chunk.length, remaining);
+      if (byteCount >= length) {
+        enough = true;
+        child.kill();
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => errors.push(chunk));
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      if (enough || code === 0) resolve(Buffer.concat(chunks));
+      else reject(new Error(`git ${args.join(" ")} failed: ${Buffer.concat(errors).toString().trim() || `exited ${code ?? signal}`}`));
+    });
+  });
 }
 
 function describeGitError(args: string[], err: unknown, timeoutMs: number): Error {
@@ -165,9 +200,31 @@ export function createGitEngine(clonesRoot: string): GitEngine {
       // NUL byte in the content is the standard cheap binary heuristic (same one git itself
       // uses internally). Decoding a binary blob as UTF-8 would mangle it into U+FFFD replacement
       // characters that then get hashed and stored as the "reviewed snapshot" — nonsense.
-      const binary = buf.includes(0);
+      // Some valid image encodings can avoid a NUL in small files. Treat a recognized
+      // image signature as binary too, so its bytes are never decoded or snapshotted as text.
+      const binary = buf.includes(0) || imageMediaType(buf) !== null;
       if (binary) return { content: null, hash, binary: true };
       return { content: buf.toString("utf8"), hash, binary: false };
+    },
+
+    async showImage(cloneDir, rev, path) {
+      const sizeText = await git(cloneDir, ["cat-file", "-s", `${rev}:${path}`]);
+      const size = Number.parseInt(sizeText.trim(), 10);
+      if (!Number.isSafeInteger(size) || size < 0) throw new Error(`git returned an invalid blob size for ${path}`);
+
+      if (size > MAX_IMAGE_BYTES) {
+        // Read only enough bytes to identify the format. Large ordinary binaries retain
+        // the generic fallback and large images are rejected without crossing IPC.
+        const mediaType = imageMediaType(await gitPrefix(cloneDir, rev, path, 32));
+        return mediaType === null
+          ? { kind: "unsupported", size }
+          : { kind: "too-large", size, limit: MAX_IMAGE_BYTES };
+      }
+
+      const bytes = await gitBuffer(cloneDir, ["show", `${rev}:${path}`]);
+      const mediaType = imageMediaType(bytes);
+      if (mediaType === null) return { kind: "unsupported", size };
+      return { kind: "image", mediaType, size, bytes };
     },
 
     async resolveRef(cloneDir, ref) {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -62,6 +62,7 @@ async function bootstrap(): Promise<GanderConfig> {
   ipcMain.handle("gander:refreshPr", async (_e, repoId: string, n: number) => reviewer.refreshPr(repoId, n));
   ipcMain.handle("gander:setChecked", async (_e, repoId: string, n: number, path: string, checked: boolean) => reviewer.setChecked(repoId, n, path, checked));
   ipcMain.handle("gander:reviewedSnapshot", async (_e, repoId: string, n: number, path: string) => reviewer.reviewedSnapshot(repoId, n, path));
+  ipcMain.handle("gander:imagePreview", async (_e, repoId: string, n: number, path: string) => reviewer.imagePreview(repoId, n, path));
   ipcMain.handle("gander:addQuestion", async (_e, repoId: string, n: number, input: { path: string | null; line: number | null; text: string }) => reviewer.addQuestion(repoId, n, input));
   ipcMain.handle("gander:addReviewerReply", async (_e, repoId: string, n: number, id: number, text: string) => reviewer.addReviewerReply(repoId, n, id, text));
   ipcMain.handle("gander:deleteQuestion", async (_e, repoId: string, n: number, id: number) => reviewer.deleteQuestion(repoId, n, id));

--- a/packages/app/src/main/review.test.ts
+++ b/packages/app/src/main/review.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -210,5 +210,53 @@ describe("review pipeline", () => {
     const moved = await instrumented.refreshPr("acme/atlas", 1);
     expect(showFileCalls).toBeGreaterThan(afterOpen);
     expect(moved.files.find((f) => f.path === "a.rb")!.changedSince).toBe(true);
+  });
+
+  it("previews modified, added, and deleted images without persisting binary snapshots", async () => {
+    await server.close(); storage.close();
+    rmSync(fixture.dir, { recursive: true, force: true });
+    const basePng = readFileSync(join(import.meta.dirname, "../../resources/icon.png"));
+    const headPng = readFileSync(join(import.meta.dirname, "../../resources/icon-dev.png"));
+    fixture = await makeFixtureRepo(
+      { "modified.png": headPng, "added.png": headPng },
+      { "modified.png": basePng, "deleted.png": basePng },
+    );
+    await fixture.git(["checkout", "feature"]);
+    await fixture.git(["rm", "deleted.png"]);
+    await fixture.git(["commit", "--amend", "--no-edit"]);
+    await fixture.git(["update-ref", "refs/pull/1/head", await fixture.git(["rev-parse", "HEAD"])]);
+    await fixture.git(["checkout", "main"]);
+
+    storage = openStorage(join(dbDir, "images.db"));
+    server = buildServer({ storage, token: "t", version: "test" });
+    await server.listen({ port: 0, host: "127.0.0.1" });
+    port = (server.addresses()[0] as { port: number }).port;
+    reviewer = createReviewer({
+      git: createGitEngine(clonesRoot),
+      service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
+      listPrs: async () => [await currentPr(fixture)],
+      repoUrl: () => fixture.dir,
+      machine: "test-machine",
+    });
+
+    const view = await reviewer.openPr("acme/atlas", 1);
+    expect(view.files.find((file) => file.path === "modified.png")).toMatchObject({
+      status: "M", baseContent: null, headContent: null,
+    });
+    await expect(reviewer.imagePreview("acme/atlas", 1, "modified.png")).resolves.toMatchObject({
+      base: { kind: "image", mediaType: "image/png" },
+      head: { kind: "image", mediaType: "image/png" },
+    });
+    await expect(reviewer.imagePreview("acme/atlas", 1, "added.png")).resolves.toMatchObject({
+      base: { kind: "absent" }, head: { kind: "image" },
+    });
+    await expect(reviewer.imagePreview("acme/atlas", 1, "deleted.png")).resolves.toMatchObject({
+      base: { kind: "image" }, head: { kind: "absent" },
+    });
+
+    await reviewer.setChecked("acme/atlas", 1, "modified.png", true);
+    expect(storage.getSnapshot("acme/atlas", 1, "modified.png")).toMatchObject({
+      baseContent: null, headContent: null,
+    });
   });
 });

--- a/packages/app/src/main/review.ts
+++ b/packages/app/src/main/review.ts
@@ -1,6 +1,7 @@
 import type { FileCheckoff, NewQuestion, PrFile, PrSummary, PrView } from "@gander/shared";
 import type { GitEngine } from "./git.js";
 import type { ServiceClient } from "./service-client.js";
+import type { ImagePreview, ImageSide } from "../image-preview.js";
 
 export interface ReviewerDeps {
   git: GitEngine;
@@ -19,9 +20,10 @@ export interface Reviewer {
   deleteQuestion(repoId: string, prNumber: number, id: number): Promise<PrView>;
   /** The file as it stood when the reviewer last checked it — the base for the delta view. */
   reviewedSnapshot(repoId: string, prNumber: number, path: string): Promise<string | null>;
+  imagePreview(repoId: string, prNumber: number, path: string): Promise<ImagePreview>;
 }
 
-interface CacheEntry { view: PrView; headSha: string; }
+interface CacheEntry { view: PrView; headSha: string; clone: string; mergeBase: string; }
 
 export function createReviewer(deps: ReviewerDeps): Reviewer {
   const cache = new Map<string, CacheEntry>();
@@ -111,7 +113,7 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     const files = await computeFiles(repoId, prNumber, clone, mergeBase, head);
     const questions = await deps.service.listQuestions(repoId, prNumber);
     const view: PrView = { pr, files, questions };
-    cache.set(key(repoId, prNumber), { view, headSha: head });
+    cache.set(key(repoId, prNumber), { view, headSha: head, clone, mergeBase });
     return view;
   }
 
@@ -136,7 +138,7 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
       const files = applyServiceState(cached.view.files, state);
       const questions = await deps.service.listQuestions(repoId, prNumber);
       const view: PrView = { pr, files, questions };
-      cache.set(key(repoId, prNumber), { view, headSha: head });
+      cache.set(key(repoId, prNumber), { ...cached, view });
       return view;
     }
 
@@ -146,7 +148,7 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     const files = await computeFiles(repoId, prNumber, clone, mergeBase, head);
     const questions = await deps.service.listQuestions(repoId, prNumber);
     const view: PrView = { pr, files, questions };
-    cache.set(key(repoId, prNumber), { view, headSha: head });
+    cache.set(key(repoId, prNumber), { view, headSha: head, clone, mergeBase });
     return view;
   }
 
@@ -190,6 +192,20 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     },
     async reviewedSnapshot(repoId, prNumber, path) {
       return (await deps.service.getSnapshot(repoId, prNumber, path)).headContent;
+    },
+    async imagePreview(repoId, prNumber, path) {
+      const entry = cache.get(key(repoId, prNumber));
+      if (!entry) throw new Error(`PR #${prNumber} on ${repoId} must be opened first`);
+      const file = entry.view.files.find((candidate) => candidate.path === path);
+      if (!file) throw new Error(`${path} is not part of PR #${prNumber}`);
+      const side = (hash: string | null, rev: string): Promise<ImageSide> => hash === null
+        ? Promise.resolve({ kind: "absent" })
+        : deps.git.showImage(entry.clone, rev, path);
+      const [base, head] = await Promise.all([
+        side(file.baseHash, entry.mergeBase),
+        side(file.headHash, entry.headSha),
+      ]);
+      return { base, head };
     },
     async addReviewerReply(repoId, prNumber, id, text) {
       const view = requireOpen(repoId, prNumber);

--- a/packages/app/src/preload/api.test.ts
+++ b/packages/app/src/preload/api.test.ts
@@ -55,6 +55,14 @@ describe("preload API", () => {
     expect(invoke).toHaveBeenLastCalledWith("gander:addReviewerReply", "acme/atlas", 7, 12, "A reviewer reply");
   });
 
+  it("requests an image preview only through its explicit IPC channel", async () => {
+    const invoke = vi.fn(async () => ({}));
+    const api = createGanderApi(invoke, vi.fn());
+
+    await api.imagePreview("acme/atlas", 7, "assets/logo.png");
+    expect(invoke).toHaveBeenLastCalledWith("gander:imagePreview", "acme/atlas", 7, "assets/logo.png");
+  });
+
   it("routes launch targets and subscribes to later open-target events", async () => {
     const invoke = vi.fn(async () => ({ repoId: "acme/atlas", prNumber: 4 }));
     const cleanup = vi.fn();

--- a/packages/app/src/preload/api.ts
+++ b/packages/app/src/preload/api.ts
@@ -73,6 +73,7 @@ export function createGanderApi(
     setCheckedMany: (repoId, prNumber, paths, checked) => call("setCheckedMany", repoId, prNumber, paths, checked),
     refreshPr: (repoId, prNumber) => call("refreshPr", repoId, prNumber),
     reviewedSnapshot: (repoId, prNumber, path) => call("reviewedSnapshot", repoId, prNumber, path),
+    imagePreview: (repoId, prNumber, path) => call("imagePreview", repoId, prNumber, path),
     addQuestion: (repoId, prNumber, input) => call("addQuestion", repoId, prNumber, input),
     addReviewerReply: (repoId, prNumber, id, text) => call("addReviewerReply", repoId, prNumber, id, text),
     deleteQuestion: (repoId, prNumber, id) => call("deleteQuestion", repoId, prNumber, id),

--- a/packages/app/src/renderer/index.html
+++ b/packages/app/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Gander</title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'" />
   </head>
   <body style="margin:0;background:#1e1e2e">
     <div id="app"></div>

--- a/packages/app/src/renderer/index.test.ts
+++ b/packages/app/src/renderer/index.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("renderer content security policy", () => {
+  it("allows controlled image object URLs without allowing blob scripts", () => {
+    const html = readFileSync(new URL("./index.html", import.meta.url), "utf8");
+
+    expect(html).toContain("img-src 'self' data: blob:");
+    expect(html).toContain("default-src 'self'");
+    expect(html).not.toContain("script-src blob:");
+  });
+});

--- a/packages/app/src/renderer/src/components/DiffPane.vue
+++ b/packages/app/src/renderer/src/components/DiffPane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import * as monaco from "monaco-editor";
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
 import { languageForPath } from "../languages.js";
 import { setupMonacoWorkers } from "../monaco.js";
 import { codeEditorOptions, diffEditorOptions, editorFontOptions } from "../editor-options.js";
@@ -9,6 +9,8 @@ import type { EditorSettings } from "../../../settings.js";
 import { currentLine, pendingReveal } from "../selection.js";
 import type { QuestionTarget } from "../selection.js";
 import { Check, FileClock, FileDiff, FileText, TriangleAlert } from "lucide-vue-next";
+import ImageDiff from "./ImageDiff.vue";
+import type { ImagePreview } from "../../../api.js";
 
 const props = defineProps<{ store: Store; editorSettings: EditorSettings }>();
 const emit = defineEmits<{ addQuestion: [target: QuestionTarget] }>();
@@ -19,6 +21,10 @@ const view = ref<"diff" | "full" | "since">("diff");
 // round trip to the service and only the delta tab needs it.
 const snapshot = ref<string | null>(null);
 const snapshotFor = ref<string | null>(null);
+const imagePreview = shallowRef<ImagePreview | null>(null);
+const imageLoading = shallowRef(false);
+const imageError = shallowRef<string | null>(null);
+let imageRequest = 0;
 
 // Only offered once the file has actually moved since it was reviewed. Before that
 // the tab would render an empty diff and mean nothing.
@@ -48,6 +54,10 @@ const baseRef = computed(() => props.store.view?.pr.baseRef ?? "the base branch"
 const baseBinary = computed(() => current.value !== null && current.value.baseContent === null && current.value.baseHash !== null);
 const headBinary = computed(() => current.value !== null && current.value.headContent === null && current.value.headHash !== null);
 const isBinary = computed(() => baseBinary.value || headBinary.value);
+const imageKey = computed(() => {
+  const file = current.value;
+  return file && isBinary.value ? `${file.path}#${file.baseHash ?? ""}#${file.headHash ?? ""}` : null;
+});
 
 /** The editor holding the head revision: the diff editor's right-hand side, or the full file. */
 function headEditor(): monaco.editor.ICodeEditor | null {
@@ -186,6 +196,11 @@ const renderKey = computed(() => {
 watch([() => current.value?.path, view], async ([path]) => {
   if (view.value !== "since" || !path) return;
   if (snapshotFor.value === path) return;
+  if (isBinary.value) {
+    snapshot.value = null;
+    snapshotFor.value = path;
+    return;
+  }
   snapshot.value = await props.store.reviewedSnapshot(path);
   snapshotFor.value = path;
 }, { immediate: true });
@@ -193,6 +208,22 @@ watch([() => current.value?.path, view], async ([path]) => {
 // A file that has not moved since review has nothing to show here; fall back rather
 // than leave the reader on an empty tab after switching files.
 watch(canShowDelta, (can) => { if (!can && view.value === "since") view.value = "diff"; });
+
+watch(imageKey, async (key) => {
+  const request = ++imageRequest;
+  imagePreview.value = null;
+  imageError.value = null;
+  imageLoading.value = key !== null;
+  if (key === null || current.value === null) return;
+  try {
+    const preview = await props.store.imagePreview(current.value.path);
+    if (request === imageRequest) imagePreview.value = preview;
+  } catch (err) {
+    if (request === imageRequest) imageError.value = (err as Error).message;
+  } finally {
+    if (request === imageRequest) imageLoading.value = false;
+  }
+}, { immediate: true });
 
 onMounted(() => {
   setupMonacoWorkers();
@@ -273,7 +304,17 @@ onBeforeUnmount(dispose);
       <TriangleAlert :size="14" />
       <span>Changed since your review — un-checked automatically. Re-review and mark again.</span>
     </div>
-    <div v-if="isBinary" class="binary-note">Binary file — diff cannot be displayed.</div>
+    <div v-if="isBinary && imageLoading" class="binary-note">Loading image preview…</div>
+    <div v-else-if="isBinary && imageError" class="binary-note" role="alert">Image preview failed: {{ imageError }}</div>
+    <ImageDiff
+      v-else-if="isBinary && imagePreview"
+      :preview="imagePreview"
+      :filename="baseName"
+      :base-label="baseRef"
+      head-label="Head"
+      :mode="view"
+    />
+    <div v-else-if="isBinary" class="binary-note">Binary file — diff cannot be displayed.</div>
     <div v-else ref="host" class="editor" />
   </section>
 </template>

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -49,6 +49,7 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
     async refresh() {},
     async fetchNow() {},
     async reviewedSnapshot() { return null; },
+    async imagePreview() { return null; },
     async addQuestion() {},
     async addReviewerReply() {},
     async deleteQuestion() {},

--- a/packages/app/src/renderer/src/components/ImageDiff.test.ts
+++ b/packages/app/src/renderer/src/components/ImageDiff.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ImageSide } from "../../../api.js";
+import ImageDiff from "./ImageDiff.vue";
+import ImageDiffSide from "./ImageDiffSide.vue";
+
+const image = (byte = 1): ImageSide => ({
+  kind: "image",
+  mediaType: "image/png",
+  size: 2048,
+  bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, byte]),
+});
+
+const createObjectURL = vi.fn(() => "blob:gander-preview");
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+  Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+  Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: revokeObjectURL });
+});
+
+describe("ImageDiff", () => {
+  it("renders both modified image sides and switches between fit and actual size", async () => {
+    const wrapper = mount(ImageDiff, {
+      props: {
+        preview: { base: image(1), head: image(2) },
+        filename: "logo.png",
+        baseLabel: "main",
+        headLabel: "Head",
+        mode: "diff",
+      },
+    });
+
+    expect(wrapper.findAll("img")).toHaveLength(2);
+    expect(wrapper.text()).toContain("main");
+    expect(wrapper.text()).toContain("Head");
+    expect(wrapper.findAll("img").every((node) => node.classes().includes("fit"))).toBe(true);
+    await wrapper.get("button[aria-pressed='false']").trigger("click");
+    expect(wrapper.findAll("img").every((node) => !node.classes().includes("fit"))).toBe(true);
+  });
+
+  it("labels missing sides for added and deleted images", () => {
+    const added = mount(ImageDiff, {
+      props: {
+        preview: { base: { kind: "absent" }, head: image() },
+        filename: "added.png", baseLabel: "main", headLabel: "Head", mode: "diff",
+      },
+    });
+    expect(added.text()).toContain("No image on this side.");
+    expect(added.findAll("img")).toHaveLength(1);
+
+    const deleted = mount(ImageDiff, {
+      props: {
+        preview: { base: image(), head: { kind: "absent" } },
+        filename: "deleted.png", baseLabel: "main", headLabel: "Head", mode: "diff",
+      },
+    });
+    expect(deleted.text()).toContain("No image on this side.");
+    expect(deleted.findAll("img")).toHaveLength(1);
+  });
+
+  it("explains the intentionally unavailable binary snapshot in since-my-check mode", () => {
+    const wrapper = mount(ImageDiff, {
+      props: {
+        preview: { base: image(), head: image() },
+        filename: "logo.png", baseLabel: "main", headLabel: "Head", mode: "since",
+      },
+    });
+    expect(wrapper.get("[role='status']").text()).toContain("No historical visual snapshot is available");
+    expect(wrapper.find("img").exists()).toBe(false);
+  });
+
+  it("keeps ordinary binary files on the generic fallback and reports over-limit images", async () => {
+    const binary = mount(ImageDiff, {
+      props: {
+        preview: { base: { kind: "unsupported", size: 40 }, head: { kind: "unsupported", size: 50 } },
+        filename: "archive.bin", baseLabel: "main", headLabel: "Head", mode: "diff",
+      },
+    });
+    expect(binary.text()).toBe("Binary file — diff cannot be displayed.");
+    await binary.setProps({ mode: "since" });
+    expect(binary.text()).toBe("Binary file — diff cannot be displayed.");
+
+    const large = mount(ImageDiff, {
+      props: {
+        preview: { base: { kind: "absent" }, head: { kind: "too-large", size: 20_000_000, limit: 10_485_760 } },
+        filename: "large.png", baseLabel: "main", headLabel: "Head", mode: "diff",
+      },
+    });
+    expect(large.get("[role='status']").text()).toContain("too large to preview");
+  });
+});
+
+describe("ImageDiffSide", () => {
+  it("shows decoded dimensions and revokes object URLs on replacement and unmount", async () => {
+    const wrapper = mount(ImageDiffSide, {
+      props: { side: image(1), label: "Head", filename: "logo.png", fit: true },
+    });
+    const element = wrapper.get("img").element;
+    Object.defineProperty(element, "naturalWidth", { configurable: true, value: 640 });
+    Object.defineProperty(element, "naturalHeight", { configurable: true, value: 480 });
+    await wrapper.get("img").trigger("load");
+    expect(wrapper.text()).toContain("640 × 480");
+    expect(wrapper.text()).toContain("2.0 KB");
+    expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+
+    await wrapper.setProps({ side: image(2) });
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:gander-preview");
+    wrapper.unmount();
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails visibly when Chromium cannot decode signature-matching bytes", async () => {
+    const wrapper = mount(ImageDiffSide, {
+      props: { side: image(), label: "Head", filename: "corrupt.png", fit: true },
+    });
+    await wrapper.get("img").trigger("error");
+    expect(wrapper.get("[role='status']").text()).toBe("Image could not be decoded.");
+  });
+});

--- a/packages/app/src/renderer/src/components/ImageDiff.vue
+++ b/packages/app/src/renderer/src/components/ImageDiff.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed, shallowRef } from "vue";
+import type { ImagePreview } from "../../../api.js";
+import ImageDiffSide from "./ImageDiffSide.vue";
+
+const props = defineProps<{
+  preview: ImagePreview;
+  filename: string;
+  baseLabel: string;
+  headLabel: string;
+  mode: "diff" | "full" | "since";
+}>();
+
+const fit = shallowRef(true);
+const hasImageCandidate = computed(() => [props.preview.base, props.preview.head]
+  .some((side) => side.kind === "image" || side.kind === "too-large"));
+</script>
+
+<template>
+  <div v-if="!hasImageCandidate" class="binary-note">Binary file — diff cannot be displayed.</div>
+  <div v-else-if="mode === 'since'" class="snapshot-note" role="status">
+    No historical visual snapshot is available for images. Use “Changes against {{ baseLabel }}” to compare the current base and head images.
+  </div>
+  <div v-else class="image-diff">
+    <div class="toolbar" role="toolbar" aria-label="Image preview size">
+      <button type="button" :aria-pressed="fit" :class="{ active: fit }" @click="fit = true">Fit</button>
+      <button type="button" :aria-pressed="!fit" :class="{ active: !fit }" @click="fit = false">Actual size</button>
+    </div>
+    <div class="sides">
+      <ImageDiffSide
+        v-if="mode === 'diff'"
+        :side="preview.base"
+        :label="baseLabel"
+        :filename="filename"
+        :fit="fit"
+      />
+      <ImageDiffSide
+        :side="preview.head"
+        :label="headLabel"
+        :filename="filename"
+        :fit="fit"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.image-diff { display: flex; flex: 1; min-width: 0; min-height: 0; flex-direction: column; }
+.toolbar { display: flex; flex: none; justify-content: flex-end; gap: 2px; padding: 5px 10px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); }
+.toolbar button { border: 0; border-radius: 4px; padding: 3px 8px; background: transparent; color: var(--muted-foreground); font-size: 11px; cursor: pointer; }
+.toolbar button:hover, .toolbar button.active { background: var(--elevated-background); color: var(--workbench-foreground); }
+.toolbar button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.sides { display: flex; flex: 1; min-width: 0; min-height: 0; }
+.snapshot-note, .binary-note { display: flex; flex: 1; align-items: center; justify-content: center; padding: 32px; color: var(--faint-foreground); font-size: 13px; text-align: center; }
+.snapshot-note { color: var(--warning); background: var(--warning-background); }
+</style>

--- a/packages/app/src/renderer/src/components/ImageDiffSide.vue
+++ b/packages/app/src/renderer/src/components/ImageDiffSide.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, shallowRef, watch } from "vue";
+import type { ImageSide } from "../../../api.js";
+
+const props = defineProps<{
+  side: ImageSide;
+  label: string;
+  filename: string;
+  fit: boolean;
+}>();
+
+const objectUrl = shallowRef<string | null>(null);
+const width = shallowRef<number | null>(null);
+const height = shallowRef<number | null>(null);
+const decodeFailed = shallowRef(false);
+
+function releaseUrl(): void {
+  if (objectUrl.value !== null) URL.revokeObjectURL(objectUrl.value);
+  objectUrl.value = null;
+}
+
+watch(() => props.side, (side) => {
+  releaseUrl();
+  width.value = null;
+  height.value = null;
+  decodeFailed.value = false;
+  if (side.kind !== "image") return;
+  const bytes = side.bytes.slice();
+  objectUrl.value = URL.createObjectURL(new Blob([bytes.buffer], { type: side.mediaType }));
+}, { immediate: true });
+
+onBeforeUnmount(releaseUrl);
+
+const size = computed(() => props.side.kind === "absent" ? null : props.side.size);
+const metadata = computed(() => {
+  const parts: string[] = [];
+  if (width.value !== null && height.value !== null) parts.push(`${width.value} × ${height.value}`);
+  if (size.value !== null) parts.push(formatBytes(size.value));
+  return parts.join(" · ");
+});
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function loaded(event: Event): void {
+  const image = event.currentTarget as HTMLImageElement;
+  width.value = image.naturalWidth;
+  height.value = image.naturalHeight;
+}
+</script>
+
+<template>
+  <section class="side" :aria-label="label">
+    <header class="side-head">
+      <strong>{{ label }}</strong>
+      <span v-if="side.kind !== 'absent'" class="filename">{{ filename }}</span>
+      <span v-if="metadata" class="metadata">{{ metadata }}</span>
+    </header>
+    <div v-if="side.kind === 'absent'" class="fallback">No image on this side.</div>
+    <div v-else-if="side.kind === 'too-large'" class="fallback" role="status">
+      Image is too large to preview ({{ formatBytes(side.size) }}; limit {{ formatBytes(side.limit) }}).
+    </div>
+    <div v-else-if="side.kind === 'unsupported'" class="fallback">Not a supported image.</div>
+    <div v-else class="viewport">
+      <div v-if="decodeFailed" class="fallback" role="status">Image could not be decoded.</div>
+      <img
+        v-else-if="objectUrl"
+        :src="objectUrl"
+        :alt="`${label} preview of ${filename}`"
+        :class="{ fit }"
+        @load="loaded"
+        @error="decodeFailed = true"
+      />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.side { display: flex; flex: 1 1 0; min-width: 0; min-height: 0; flex-direction: column; border-right: 1px solid var(--workbench-border); }
+.side:last-child { border-right: 0; }
+.side-head { display: flex; min-height: 34px; flex: none; align-items: center; gap: 8px; padding: 6px 10px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); font-size: 11px; }
+.side-head strong { color: var(--workbench-foreground); text-transform: uppercase; letter-spacing: 0.04em; }
+.filename { overflow: hidden; color: var(--muted-foreground); font-family: var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.metadata { margin-left: auto; flex: none; color: var(--faint-foreground); font-variant-numeric: tabular-nums; }
+.viewport { flex: 1; min-width: 0; min-height: 0; overflow: auto; display: flex; align-items: flex-start; justify-content: flex-start; padding: 20px; background-color: #fff; background-image: linear-gradient(45deg, #d8d8d8 25%, transparent 25%), linear-gradient(-45deg, #d8d8d8 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #d8d8d8 75%), linear-gradient(-45deg, transparent 75%, #d8d8d8 75%); background-position: 0 0, 0 8px, 8px -8px, -8px 0; background-size: 16px 16px; }
+.viewport img { display: block; flex: none; max-width: none; max-height: none; }
+.viewport img.fit { max-width: 100%; max-height: 100%; margin: auto; object-fit: contain; }
+.viewport > .fallback { width: 100%; height: 100%; }
+.fallback { flex: 1; display: flex; align-items: center; justify-content: center; padding: 24px; color: var(--faint-foreground); font-size: 13px; text-align: center; }
+</style>

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -38,6 +38,7 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     onOpenTarget: () => () => {},
     serviceHealthy: async () => true,
     reviewedSnapshot: async () => null,
+    imagePreview: async () => ({ base: { kind: "absent" }, head: { kind: "absent" } }),
     addQuestion: async () => prView(),
     addReviewerReply: async () => prView(),
     deleteQuestion: async () => prView(),

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -1,6 +1,7 @@
 import { reactive } from "vue";
 import type { OpenTarget, PrSummary, PrView, RepoEntry } from "@gander/shared";
 import type { GanderApi, GithubRepository } from "./api.js";
+import type { ImagePreview } from "../../api.js";
 
 export interface Store {
   repos: RepoEntry[];
@@ -35,6 +36,7 @@ export interface Store {
   setChecked(path: string, checked: boolean): Promise<void>;
   setCheckedMany(paths: string[], checked: boolean): Promise<void>;
   reviewedSnapshot(path: string): Promise<string | null>;
+  imagePreview(path: string): Promise<ImagePreview | null>;
   addQuestion(text: string, path: string | null, line: number | null): Promise<void>;
   addReviewerReply(id: number, text: string): Promise<void>;
   deleteQuestion(id: number): Promise<void>;
@@ -163,6 +165,10 @@ export function createStore(api: GanderApi): Store {
     async reviewedSnapshot(path: string) {
       if (!store.currentRepoId || !store.view) return null;
       return api.reviewedSnapshot(store.currentRepoId, store.view.pr.number, path);
+    },
+    async imagePreview(path: string) {
+      if (!store.currentRepoId || !store.view) return null;
+      return api.imagePreview(store.currentRepoId, store.view.pr.number, path);
     },
     async addQuestion(text: string, path: string | null, line: number | null) {
       await guard(async () => {


### PR DESCRIPTION
## Summary

- detect supported image formats from bounded Git blob bytes and expose them through a dedicated preload contract
- render modified images side by side, label added/deleted sides, show dimensions and byte size, and support fit or scrollable actual-size viewing on a transparency checkerboard
- keep raw-byte hashes and text-only snapshots unchanged, with an explicit explanation in since-my-check mode that no historical visual snapshot is available
- reject over-limit images before IPC, surface corrupt images visibly, preserve the ordinary binary fallback, and revoke renderer object URLs on replacement and unmount

## Readiness

- Simplify: clean
- Code review: clean; 3 findings fixed
- Adversarial review: clean after 3 passes
- Impeccable UI detector: clean
- Integrated shared E2E harness fix `0ea8723`; no duplicate harness fix is included in the feature diff

## Test plan

- `pnpm typecheck` — passed
- `pnpm test` — passed, 267 tests across 41 files
- `pnpm test:e2e` — run exactly once after integrating `0ea8723`: 7 of 10 scenarios passed. The changed-image scenario exposed that the renderer CSP did not allow the controlled `blob:` image URLs; `66191ec` fixes that narrowly under `img-src` and adds a regression test. Two later repository-selection scenarios also failed after the image timeout. Per instruction, E2E was not rerun; the CSP fix is covered by the passing non-E2E suite but remains E2E-unverified in this PR run.

Closes #49
