### PR TITLE
Handle review service outages and version skew

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -25,6 +25,13 @@ Review state is content-based: files key on sha256 of blob text, so checkoffs
 survive rebases and force-pushes. A bare un-check retains the snapshot, which
 is the base for the M2 delta view.
 
+An already-open review remains readable from the desktop app's in-memory cache
+when the review service is unreachable. Authored-state writes fail visibly and
+are never queued; after reconnection the service replaces cached review state.
+The app also compares the service API version from `/healthz`: an older service
+is blocked with an update instruction, while a newer service remains usable with
+a visible warning.
+
 ## Running it locally
 
 ```

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -1,7 +1,7 @@
 import type { NewQuestion, OpenTarget, PrSummary, PrView, RepoEntry } from "@gander/shared";
 import type { AppSettings } from "./settings.js";
 import type { ThemeId } from "./themes.js";
-import type { ConnectionCheck } from "./main/connection.js";
+import type { ConnectionCheck, ServiceStatus } from "./main/connection.js";
 import type { ImagePreview } from "./image-preview.js";
 
 export type { ImagePreview, ImageSide } from "./image-preview.js";
@@ -26,7 +26,7 @@ export interface InitialWindowState {
   worktreeLabel: string | null;
 }
 
-export type { ConnectionCheck };
+export type { ConnectionCheck, ServiceStatus };
 
 export interface GanderApi {
   /** Fixed by the main process when the window is created; renderer code cannot change it. */
@@ -48,7 +48,7 @@ export interface GanderApi {
   testConnection(url: string, token: string): Promise<ConnectionCheck>;
   /** Checks first, and saves only a connection that answered. */
   setConnection(url: string, token: string): Promise<ConnectionCheck>;
-  serviceHealthy(): Promise<boolean>;
+  serviceStatus(): Promise<ServiceStatus>;
   openPr(repoId: string, prNumber: number): Promise<PrView>;
   setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<PrView>;
   setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView>;

--- a/packages/app/src/main/connection.test.ts
+++ b/packages/app/src/main/connection.test.ts
@@ -1,18 +1,25 @@
 import { afterEach, describe, expect, it } from "vitest";
 import Fastify, { type FastifyInstance } from "fastify";
-import { checkConnection } from "./connection.js";
+import { SERVICE_VERSION } from "@gander/shared";
+import { checkConnection, checkServiceStatus, compareServiceVersion } from "./connection.js";
+import { createServiceClient } from "./service-client.js";
 
 let server: FastifyInstance | undefined;
 
 afterEach(async () => { await server?.close(); server = undefined; });
 
 /** A real service-shaped server, so the check meets the responses it will meet in life. */
-async function serve(token: string): Promise<string> {
+async function serve(token: string, version = SERVICE_VERSION): Promise<string> {
   server = Fastify({ logger: false });
-  server.get("/healthz", async () => ({ ok: true, version: "1.2.3" }));
+  server.get("/healthz", async () => ({ ok: true, version }));
   server.get("/api/reviews/:repoId/:prNumber", async (req, reply) => {
     if (req.headers.authorization !== `Bearer ${token}`) return reply.code(401).send({ error: "no" });
     return { repoId: "x/y", prNumber: 1, files: [] };
+  });
+  server.put("/api/reviews/:repoId/:prNumber/files", async (req, reply) => {
+    if (req.headers.authorization !== `Bearer ${token}`) return reply.code(401).send({ error: "no" });
+    const body = req.body as { path: string; checked: boolean };
+    return { path: body.path, checked: body.checked, baseHash: null, headHash: null, checkedAt: null, machine: null };
   });
   return server.listen({ host: "127.0.0.1", port: 0 });
 }
@@ -20,12 +27,12 @@ async function serve(token: string): Promise<string> {
 describe("checkConnection", () => {
   it("accepts a reachable service and the right token", async () => {
     const url = await serve("good-token");
-    expect(await checkConnection(url, "good-token")).toEqual({ ok: true, version: "1.2.3" });
+    expect(await checkConnection(url, "good-token")).toEqual({ ok: true, version: SERVICE_VERSION, compatibility: "compatible" });
   });
 
   it("tolerates a trailing slash and surrounding whitespace", async () => {
     const url = await serve("good-token");
-    expect(await checkConnection(`  ${url}/  `, " good-token ")).toEqual({ ok: true, version: "1.2.3" });
+    expect(await checkConnection(`  ${url}/  `, " good-token ")).toEqual({ ok: true, version: SERVICE_VERSION, compatibility: "compatible" });
   });
 
   it("names the token when the service rejects it", async () => {
@@ -58,5 +65,68 @@ describe("checkConnection", () => {
   it("asks for the missing half rather than probing", async () => {
     expect(await checkConnection("", "t")).toEqual({ ok: false, reason: "Enter the service URL." });
     expect(await checkConnection("http://x", " ")).toEqual({ ok: false, reason: "Enter the service token." });
+  });
+
+  it("blocks an older service and tells the reviewer which version to install", async () => {
+    const url = await serve("good-token", "0.0.9");
+    await expect(checkConnection(url, "good-token")).resolves.toEqual({
+      ok: false,
+      reason: `Gander service 0.0.9 is too old for this app. Update the service to ${SERVICE_VERSION}.`,
+    });
+
+    const client = createServiceClient(() => ({ url, token: "good-token" }));
+    await expect(client.getReview("acme/atlas", 1)).rejects.toThrow(/service 0\.0\.9 is too old/i);
+    await expect(client.putFileState("acme/atlas", 1, { checked: false, path: "a.rb" })).rejects.toThrow(
+      /not saved and will not be retried/i,
+    );
+  });
+
+  it("allows a newer service with an explicit warning state", async () => {
+    const url = await serve("good-token", "0.2.0");
+    await expect(checkConnection(url, "good-token")).resolves.toEqual({
+      ok: true,
+      version: "0.2.0",
+      compatibility: "newer",
+    });
+    await expect(checkServiceStatus(url)).resolves.toMatchObject({ state: "newer", serviceVersion: "0.2.0" });
+  });
+
+  it("rejects a version that cannot participate in the compatibility policy", () => {
+    expect(compareServiceVersion("development")).toMatchObject({
+      state: "incompatible",
+      reason: expect.stringContaining("not a supported version"),
+    });
+  });
+
+  it("requires an authoritative review read after the health check observes an outage", async () => {
+    let url = await serve("good-token");
+    const client = createServiceClient(() => ({ url, token: "good-token" }));
+    await client.getReview("acme/atlas", 1);
+
+    await server!.close();
+    await expect(client.status()).resolves.toMatchObject({ state: "unreachable" });
+    url = await serve("good-token");
+
+    await expect(client.putFileState("acme/atlas", 1, { checked: false, path: "a.rb" })).rejects.toThrow(
+      /refresh it after the service reconnects/i,
+    );
+    await client.getReview("acme/atlas", 1);
+    await expect(client.putFileState("acme/atlas", 1, { checked: false, path: "a.rb" })).resolves.toMatchObject({
+      path: "a.rb",
+      checked: false,
+    });
+  });
+
+  it("does not carry cached review state across a service URL change", async () => {
+    let url = await serve("good-token");
+    const client = createServiceClient(() => ({ url, token: "good-token" }));
+    await client.getReview("acme/atlas", 1);
+
+    await server!.close();
+    url = await serve("good-token");
+
+    await expect(client.putFileState("acme/atlas", 1, { checked: false, path: "a.rb" })).rejects.toThrow(
+      /refresh it after the service reconnects/i,
+    );
   });
 });

--- a/packages/app/src/main/connection.ts
+++ b/packages/app/src/main/connection.ts
@@ -1,3 +1,5 @@
+import { SERVICE_VERSION } from "@gander/shared";
+
 /**
  * Checking a connection the reviewer has just typed.
  *
@@ -8,33 +10,80 @@
  */
 
 export type ConnectionCheck =
-  | { ok: true; version: string }
+  | { ok: true; version: string; compatibility: "compatible" | "newer" }
   | { ok: false; reason: string };
 
+export type ServiceStatus =
+  | { state: "connected"; serviceVersion: string; supportedVersion: string }
+  | { state: "newer"; serviceVersion: string; supportedVersion: string }
+  | { state: "incompatible"; serviceVersion: string; supportedVersion: string; reason: string }
+  | { state: "unreachable"; reason: string };
+
 const PROBE = "/api/reviews/gander%2Fconnection-check/1";
+
+function semverParts(version: string): [number, number, number] | null {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function compareServiceVersion(version: string): ServiceStatus {
+  const actual = semverParts(version);
+  const supported = semverParts(SERVICE_VERSION)!;
+  if (actual === null) {
+    return {
+      state: "incompatible",
+      serviceVersion: version,
+      supportedVersion: SERVICE_VERSION,
+      reason: `Gander service version ${version} is not a supported version. Update the service to ${SERVICE_VERSION}.`,
+    };
+  }
+  const comparison = actual.findIndex((part, index) => part !== supported[index]);
+  if (comparison === -1) {
+    return { state: "connected", serviceVersion: version, supportedVersion: SERVICE_VERSION };
+  }
+  if (actual[comparison]! < supported[comparison]!) {
+    return {
+      state: "incompatible",
+      serviceVersion: version,
+      supportedVersion: SERVICE_VERSION,
+      reason: `Gander service ${version} is too old for this app. Update the service to ${SERVICE_VERSION}.`,
+    };
+  }
+  return { state: "newer", serviceVersion: version, supportedVersion: SERVICE_VERSION };
+}
+
+export async function checkServiceStatus(url: string): Promise<ServiceStatus> {
+  const base = url.trim().replace(/\/+$/, "");
+  if (base === "") return { state: "unreachable", reason: "No Gander service configured." };
+
+  let health: Response;
+  try {
+    health = await fetch(`${base}/healthz`);
+  } catch (err) {
+    return { state: "unreachable", reason: `Could not reach ${base}: ${(err as Error).message}` };
+  }
+  if (!health.ok) return { state: "unreachable", reason: `${base} answered ${health.status} on /healthz` };
+
+  try {
+    const body = (await health.json()) as { version?: unknown };
+    if (typeof body.version !== "string" || body.version.trim() === "") {
+      return { state: "unreachable", reason: `${base} is not a Gander service` };
+    }
+    return compareServiceVersion(body.version);
+  } catch {
+    return { state: "unreachable", reason: `${base} is not a Gander service` };
+  }
+}
 
 export async function checkConnection(url: string, token: string): Promise<ConnectionCheck> {
   const base = url.trim().replace(/\/+$/, "");
   if (base === "") return { ok: false, reason: "Enter the service URL." };
   if (token.trim() === "") return { ok: false, reason: "Enter the service token." };
 
-  let health: Response;
-  try {
-    health = await fetch(`${base}/healthz`);
-  } catch (err) {
-    return { ok: false, reason: `Could not reach ${base}: ${(err as Error).message}` };
-  }
-  if (!health.ok) return { ok: false, reason: `${base} answered ${health.status} on /healthz` };
-
-  let version: string;
-  try {
-    const body = (await health.json()) as { version?: unknown };
-    if (typeof body.version !== "string" || body.version.trim() === "") {
-      return { ok: false, reason: `${base} is not a Gander service` };
-    }
-    version = body.version;
-  } catch {
-    return { ok: false, reason: `${base} is not a Gander service` };
+  const status = await checkServiceStatus(base);
+  if (status.state === "unreachable" || status.state === "incompatible") {
+    return { ok: false, reason: status.reason };
   }
 
   let probe: Response;
@@ -46,5 +95,5 @@ export async function checkConnection(url: string, token: string): Promise<Conne
   if (probe.status === 401) return { ok: false, reason: "The service rejected that token." };
   if (!probe.ok) return { ok: false, reason: `${base} answered ${probe.status}` };
 
-  return { ok: true, version };
+  return { ok: true, version: status.serviceVersion, compatibility: status.state === "newer" ? "newer" : "compatible" };
 }

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -48,7 +48,7 @@ async function bootstrap(): Promise<GanderConfig> {
     return entry;
   });
   ipcMain.handle("gander:listPrs", async (_e, repoId: string) => listOpenPrs(repoId, await githubToken()));
-  ipcMain.handle("gander:serviceHealthy", async () => service.healthy());
+  ipcMain.handle("gander:serviceStatus", async () => service.status());
   ipcMain.handle("gander:lastReview", async () => cfg.lastReview ?? null);
   ipcMain.handle("gander:initialTarget", async () => launchTarget);
   ipcMain.handle("gander:openPr", async (_e, repoId: string, n: number) => {

--- a/packages/app/src/main/review.test.ts
+++ b/packages/app/src/main/review.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { FastifyInstance } from "fastify";
-import type { PrSummary } from "@gander/shared";
+import { SERVICE_VERSION, type PrSummary } from "@gander/shared";
 import { buildServer } from "../../../service/src/server.js";
 import { openStorage, type Storage } from "../../../service/src/storage.js";
 import { makeFixtureRepo, type FixtureRepo } from "./fixtures.js";
@@ -26,7 +26,7 @@ beforeEach(async () => {
   clonesRoot = mkdtempSync(join(tmpdir(), "gander-clones-"));
   dbDir = mkdtempSync(join(tmpdir(), "gander-db-"));
   storage = openStorage(join(dbDir, "t.db"));
-  server = buildServer({ storage, token: "t", version: "test" });
+  server = buildServer({ storage, token: "t", version: SERVICE_VERSION });
   await server.listen({ port: 0, host: "127.0.0.1" });
   port = (server.addresses()[0] as { port: number }).port;
 
@@ -212,6 +212,50 @@ describe("review pipeline", () => {
     expect(moved.files.find((f) => f.path === "a.rb")!.changedSince).toBe(true);
   });
 
+  it("keeps the loaded review readable while offline, fails writes without queuing, and accepts service state on recovery", async () => {
+    const loaded = await reviewer.openPr("acme/atlas", 1);
+    expect(loaded.files.find((file) => file.path === "a.rb")!.checked).toBe(false);
+
+    await server.close();
+
+    await expect(reviewer.setChecked("acme/atlas", 1, "a.rb", true)).rejects.toThrow(
+      /not saved and will not be retried/i,
+    );
+    expect(loaded.files.find((file) => file.path === "a.rb")!.checked).toBe(false);
+
+    const offline = await reviewer.refreshPr("acme/atlas", 1);
+    expect(offline).toBe(loaded);
+    expect(offline.files.map((file) => file.path)).toEqual(["a.rb", "b.rb"]);
+    await expect(reviewer.addQuestion("acme/atlas", 1, { path: "a.rb", line: 1, text: "Queued?" })).rejects.toThrow(
+      /not saved and will not be retried/i,
+    );
+    expect(offline.questions).toEqual([]);
+
+    storage.putFileState("acme/atlas", 1, {
+      checked: true,
+      path: "a.rb",
+      baseHash: loaded.files[0]!.baseHash,
+      headHash: loaded.files[0]!.headHash,
+      baseContent: loaded.files[0]!.baseContent,
+      headContent: loaded.files[0]!.headContent,
+      machine: "other-machine",
+    });
+    server = buildServer({ storage, token: "t", version: SERVICE_VERSION });
+    await server.listen({ port, host: "127.0.0.1" });
+
+    await expect(reviewer.setChecked("acme/atlas", 1, "a.rb", false)).rejects.toThrow(
+      /refresh it after the service reconnects/i,
+    );
+    expect(storage.getReview("acme/atlas", 1).files.find((file) => file.path === "a.rb")).toMatchObject({
+      checked: true,
+      machine: "other-machine",
+    });
+
+    const recovered = await reviewer.refreshPr("acme/atlas", 1);
+    expect(recovered.files.find((file) => file.path === "a.rb")!.checked).toBe(true);
+    expect(storage.getReview("acme/atlas", 1).files.find((file) => file.path === "a.rb")!.machine).toBe("other-machine");
+  });
+
   it("previews modified, added, and deleted images without persisting binary snapshots", async () => {
     await server.close(); storage.close();
     rmSync(fixture.dir, { recursive: true, force: true });
@@ -228,7 +272,7 @@ describe("review pipeline", () => {
     await fixture.git(["checkout", "main"]);
 
     storage = openStorage(join(dbDir, "images.db"));
-    server = buildServer({ storage, token: "t", version: "test" });
+    server = buildServer({ storage, token: "t", version: SERVICE_VERSION });
     await server.listen({ port: 0, host: "127.0.0.1" });
     port = (server.addresses()[0] as { port: number }).port;
     reviewer = createReviewer({

--- a/packages/app/src/main/review.ts
+++ b/packages/app/src/main/review.ts
@@ -1,6 +1,6 @@
 import type { FileCheckoff, NewQuestion, PrFile, PrSummary, PrView } from "@gander/shared";
 import type { GitEngine } from "./git.js";
-import type { ServiceClient } from "./service-client.js";
+import { ServiceConnectionError, STALE_SERVICE_DATA_WRITE_ERROR, type ServiceClient } from "./service-client.js";
 import type { ImagePreview, ImageSide } from "../image-preview.js";
 
 export interface ReviewerDeps {
@@ -23,11 +23,35 @@ export interface Reviewer {
   imagePreview(repoId: string, prNumber: number, path: string): Promise<ImagePreview>;
 }
 
-interface CacheEntry { view: PrView; headSha: string; clone: string; mergeBase: string; }
+interface CacheEntry {
+  view: PrView;
+  headSha: string;
+  clone: string;
+  mergeBase: string;
+  /** False after a service failure until an authoritative read replaces service-owned state. */
+  serviceStateFresh: boolean;
+}
 
 export function createReviewer(deps: ReviewerDeps): Reviewer {
   const cache = new Map<string, CacheEntry>();
   const key = (repoId: string, prNumber: number): string => `${repoId}#${prNumber}`;
+
+  async function useCachedViewOnConnectionFailure(
+    repoId: string,
+    prNumber: number,
+    load: () => Promise<PrView>,
+  ): Promise<PrView> {
+    try {
+      return await load();
+    } catch (err) {
+      const cached = cache.get(key(repoId, prNumber));
+      if (err instanceof ServiceConnectionError && cached) {
+        cached.serviceStateFresh = false;
+        return cached.view;
+      }
+      throw err;
+    }
+  }
 
   /** Re-derives checked/changedSince for the already-fetched `files` against the latest service state, without re-reading any blobs. */
   function applyServiceState(files: PrFile[], state: { files: FileCheckoff[] }): PrFile[] {
@@ -95,7 +119,7 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     await Promise.all([write(pr), ...siblings.map(write)]);
   }
 
-  async function openPr(repoId: string, prNumber: number): Promise<PrView> {
+  async function loadPr(repoId: string, prNumber: number): Promise<PrView> {
     const all = await deps.listPrs(repoId);
     const pr = all.find((p) => p.number === prNumber);
     if (!pr) throw new Error(`PR #${prNumber} not open on ${repoId}`);
@@ -113,11 +137,15 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     const files = await computeFiles(repoId, prNumber, clone, mergeBase, head);
     const questions = await deps.service.listQuestions(repoId, prNumber);
     const view: PrView = { pr, files, questions };
-    cache.set(key(repoId, prNumber), { view, headSha: head, clone, mergeBase });
+    cache.set(key(repoId, prNumber), { view, headSha: head, clone, mergeBase, serviceStateFresh: true });
     return view;
   }
 
-  async function refreshPr(repoId: string, prNumber: number): Promise<PrView> {
+  async function openPr(repoId: string, prNumber: number): Promise<PrView> {
+    return useCachedViewOnConnectionFailure(repoId, prNumber, () => loadPr(repoId, prNumber));
+  }
+
+  async function loadRefresh(repoId: string, prNumber: number): Promise<PrView> {
     const all = await deps.listPrs(repoId);
     const pr = all.find((p) => p.number === prNumber);
     if (!pr) throw new Error(`PR #${prNumber} not open on ${repoId}`);
@@ -138,7 +166,7 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
       const files = applyServiceState(cached.view.files, state);
       const questions = await deps.service.listQuestions(repoId, prNumber);
       const view: PrView = { pr, files, questions };
-      cache.set(key(repoId, prNumber), { ...cached, view });
+      cache.set(key(repoId, prNumber), { ...cached, view, serviceStateFresh: true });
       return view;
     }
 
@@ -148,46 +176,67 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     const files = await computeFiles(repoId, prNumber, clone, mergeBase, head);
     const questions = await deps.service.listQuestions(repoId, prNumber);
     const view: PrView = { pr, files, questions };
-    cache.set(key(repoId, prNumber), { view, headSha: head, clone, mergeBase });
+    cache.set(key(repoId, prNumber), { view, headSha: head, clone, mergeBase, serviceStateFresh: true });
     return view;
+  }
+
+  async function refreshPr(repoId: string, prNumber: number): Promise<PrView> {
+    return useCachedViewOnConnectionFailure(repoId, prNumber, () => loadRefresh(repoId, prNumber));
   }
 
   async function applyChecked(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView> {
     const entry = cache.get(key(repoId, prNumber));
     if (!entry) throw new Error(`PR #${prNumber} on ${repoId} must be opened before checking files`);
+    if (!entry.serviceStateFresh) {
+      throw new ServiceConnectionError(STALE_SERVICE_DATA_WRITE_ERROR);
+    }
     const { view } = entry;
     for (const path of paths) {
       const file = view.files.find((f) => f.path === path);
       if (!file) throw new Error(`${path} is not part of PR #${prNumber}`);
       if (checked) {
-        await deps.service.putFileState(repoId, prNumber, {
+        await writeServiceState(entry, () => deps.service.putFileState(repoId, prNumber, {
           checked: true, path,
           baseHash: file.baseHash, headHash: file.headHash,
           baseContent: file.baseContent, headContent: file.headContent,
           machine: deps.machine,
-        });
+        }));
         file.checked = true;
         file.changedSince = false;
       } else {
-        await deps.service.putFileState(repoId, prNumber, { checked: false, path });
+        await writeServiceState(entry, () => deps.service.putFileState(repoId, prNumber, { checked: false, path }));
         file.checked = false;
       }
     }
     return view;
   }
 
-  function requireOpen(repoId: string, prNumber: number): PrView {
+  function requireWritable(repoId: string, prNumber: number): CacheEntry {
     const entry = cache.get(key(repoId, prNumber));
     if (!entry) throw new Error(`PR #${prNumber} on ${repoId} must be opened first`);
-    return entry.view;
+    if (!entry.serviceStateFresh) {
+      throw new ServiceConnectionError(STALE_SERVICE_DATA_WRITE_ERROR);
+    }
+    return entry;
+  }
+
+  async function writeServiceState<T>(entry: CacheEntry, write: () => Promise<T>): Promise<T> {
+    try {
+      return await write();
+    } catch (err) {
+      if (err instanceof ServiceConnectionError) entry.serviceStateFresh = false;
+      throw err;
+    }
   }
 
   return {
     openPr,
     refreshPr,
     async addQuestion(repoId, prNumber, input) {
-      const view = requireOpen(repoId, prNumber);
-      view.questions = [...view.questions, await deps.service.addQuestion(repoId, prNumber, { ...input, headSha: view.pr.headSha })];
+      const entry = requireWritable(repoId, prNumber);
+      const { view } = entry;
+      const question = await writeServiceState(entry, () => deps.service.addQuestion(repoId, prNumber, { ...input, headSha: view.pr.headSha }));
+      view.questions = [...view.questions, question];
       return view;
     },
     async reviewedSnapshot(repoId, prNumber, path) {
@@ -208,16 +257,18 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
       return { base, head };
     },
     async addReviewerReply(repoId, prNumber, id, text) {
-      const view = requireOpen(repoId, prNumber);
+      const entry = requireWritable(repoId, prNumber);
+      const { view } = entry;
       const question = view.questions.find((q) => q.id === id);
       if (!question) throw new Error(`Question ${id} is not part of PR #${prNumber}`);
-      const reply = await deps.service.addReviewerReply(repoId, prNumber, id, text);
+      const reply = await writeServiceState(entry, () => deps.service.addReviewerReply(repoId, prNumber, id, text));
       question.replies = [...question.replies, reply];
       return view;
     },
     async deleteQuestion(repoId, prNumber, id) {
-      const view = requireOpen(repoId, prNumber);
-      await deps.service.deleteQuestion(repoId, prNumber, id);
+      const entry = requireWritable(repoId, prNumber);
+      const { view } = entry;
+      await writeServiceState(entry, () => deps.service.deleteQuestion(repoId, prNumber, id));
       view.questions = view.questions.filter((q) => q.id !== id);
       return view;
     },

--- a/packages/app/src/main/service-client.ts
+++ b/packages/app/src/main/service-client.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import { FileCheckoffSchema, QuestionReplySchema, QuestionSchema, ReviewStateSchema, type FileCheckoff, type NewQuestion, type PrContext, type PutFileState, type Question, type QuestionReply, type ReviewState } from "@gander/shared";
+import { checkServiceStatus, type ServiceStatus } from "./connection.js";
+
+export class ServiceConnectionError extends Error {}
+export const STALE_SERVICE_DATA_WRITE_ERROR = "This review is showing cached service data. Refresh it after the service reconnects before making changes. This change was not saved and will not be retried.";
 
 export interface ServiceClient {
   getReview(repoId: string, prNumber: number): Promise<ReviewState>;
@@ -10,8 +14,8 @@ export interface ServiceClient {
   deleteQuestion(repoId: string, prNumber: number, id: number): Promise<void>;
   setPrContext(repoId: string, prNumber: number, context: PrContext): Promise<void>;
   getSnapshot(repoId: string, prNumber: number, path: string): Promise<{ baseContent: string | null; headContent: string | null }>;
-  /** Whether the service answers at all. Never throws — unreachable is an answer, not a failure. */
-  healthy(): Promise<boolean>;
+  /** Reachability and API compatibility. Never throws — connection failure is a status. */
+  status(): Promise<ServiceStatus>;
 }
 
 const SnapshotSchema = z.object({
@@ -27,15 +31,65 @@ const SnapshotSchema = z.object({
 export type Connection = () => { url: string; token: string };
 
 export function createServiceClient(connection: Connection): ServiceClient {
-  const req = async (method: string, path: string, body?: unknown): Promise<unknown> => {
+  let checkedConnection: { url: string; status: ServiceStatus } | null = null;
+  let recoveryReadRequired = false;
+  const reviewsReadSinceRecovery = new Set<string>();
+  const reviewKey = (repoId: string, prNumber: number): string => `${repoId}#${prNumber}`;
+
+  function requireRecoveryReads(): void {
+    recoveryReadRequired = true;
+    reviewsReadSinceRecovery.clear();
+  }
+
+  async function serviceStatus(): Promise<ServiceStatus> {
+    const { url } = connection();
+    const connectionChanged = checkedConnection !== null && checkedConnection.url !== url;
+    const status = await checkServiceStatus(url);
+    checkedConnection = { url, status };
+    if (connectionChanged || status.state === "unreachable" || status.state === "incompatible") requireRecoveryReads();
+    return status;
+  }
+
+  async function ensureCompatible(baseUrl: string): Promise<void> {
+    const cached = checkedConnection?.url === baseUrl ? checkedConnection.status : null;
+    // A later explicit action is a new connection attempt, not a retry of the failed
+    // write. Re-probing here is what lets the app recover as soon as the service returns.
+    const status = cached?.state === "connected" || cached?.state === "newer"
+      ? cached
+      : await serviceStatus();
+    if (status.state === "unreachable") throw new ServiceConnectionError(status.reason);
+    if (status.state === "incompatible") throw new ServiceConnectionError(status.reason);
+  }
+
+  const req = async (
+    method: string,
+    path: string,
+    body?: unknown,
+    options: { allowBeforeRecoveryRead?: boolean; reviewKey?: string } = {},
+  ): Promise<unknown> => {
     const { url: baseUrl, token } = connection();
     if (baseUrl === "") throw new Error("No Gander service configured — set the service URL and token in Settings");
+    try {
+      await ensureCompatible(baseUrl);
+    } catch (err) {
+      if (err instanceof ServiceConnectionError && method !== "GET") {
+        throw new ServiceConnectionError(`${err.message} This change was not saved and will not be retried.`);
+      }
+      throw err;
+    }
+    if (method !== "GET" && recoveryReadRequired && !options.allowBeforeRecoveryRead
+      && (options.reviewKey === undefined || !reviewsReadSinceRecovery.has(options.reviewKey))) {
+      throw new ServiceConnectionError(STALE_SERVICE_DATA_WRITE_ERROR);
+    }
     const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
     let res: Response;
     try {
       res = await fetch(`${baseUrl}${path}`, { method, headers, body: body === undefined ? undefined : JSON.stringify(body) });
     } catch (err) {
-      throw new Error(`Gander service unreachable at ${baseUrl}: ${(err as Error).message}`);
+      checkedConnection = { url: baseUrl, status: { state: "unreachable", reason: `Could not reach ${baseUrl}: ${(err as Error).message}` } };
+      requireRecoveryReads();
+      const consequence = method === "GET" ? "" : " This change was not saved and will not be retried.";
+      throw new ServiceConnectionError(`Gander service unreachable at ${baseUrl}: ${(err as Error).message}.${consequence}`);
     }
     if (!res.ok) throw new Error(`Gander service ${res.status} on ${method} ${baseUrl}${path}: ${await res.text()}`);
     // 204 has no body — reading it as JSON would throw on a successful delete.
@@ -57,11 +111,13 @@ export function createServiceClient(connection: Connection): ServiceClient {
   return {
     getReview: async (repoId, prNumber) => {
       const path = `/api/reviews/${enc(repoId)}/${prNumber}`;
-      return validate(ReviewStateSchema, path, await req("GET", path));
+      const review = validate(ReviewStateSchema, path, await req("GET", path));
+      reviewsReadSinceRecovery.add(reviewKey(repoId, prNumber));
+      return review;
     },
     putFileState: async (repoId, prNumber, input) => {
       const path = `/api/reviews/${enc(repoId)}/${prNumber}/files`;
-      return validate(FileCheckoffSchema, path, await req("PUT", path, input));
+      return validate(FileCheckoffSchema, path, await req("PUT", path, input, { reviewKey: reviewKey(repoId, prNumber) }));
     },
     listQuestions: async (repoId, prNumber) => {
       const path = `/api/reviews/${enc(repoId)}/${prNumber}/questions`;
@@ -69,31 +125,24 @@ export function createServiceClient(connection: Connection): ServiceClient {
     },
     addQuestion: async (repoId, prNumber, input) => {
       const path = `/api/reviews/${enc(repoId)}/${prNumber}/questions`;
-      return validate(QuestionSchema, path, await req("POST", path, input));
+      return validate(QuestionSchema, path, await req("POST", path, input, { reviewKey: reviewKey(repoId, prNumber) }));
     },
     addReviewerReply: async (repoId, prNumber, id, text) => {
       const path = `/api/reviews/${enc(repoId)}/${prNumber}/questions/${id}/replies`;
-      return validate(QuestionReplySchema, path, await req("POST", path, { text }));
+      return validate(QuestionReplySchema, path, await req("POST", path, { text }, { reviewKey: reviewKey(repoId, prNumber) }));
     },
     deleteQuestion: async (repoId, prNumber, id) => {
-      await req("DELETE", `/api/reviews/${enc(repoId)}/${prNumber}/questions/${id}`);
+      await req("DELETE", `/api/reviews/${enc(repoId)}/${prNumber}/questions/${id}`, undefined, { reviewKey: reviewKey(repoId, prNumber) });
     },
-    healthy: async () => {
-      const { url } = connection();
-      if (url === "") return false;
-      try {
-        const res = await fetch(`${url}/healthz`);
-        return res.ok;
-      } catch {
-        return false;
-      }
-    },
+    status: serviceStatus,
     getSnapshot: async (repoId, prNumber, path) => {
       const url = `/api/reviews/${enc(repoId)}/${prNumber}/snapshot?path=${enc(path)}`;
       return validate(SnapshotSchema, url, await req("GET", url));
     },
     setPrContext: async (repoId, prNumber, context) => {
-      await req("PUT", `/api/reviews/${enc(repoId)}/${prNumber}/context`, context);
+      // Refresh records derived GitHub context before reading authored review state. It
+      // never copies cached authored data, so it is safe on the recovery path.
+      await req("PUT", `/api/reviews/${enc(repoId)}/${prNumber}/context`, context, { allowBeforeRecoveryRead: true });
     },
   };
 }

--- a/packages/app/src/preload/api.ts
+++ b/packages/app/src/preload/api.ts
@@ -67,7 +67,7 @@ export function createGanderApi(
     lastReview: () => call("lastReview"),
     initialTarget: () => call("initialTarget"),
     onOpenTarget: (listener) => subscribe("gander:openTarget", (target: OpenTarget) => listener(target)),
-    serviceHealthy: () => call("serviceHealthy"),
+    serviceStatus: () => call("serviceStatus"),
     openPr: (repoId, prNumber) => call("openPr", repoId, prNumber),
     setChecked: (repoId, prNumber, path, checked) => call("setChecked", repoId, prNumber, path, checked),
     setCheckedMany: (repoId, prNumber, paths, checked) => call("setCheckedMany", repoId, prNumber, paths, checked),

--- a/packages/app/src/renderer/src/components/ConnectionSettings.vue
+++ b/packages/app/src/renderer/src/components/ConnectionSettings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, shallowRef } from "vue";
 import { api, type ConnectionCheck, type GithubTokenCheck } from "../api.js";
 import { Loader2 } from "lucide-vue-next";
 
@@ -15,15 +15,15 @@ const emit = defineEmits<{ connected: [] }>();
  * editable as JSON inside the app, and a token does not belong on screen in a text editor.
  */
 
-const url = ref("");
-const token = ref("");
-const fromEnvironment = ref(false);
-const busy = ref(false);
-const result = ref<ConnectionCheck | null>(null);
+const url = shallowRef("");
+const token = shallowRef("");
+const fromEnvironment = shallowRef(false);
+const busy = shallowRef(false);
+const result = shallowRef<ConnectionCheck | null>(null);
 
-const githubToken = ref("");
-const githubBusy = ref(false);
-const githubResult = ref<GithubTokenCheck | null>(null);
+const githubToken = shallowRef("");
+const githubBusy = shallowRef(false);
+const githubResult = shallowRef<GithubTokenCheck | null>(null);
 
 onMounted(async () => {
   const current = await api.getConnection();
@@ -105,8 +105,18 @@ async function run(action: "test" | "save"): Promise<void> {
       <span v-if="busy" class="working"><Loader2 :size="13" class="spin" />Reaching the service…</span>
       <!-- Saving tests first and keeps nothing that failed, so the only outcomes worth
            reporting are "connected" and the reason it is not. -->
-      <span v-if="result" class="result" :class="{ bad: !result.ok }" role="status" aria-live="polite">
-        {{ result.ok ? `Connected to Gander ${result.version}` : result.reason }}
+      <span
+        v-if="result"
+        class="result"
+        :class="{ bad: !result.ok, warning: result.ok && result.compatibility === 'newer' }"
+        role="status"
+        aria-live="polite"
+      >
+        {{ result.ok
+          ? (result.compatibility === "newer"
+            ? `Connected with warning: service ${result.version} is newer than this app`
+            : `Connected to Gander ${result.version}`)
+          : result.reason }}
       </span>
     </div>
 
@@ -169,5 +179,6 @@ button:disabled { opacity: .55; cursor: default; }
 .spin { animation: spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .result.bad { color: var(--red, #e06c75); }
+.result.warning { color: var(--warning); }
 code { font-family: var(--mono, monospace); font-size: 11px; }
 </style>

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -34,7 +34,7 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
     view,
     selectedPath: view.files[0]!.path,
     error: null,
-    serviceReachable: true,
+    serviceStatus: { state: "connected", serviceVersion: "0.1.0", supportedVersion: "0.1.0" },
     lastFetchAt: null,
     busy: false,
     async loadRepos() {},

--- a/packages/app/src/renderer/src/components/StatusBar.test.ts
+++ b/packages/app/src/renderer/src/components/StatusBar.test.ts
@@ -2,11 +2,12 @@
 
 import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
+import { reactive } from "vue";
 import type { Store } from "../store.js";
 import StatusBar from "./StatusBar.vue";
 
 const store = {
-  serviceReachable: true,
+  serviceStatus: { state: "connected", serviceVersion: "0.1.0", supportedVersion: "0.1.0" },
   view: null,
   lastFetchAt: null,
   busy: false,
@@ -44,6 +45,30 @@ describe("StatusBar", () => {
     expect(wrapper.get(".development-kind").text()).toBe("DEV");
     expect(wrapper.get(".worktree-label").text()).toBe("· feature/review-status");
     expect(wrapper.get(".development").attributes("title")).toBe("Development build · feature/review-status");
+
+    wrapper.unmount();
+  });
+
+  it("makes cached offline reads and both version-skew policies visible", async () => {
+    const mutableStore = reactive({
+      ...store,
+      view: { pr: { number: 1 }, files: [], questions: [] },
+      serviceStatus: { state: "unreachable", reason: "connection refused" },
+    }) as unknown as Store;
+    const wrapper = mount(StatusBar, {
+      props: { store: mutableStore, treeVisible: true, isDevelopment: false, worktreeLabel: null, zoomLevel: 0 },
+    });
+    expect(wrapper.get(".service").text()).toContain("showing cached review");
+    expect(wrapper.get(".service").attributes("title")).toBe("connection refused");
+
+    mutableStore.serviceStatus = { state: "incompatible", serviceVersion: "0.0.9", supportedVersion: "0.1.0", reason: "update service" };
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get(".service").text()).toContain("too old · update to 0.1.0");
+
+    mutableStore.serviceStatus = { state: "newer", serviceVersion: "0.2.0", supportedVersion: "0.1.0" };
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get(".service").text()).toContain("newer · app supports 0.1.0");
+    expect(wrapper.get(".service").classes()).toContain("warning");
 
     wrapper.unmount();
   });

--- a/packages/app/src/renderer/src/components/StatusBar.vue
+++ b/packages/app/src/renderer/src/components/StatusBar.vue
@@ -21,6 +21,20 @@ const developmentLabel = computed(() => props.worktreeLabel
   ? `Development build · ${props.worktreeLabel}`
   : "Development build");
 
+const serviceLabel = computed(() => {
+  const status = props.store.serviceStatus;
+  if (status.state === "connected") return `Service connected · ${status.serviceVersion}`;
+  if (status.state === "newer") return `Service ${status.serviceVersion} is newer · app supports ${status.supportedVersion}`;
+  if (status.state === "incompatible") return `Service ${status.serviceVersion} is too old · update to ${status.supportedVersion}`;
+  return props.store.view ? "Service unreachable · showing cached review" : "Service unreachable";
+});
+const serviceTitle = computed(() => {
+  const status = props.store.serviceStatus;
+  return status.state === "unreachable" || status.state === "incompatible"
+    ? status.reason
+    : serviceLabel.value;
+});
+
 // Re-read on a timer so "3 minutes ago" does not sit frozen at "just now".
 const now = ref(Date.now());
 const tick = setInterval(() => { now.value = Date.now(); }, 15_000);
@@ -50,9 +64,14 @@ const lastFetch = computed(() => {
       <PanelLeft :size="14" />
     </button>
 
-    <span class="service" :class="{ down: !store.serviceReachable }">
+    <span
+      class="service"
+      :class="{ down: store.serviceStatus.state === 'unreachable' || store.serviceStatus.state === 'incompatible', warning: store.serviceStatus.state === 'newer' }"
+      :title="serviceTitle"
+      role="status"
+    >
       <span class="dot" />
-      {{ store.serviceReachable ? "Service connected" : "Service unreachable" }}
+      <span class="service-label">{{ serviceLabel }}</span>
     </span>
 
     <span v-if="store.view" class="sep">·</span>
@@ -81,10 +100,13 @@ const lastFetch = computed(() => {
 .status { display: flex; align-items: center; gap: 8px; height: 24px; padding: 0 10px; background: var(--panel-background); border-top: 1px solid var(--workbench-border); font-size: 11px; color: var(--faint-foreground); flex: none; }
 .toggle { display: flex; align-items: center; background: none; border: none; color: var(--faint-foreground); cursor: pointer; padding: 0 2px; }
 .toggle:hover, .toggle[aria-pressed="true"] { color: var(--workbench-foreground); }
-.service { display: flex; align-items: center; gap: 5px; }
+.service { display: flex; align-items: center; gap: 5px; min-width: 0; max-width: min(50vw, 62ch); }
+.service-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success); flex: none; }
 .service.down { color: var(--danger); }
 .service.down .dot { background: var(--danger); }
+.service.warning { color: var(--warning); }
+.service.warning .dot { background: var(--warning); }
 .spacer { flex: 1; }
 .working { color: var(--muted-foreground); }
 .development { display: flex; align-items: center; gap: 4px; min-width: 0; max-width: 32ch; color: var(--warning); }

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -33,10 +33,10 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     initialTarget: async () => null,
     getConnection: async () => ({ url: "http://service", token: "t", githubToken: "", fromEnvironment: false }),
     setGithubToken: async () => ({ ok: true as const, login: "octocat" }),
-    testConnection: async () => ({ ok: true, version: "test" }),
-    setConnection: async () => ({ ok: true, version: "test" }),
+    testConnection: async () => ({ ok: true, version: "0.1.0", compatibility: "compatible" }),
+    setConnection: async () => ({ ok: true, version: "0.1.0", compatibility: "compatible" }),
     onOpenTarget: () => () => {},
-    serviceHealthy: async () => true,
+    serviceStatus: async () => ({ state: "connected", serviceVersion: "0.1.0", supportedVersion: "0.1.0" }),
     reviewedSnapshot: async () => null,
     imagePreview: async () => ({ base: { kind: "absent" }, head: { kind: "absent" } }),
     addQuestion: async () => prView(),
@@ -281,10 +281,28 @@ describe("store", () => {
       expect(store.lastFetchAt).not.toBeNull();
     });
 
-    it("reports the service as unreachable when the health check fails", async () => {
-      const store = createStore(fakeApi({ serviceHealthy: async () => false }));
+    it("records the service handshake state", async () => {
+      const store = createStore(fakeApi({ serviceStatus: async () => ({ state: "unreachable", reason: "network down" }) }));
       await store.checkService();
-      expect(store.serviceReachable).toBe(false);
+      expect(store.serviceStatus).toEqual({ state: "unreachable", reason: "network down" });
+    });
+
+    it("shows cached mode immediately when refresh falls back while the service is down", async () => {
+      let status: "connected" | "unreachable" = "connected";
+      const store = createStore(fakeApi({
+        refreshPr: async () => prView(),
+        serviceStatus: async () => status === "connected"
+          ? { state: "connected", serviceVersion: "0.1.0", supportedVersion: "0.1.0" }
+          : { state: "unreachable", reason: "network down" },
+      }));
+      await store.loadRepos();
+      await store.selectRepo("acme/atlas");
+      await store.openPr(1);
+
+      status = "unreachable";
+      await store.refresh();
+      expect(store.view?.files).toHaveLength(2);
+      expect(store.serviceStatus).toEqual({ state: "unreachable", reason: "network down" });
     });
   });
 });

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -2,6 +2,7 @@ import { reactive } from "vue";
 import type { OpenTarget, PrSummary, PrView, RepoEntry } from "@gander/shared";
 import type { GanderApi, GithubRepository } from "./api.js";
 import type { ImagePreview } from "../../api.js";
+import type { ServiceStatus } from "../../api.js";
 
 export interface Store {
   repos: RepoEntry[];
@@ -13,8 +14,8 @@ export interface Store {
   view: PrView | null;
   selectedPath: string | null;
   error: string | null;
-  /** Whether the review service answered its last health check. */
-  serviceReachable: boolean;
+  /** Reachability and compatibility from the service's version handshake. */
+  serviceStatus: ServiceStatus;
   /** When the pull request was last fetched from origin, as an ISO string. */
   lastFetchAt: string | null;
   /** True while a long-running main-process action (openPr, refresh, addRepo, selectRepo) is in flight. Not for setChecked/setCheckedMany — those are near-instant and shouldn't flicker a "busy" indicator. */
@@ -55,7 +56,7 @@ export function createStore(api: GanderApi): Store {
     view: null,
     selectedPath: null,
     error: null,
-    serviceReachable: true,
+    serviceStatus: { state: "unreachable", reason: "Checking the Gander service…" },
     lastFetchAt: null,
     busy: false,
 
@@ -76,7 +77,7 @@ export function createStore(api: GanderApi): Store {
       }
     },
     async checkService() {
-      store.serviceReachable = await api.serviceHealthy();
+      store.serviceStatus = await api.serviceStatus();
     },
     dismissError() {
       store.error = null;
@@ -120,6 +121,7 @@ export function createStore(api: GanderApi): Store {
         store.selectedPath = null;
         if (target.prNumber === null) return;
         store.view = await api.openPr(target.repoId, target.prNumber);
+        await store.checkService();
         store.selectedPath = store.view.files[0]?.path ?? null;
         store.lastFetchAt = new Date().toISOString();
       })));
@@ -136,6 +138,7 @@ export function createStore(api: GanderApi): Store {
       await userAction(() => withBusy(() => guard(async () => {
         if (!store.currentRepoId) throw new Error("no repo selected");
         store.view = await api.openPr(store.currentRepoId, prNumber);
+        await store.checkService();
         store.selectedPath = store.view.files[0]?.path ?? null;
         store.lastFetchAt = new Date().toISOString();
       })));
@@ -144,6 +147,7 @@ export function createStore(api: GanderApi): Store {
       await withBusy(() => guard(async () => {
         if (!store.currentRepoId || !store.view) return;
         store.view = await api.refreshPr(store.currentRepoId, store.view.pr.number);
+        await store.checkService();
         store.lastFetchAt = new Date().toISOString();
       }));
     },
@@ -205,6 +209,9 @@ export function createStore(api: GanderApi): Store {
       await fn();
     } catch (err) {
       store.error = (err as Error).message;
+      // Failed service writes already surface above; update the persistent status too.
+      // This is only a health read, never a retry of the authored-state mutation.
+      await store.checkService();
     }
   }
 

--- a/packages/service/src/main.ts
+++ b/packages/service/src/main.ts
@@ -1,5 +1,6 @@
 import { openStorage } from "./storage.js";
 import { buildServer } from "./server.js";
+import { SERVICE_VERSION } from "@gander/shared";
 
 const port = Number(process.env.GANDER_PORT ?? 8390);
 const host = process.env.GANDER_HOST ?? "127.0.0.1";
@@ -8,5 +9,5 @@ const token = process.env.GANDER_TOKEN;
 if (!token) { console.error("GANDER_TOKEN is required"); process.exit(1); }
 
 const storage = openStorage(dbPath);
-const server = buildServer({ storage, token, version: "0.1.0" });
+const server = buildServer({ storage, token, version: SERVICE_VERSION });
 server.listen({ port, host }).then(() => console.log(`gander service on http://${host}:${port}`));

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+/** The service API version this workspace implements and the desktop app understands. */
+export const SERVICE_VERSION = "0.1.0";
+
 export const FileStatusSchema = z.enum(["A", "M", "D", "R"]);
 export type FileStatus = z.infer<typeof FileStatusSchema>;
 


### PR DESCRIPTION
## Summary

- keep an already-open review readable from its in-memory cache when the review service becomes unavailable
- fail authored-state writes visibly without queueing or retrying them, and require an authoritative refresh before cached state can write after recovery or a service change
- compare the service API version from `/healthz`, blocking older services and warning while allowing newer services
- surface unreachable, cached, incompatible, and newer-service states in the status bar and connection settings

## Readiness

- Simplify: clean
- Code review: clean; four ownership and recovery findings fixed
- Adversarial review: three rounds, no remaining findings
- Impeccable UI detector: clean
- Regression proof: focused cache and compatibility tests failed with their implementations disabled, then passed after restoration

## Test plan

- `pnpm typecheck` — passed across all three packages
- `pnpm test` — passed, 41 files / 285 tests
- `pnpm test:e2e` — invoked once; production build passed, then the shared Electron/WebDriver harness failed before any spec ran because Electron exited without creating `DevToolsActivePort`. Not retried per the issue delivery instructions.

Closes #44
