### PR TITLE
Show review progress in the Reviewing dropdown

### DIFF
--- a/packages/app/e2e/app.e2e.ts
+++ b/packages/app/e2e/app.e2e.ts
@@ -395,6 +395,10 @@ describe("Gander end to end", () => {
     await checkbox.click();
     await expect(checkbox).toHaveAttribute("aria-checked", "true");
     await expect($(".progress")).toHaveText("1/2 reviewed");
+    await $(".seg-review").click();
+    const currentReviewRow = await $(`//div[@role='option'][contains(normalize-space(.), 'Persist reviewed files')]`);
+    await expect(currentReviewRow.$(".review-progress")).toHaveText("1/2 reviewed");
+    await browser.keys("Escape");
 
     await browser.reloadSession();
 

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -1,4 +1,4 @@
-import type { NewQuestion, OpenTarget, PrSummary, PrView, RepoEntry } from "@gander/shared";
+import type { NewQuestion, OpenTarget, PrListItem, PrView, RepoEntry } from "@gander/shared";
 import type { AppSettings } from "./settings.js";
 import type { ThemeId } from "./themes.js";
 import type { ConnectionCheck } from "./main/connection.js";
@@ -35,7 +35,7 @@ export interface GanderApi {
   /** All non-archived repositories visible to the current GitHub credential. */
   listGithubRepos(): Promise<GithubRepository[]>;
   addRepo(url: string): Promise<RepoEntry>;
-  listPrs(repoId: string): Promise<PrSummary[]>;
+  listPrs(repoId: string): Promise<PrListItem[]>;
   lastReview(): Promise<{ repoId: string; prNumber: number } | null>;
   /** What this launch was asked to open, from the command line. Null for an ordinary launch. */
   initialTarget(): Promise<OpenTarget | null>;

--- a/packages/app/src/main/git.ts
+++ b/packages/app/src/main/git.ts
@@ -44,6 +44,8 @@ export interface ShowFileResult {
 export interface GitEngine {
   ensureClone(repoId: string, url: string): Promise<string>;
   fetchPr(cloneDir: string, prNumber: number, baseRef: string): Promise<void>;
+  /** Fetch several pull request heads and their base branches in one network operation. */
+  fetchPrs(cloneDir: string, prs: Array<{ number: number; baseRef: string }>): Promise<void>;
   mergeBase(cloneDir: string, a: string, b: string): Promise<string>;
   diffFiles(cloneDir: string, base: string, head: string): Promise<Array<{ path: string; status: FileStatus }>>;
   showFile(cloneDir: string, rev: string, path: string): Promise<ShowFileResult>;
@@ -147,6 +149,15 @@ export function createGitEngine(clonesRoot: string): GitEngine {
     return dir;
   }
 
+  async function fetchPrs(cloneDir: string, prs: Array<{ number: number; baseRef: string }>): Promise<void> {
+    const bases = [...new Set(prs.map((pr) => pr.baseRef))];
+    await git(cloneDir, [
+      "fetch", "--force", "origin",
+      ...prs.map((pr) => `+refs/pull/${pr.number}/head:refs/gander/pr/${pr.number}`),
+      ...bases.map((baseRef) => `+refs/heads/${baseRef}:refs/gander/base/${baseRef}`),
+    ], FETCH_TIMEOUT_MS);
+  }
+
   return {
     async ensureClone(repoId, url) {
       const dir = join(clonesRoot, repoId.replace("/", "__") + ".git");
@@ -161,12 +172,10 @@ export function createGitEngine(clonesRoot: string): GitEngine {
     },
 
     async fetchPr(cloneDir, prNumber, baseRef) {
-      await git(cloneDir, [
-        "fetch", "--force", "origin",
-        `+refs/pull/${prNumber}/head:refs/gander/pr/${prNumber}`,
-        `+refs/heads/${baseRef}:refs/gander/base/${baseRef}`,
-      ], FETCH_TIMEOUT_MS);
+      await fetchPrs(cloneDir, [{ number: prNumber, baseRef }]);
     },
+
+    fetchPrs,
 
     async mergeBase(cloneDir, a, b) {
       return (await git(cloneDir, ["merge-base", a, b])).trim();

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -47,7 +47,7 @@ async function bootstrap(): Promise<GanderConfig> {
     if (!cfg.repos.some((r) => r.repoId === entry.repoId)) { cfg.repos.push(entry); saveConfig(cfg); }
     return entry;
   });
-  ipcMain.handle("gander:listPrs", async (_e, repoId: string) => listOpenPrs(repoId, await githubToken()));
+  ipcMain.handle("gander:listPrs", async (_e, repoId: string) => reviewer.listPrsWithProgress(repoId));
   ipcMain.handle("gander:serviceHealthy", async () => service.healthy());
   ipcMain.handle("gander:lastReview", async () => cfg.lastReview ?? null);
   ipcMain.handle("gander:initialTarget", async () => launchTarget);

--- a/packages/app/src/main/review.test.ts
+++ b/packages/app/src/main/review.test.ts
@@ -46,6 +46,50 @@ afterEach(async () => {
 const sha256 = (s: string): string => createHash("sha256").update(s).digest("hex");
 
 describe("review pipeline", () => {
+  it("derives menu progress from current file content with one batched fetch", async () => {
+    const beforeReview = await reviewer.listPrsWithProgress("acme/atlas");
+    expect(beforeReview[0]?.reviewProgress).toBeNull();
+
+    await reviewer.openPr("acme/atlas", 1);
+    await reviewer.setCheckedMany("acme/atlas", 1, ["a.rb", "b.rb"], true);
+
+    let batchFetches = 0;
+    let individualFetches = 0;
+    const baseEngine = createGitEngine(clonesRoot);
+    const countingEngine: GitEngine = {
+      ...baseEngine,
+      async fetchPr(clone, prNumber, baseRef) {
+        individualFetches += 1;
+        return baseEngine.fetchPr(clone, prNumber, baseRef);
+      },
+      async fetchPrs(clone, prs) {
+        batchFetches += 1;
+        return baseEngine.fetchPrs(clone, prs);
+      },
+    };
+    const summaries = createReviewer({
+      git: countingEngine,
+      service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
+      listPrs: async () => [await currentPr(fixture)],
+      repoUrl: () => fixture.dir,
+      machine: "test-machine",
+    });
+
+    expect((await summaries.listPrsWithProgress("acme/atlas"))[0]?.reviewProgress).toEqual({ done: 2, total: 2 });
+    expect(batchFetches).toBe(1);
+    expect(individualFetches).toBe(0);
+
+    await fixture.git(["checkout", "feature"]);
+    writeFileSync(join(fixture.dir, "a.rb"), "class A\n  def go; puts 1; end\nend\n");
+    await fixture.git(["add", "-A"]);
+    await fixture.git(["commit", "--amend", "-m", "change reviewed content"]);
+    await fixture.git(["update-ref", "refs/pull/1/head", await fixture.git(["rev-parse", "HEAD"])]);
+    await fixture.git(["checkout", "main"]);
+
+    expect((await summaries.listPrsWithProgress("acme/atlas"))[0]?.reviewProgress).toEqual({ done: 1, total: 2 });
+    expect(storage.getReview("acme/atlas", 1).files.find((file) => file.path === "a.rb")?.checked).toBe(false);
+  });
+
   it("openPr returns the PR's files with contents and unchecked state", async () => {
     const view = await reviewer.openPr("acme/atlas", 1);
     expect(view.pr.number).toBe(1);

--- a/packages/app/src/main/review.ts
+++ b/packages/app/src/main/review.ts
@@ -1,4 +1,4 @@
-import type { FileCheckoff, NewQuestion, PrFile, PrSummary, PrView } from "@gander/shared";
+import type { FileCheckoff, NewQuestion, PrFile, PrListItem, PrSummary, PrView, ReviewState } from "@gander/shared";
 import type { GitEngine } from "./git.js";
 import type { ServiceClient } from "./service-client.js";
 import type { ImagePreview, ImageSide } from "../image-preview.js";
@@ -11,6 +11,7 @@ export interface ReviewerDeps {
   machine: string;
 }
 export interface Reviewer {
+  listPrsWithProgress(repoId: string): Promise<PrListItem[]>;
   openPr(repoId: string, prNumber: number): Promise<PrView>;
   refreshPr(repoId: string, prNumber: number): Promise<PrView>;
   setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<PrView>;
@@ -48,9 +49,9 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     });
   }
 
-  async function computeFiles(repoId: string, prNumber: number, clone: string, mergeBase: string, head: string): Promise<PrFile[]> {
+  async function computeFiles(repoId: string, prNumber: number, clone: string, mergeBase: string, head: string, knownState?: ReviewState): Promise<PrFile[]> {
     const changed = await deps.git.diffFiles(clone, mergeBase, head);
-    const state = await deps.service.getReview(repoId, prNumber);
+    const state = knownState ?? await deps.service.getReview(repoId, prNumber);
 
     const raw: PrFile[] = [];
     for (const { path, status } of changed) {
@@ -183,6 +184,33 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
   }
 
   return {
+    async listPrsWithProgress(repoId) {
+      const [prs, reviews] = await Promise.all([
+        deps.listPrs(repoId),
+        deps.service.listReviews(repoId),
+      ]);
+      const states = new Map(reviews.map((review) => [review.prNumber, review]));
+      const started = prs.filter((pr) => states.get(pr.number)?.files.some(
+        (file) => file.baseHash !== null || file.headHash !== null,
+      ));
+      const progress = new Map<number, { done: number; total: number }>();
+
+      if (started.length > 0) {
+        const clone = await deps.git.ensureClone(repoId, deps.repoUrl(repoId));
+        // Pull request rows are a repository-level view. Fetch all reviewed heads in one
+        // operation instead of opening each pull request (and fetching it) in series.
+        await deps.git.fetchPrs(clone, started.map(({ number, baseRef }) => ({ number, baseRef })));
+        await Promise.all(started.map(async (pr) => {
+          const head = await deps.git.resolveRef(clone, `refs/gander/pr/${pr.number}`);
+          const base = await deps.git.resolveRef(clone, `refs/gander/base/${pr.baseRef}`);
+          const mergeBase = await deps.git.mergeBase(clone, base, head);
+          const files = await computeFiles(repoId, pr.number, clone, mergeBase, head, states.get(pr.number));
+          progress.set(pr.number, { done: files.filter((file) => file.checked).length, total: files.length });
+        }));
+      }
+
+      return prs.map((pr) => ({ ...pr, reviewProgress: progress.get(pr.number) ?? null }));
+    },
     openPr,
     refreshPr,
     async addQuestion(repoId, prNumber, input) {

--- a/packages/app/src/main/service-client.ts
+++ b/packages/app/src/main/service-client.ts
@@ -3,6 +3,7 @@ import { FileCheckoffSchema, QuestionReplySchema, QuestionSchema, ReviewStateSch
 
 export interface ServiceClient {
   getReview(repoId: string, prNumber: number): Promise<ReviewState>;
+  listReviews(repoId: string): Promise<ReviewState[]>;
   putFileState(repoId: string, prNumber: number, input: PutFileState): Promise<FileCheckoff>;
   listQuestions(repoId: string, prNumber: number): Promise<Question[]>;
   addQuestion(repoId: string, prNumber: number, input: NewQuestion): Promise<Question>;
@@ -58,6 +59,10 @@ export function createServiceClient(connection: Connection): ServiceClient {
     getReview: async (repoId, prNumber) => {
       const path = `/api/reviews/${enc(repoId)}/${prNumber}`;
       return validate(ReviewStateSchema, path, await req("GET", path));
+    },
+    listReviews: async (repoId) => {
+      const path = `/api/reviews/${enc(repoId)}`;
+      return validate(ReviewStateSchema.array(), path, await req("GET", path));
     },
     putFileState: async (repoId, prNumber, input) => {
       const path = `/api/reviews/${enc(repoId)}/${prNumber}/files`;

--- a/packages/app/src/renderer/src/components/ReviewProgress.vue
+++ b/packages/app/src/renderer/src/components/ReviewProgress.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { ReviewProgress } from "@gander/shared";
+import { Check } from "lucide-vue-next";
+
+defineProps<{ progress: ReviewProgress }>();
+</script>
+
+<template>
+  <span v-if="progress.done === progress.total" class="review-progress complete">
+    <Check :size="13" aria-hidden="true" />
+    Reviewed
+  </span>
+  <span v-else class="review-progress">{{ progress.done }}/{{ progress.total }} reviewed</span>
+</template>
+
+<style scoped>
+.review-progress {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: auto;
+  color: var(--muted-foreground);
+  font: 11px var(--mono);
+  white-space: nowrap;
+}
+.review-progress.complete { color: var(--success); }
+</style>

--- a/packages/app/src/renderer/src/components/ReviewingList.vue
+++ b/packages/app/src/renderer/src/components/ReviewingList.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { PrSummary } from "@gander/shared";
+import type { PrListItem } from "@gander/shared";
 import { Layers3 } from "lucide-vue-next";
 import StackPosition from "./StackPosition.vue";
+import ReviewProgress from "./ReviewProgress.vue";
 
-const props = defineProps<{ prs: PrSummary[] }>();
+const props = defineProps<{ prs: PrListItem[] }>();
 const emit = defineEmits<{ select: [prNumber: number] }>();
 
 type ReviewGroup =
-  | { kind: "standalone"; pr: PrSummary }
-  | { kind: "stack"; id: number; size: number; prs: PrSummary[] };
+  | { kind: "standalone"; pr: PrListItem }
+  | { kind: "stack"; id: number; size: number; prs: PrListItem[] };
 
 const groups = computed<ReviewGroup[]>(() => {
   const seenStacks = new Set<number>();
@@ -73,6 +74,7 @@ function select(prNumber: number): void {
           <span class="dot" :class="pr.draft ? 'draft' : 'open'" />
           <span class="num">#{{ pr.number }}</span>
           <span class="nm">{{ pr.title }}</span>
+          <ReviewProgress v-if="pr.reviewProgress" :progress="pr.reviewProgress" />
         </div>
       </div>
       <div
@@ -86,6 +88,7 @@ function select(prNumber: number): void {
         <span class="dot" :class="group.pr.draft ? 'draft' : 'open'" />
         <span class="num">#{{ group.pr.number }}</span>
         <span class="nm">{{ group.pr.title }}</span>
+        <ReviewProgress v-if="group.pr.reviewProgress" :progress="group.pr.reviewProgress" />
       </div>
     </template>
   </div>

--- a/packages/app/src/renderer/src/components/TopBar.test.ts
+++ b/packages/app/src/renderer/src/components/TopBar.test.ts
@@ -2,11 +2,11 @@
 
 import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
-import type { PrSummary } from "@gander/shared";
+import type { PrListItem, PrSummary, ReviewProgress } from "@gander/shared";
 import type { Store } from "../store.js";
 import TopBar from "./TopBar.vue";
 
-function pr(number: number, title: string, stack: PrSummary["stack"] = null): PrSummary {
+function pr(number: number, title: string, stack: PrSummary["stack"] = null, reviewProgress: ReviewProgress | null = null): PrListItem {
   return {
     number,
     title,
@@ -17,11 +17,12 @@ function pr(number: number, title: string, stack: PrSummary["stack"] = null): Pr
     baseSha: "base",
     headSha: `head-${number}`,
     stack,
+    reviewProgress,
   };
 }
 
 function storeWithProgress(done: number, total: number, options: {
-  prs?: PrSummary[];
+  prs?: PrListItem[];
   currentPr?: PrSummary;
   openPr?: Store["openPr"];
 } = {}): Store {
@@ -103,8 +104,8 @@ describe("TopBar", () => {
       props: {
         store: storeWithProgress(0, 0, {
           prs: [
-            pr(22, "Add the renderer", { ...stack, position: 2 }),
-            pr(30, "Independent change"),
+            { ...pr(22, "Add the renderer", { ...stack, position: 2 }, { done: 1, total: 4 }), draft: true },
+            pr(30, "Independent change", null, { done: 2, total: 2 }),
             pr(21, "Add the service", { ...stack, position: 1 }),
           ],
           openPr,
@@ -121,11 +122,16 @@ describe("TopBar", () => {
     expect(wrapper.findAll(".stack-group")).toHaveLength(1);
     expect(wrapper.findAll(".stack-group .sw-item").map((item) => item.text())).toEqual([
       "1/2#21Add the service",
-      "2/2#22Add the renderer",
+      "2/2#22Add the renderer1/4 reviewed",
     ]);
     expect(wrapper.findAll(".standalone-item").map((item) => item.text())).toEqual([
-      "#30Independent change",
+      "#30Independent change Reviewed",
     ]);
+    expect(wrapper.findAll(".review-progress")).toHaveLength(2);
+    expect(wrapper.get(".standalone-item .review-progress svg").attributes("aria-hidden")).toBe("true");
+    expect(wrapper.findAll(".dot")).toHaveLength(3);
+    expect(wrapper.findAll(".dot.draft")).toHaveLength(1);
+    expect(wrapper.findAll(".dot.open")).toHaveLength(2);
 
     await wrapper.findAll(".stack-group .sw-item")[1]!.trigger("keydown", { key: "Enter" });
     expect(openPr).toHaveBeenCalledWith(22);

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -24,9 +24,9 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     listRepos: async () => [{ repoId: "acme/atlas", url: "u" }],
     listGithubRepos: async () => [{ repoId: "acme/atlas", url: "https://github.com/acme/atlas", private: true }],
     addRepo: async (url) => ({ repoId: "acme/new", url }),
-    listPrs: async () => [{ number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" }],
+    listPrs: async () => [{ number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b", reviewProgress: null }],
     openPr: async () => prView(),
-    setChecked: async (_r, _n, path) => prView([path]),
+    setChecked: async (_r, _n, path, checked) => prView(checked ? [path] : []),
     setCheckedMany: async (_r, _n, paths) => prView(paths),
     refreshPr: async () => prView(),
     lastReview: async () => null,
@@ -98,6 +98,9 @@ describe("store", () => {
     expect(store.progress()).toEqual({ done: 0, total: 2 });
     await store.setChecked("a.rb", true);
     expect(store.progress()).toEqual({ done: 1, total: 2 });
+    expect(store.prs[0]?.reviewProgress).toEqual({ done: 1, total: 2 });
+    await store.setChecked("a.rb", false);
+    expect(store.prs[0]?.reviewProgress).toEqual({ done: 0, total: 2 });
   });
 
   it("loads GitHub repositories separately from registered repositories", async () => {

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -1,5 +1,5 @@
 import { reactive } from "vue";
-import type { OpenTarget, PrSummary, PrView, RepoEntry } from "@gander/shared";
+import type { OpenTarget, PrListItem, PrView, RepoEntry } from "@gander/shared";
 import type { GanderApi, GithubRepository } from "./api.js";
 import type { ImagePreview } from "../../api.js";
 
@@ -8,7 +8,7 @@ export interface Store {
   githubRepos: GithubRepository[];
   githubReposBusy: boolean;
   githubReposError: string | null;
-  prs: PrSummary[];
+  prs: PrListItem[];
   currentRepoId: string | null;
   view: PrView | null;
   selectedPath: string | null;
@@ -45,6 +45,18 @@ export interface Store {
 }
 
 export function createStore(api: GanderApi): Store {
+  function syncCurrentProgress(): void {
+    if (!store.view) return;
+    const item = store.prs.find((pr) => pr.number === store.view?.pr.number);
+    if (!item) return;
+    const done = store.view.files.filter((file) => file.checked).length;
+    // Once progress exists, an explicit un-check remains progress: the retained
+    // snapshot means this review has begun even when its current count returns to zero.
+    if (item.reviewProgress !== null || done > 0 || store.view.files.some((file) => file.changedSince)) {
+      item.reviewProgress = { done, total: store.view.files.length };
+    }
+  }
+
   const store: Store = reactive({
     repos: [],
     githubRepos: [],
@@ -120,6 +132,7 @@ export function createStore(api: GanderApi): Store {
         store.selectedPath = null;
         if (target.prNumber === null) return;
         store.view = await api.openPr(target.repoId, target.prNumber);
+        syncCurrentProgress();
         store.selectedPath = store.view.files[0]?.path ?? null;
         store.lastFetchAt = new Date().toISOString();
       })));
@@ -136,6 +149,7 @@ export function createStore(api: GanderApi): Store {
       await userAction(() => withBusy(() => guard(async () => {
         if (!store.currentRepoId) throw new Error("no repo selected");
         store.view = await api.openPr(store.currentRepoId, prNumber);
+        syncCurrentProgress();
         store.selectedPath = store.view.files[0]?.path ?? null;
         store.lastFetchAt = new Date().toISOString();
       })));
@@ -144,6 +158,7 @@ export function createStore(api: GanderApi): Store {
       await withBusy(() => guard(async () => {
         if (!store.currentRepoId || !store.view) return;
         store.view = await api.refreshPr(store.currentRepoId, store.view.pr.number);
+        syncCurrentProgress();
         store.lastFetchAt = new Date().toISOString();
       }));
     },
@@ -154,12 +169,14 @@ export function createStore(api: GanderApi): Store {
       await guard(async () => {
         if (!store.currentRepoId || !store.view) throw new Error("no PR open");
         store.view = await api.setChecked(store.currentRepoId, store.view.pr.number, path, checked);
+        syncCurrentProgress();
       });
     },
     async setCheckedMany(paths: string[], checked: boolean) {
       await guard(async () => {
         if (!store.currentRepoId || !store.view) throw new Error("no PR open");
         store.view = await api.setCheckedMany(store.currentRepoId, store.view.pr.number, paths, checked);
+        syncCurrentProgress();
       });
     },
     async reviewedSnapshot(path: string) {

--- a/packages/service/src/server.test.ts
+++ b/packages/service/src/server.test.ts
@@ -45,6 +45,10 @@ describe("service API", () => {
 
     const after = await server.inject({ method: "GET", url: "/api/reviews/acme%2Fatlas/7", headers: AUTH });
     expect(after.json().files).toHaveLength(1);
+
+    const listed = await server.inject({ method: "GET", url: "/api/reviews/acme%2Fatlas", headers: AUTH });
+    expect(listed.statusCode).toBe(200);
+    expect(listed.json()).toEqual([expect.objectContaining({ repoId: "acme/atlas", prNumber: 7 })]);
   });
 
   it("rejects a malformed PUT body with 400 and the zod message", async () => {

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -33,6 +33,11 @@ export function buildServer(opts: { storage: Storage; token: string; version: st
     },
   );
 
+  app.get<{ Params: { repoId: string } }>(
+    "/api/reviews/:repoId",
+    async (req) => opts.storage.listReviews(req.params.repoId),
+  );
+
   app.put<{ Params: { repoId: string; prNumber: string } }>(
     "/api/reviews/:repoId/:prNumber/files",
     async (req, reply) => {

--- a/packages/service/src/storage.test.ts
+++ b/packages/service/src/storage.test.ts
@@ -33,6 +33,26 @@ describe("storage", () => {
     expect(storage.getSnapshot("acme/atlas", 7, "app/a.rb")).toEqual({ baseContent: "old body", headContent: "new body" });
   });
 
+  it("lists repository review state in one query without including untouched reviews", () => {
+    storage.getReview("acme/atlas", 6);
+    storage.putFileState("acme/atlas", 7, {
+      checked: true, path: "app/a.rb",
+      baseHash: "b1", headHash: "h1",
+      baseContent: "old", headContent: "new", machine: "studio",
+    });
+    storage.putFileState("acme/other", 8, {
+      checked: true, path: "other.rb",
+      baseHash: "b2", headHash: "h2",
+      baseContent: "old", headContent: "new", machine: "studio",
+    });
+
+    expect(storage.listReviews("acme/atlas")).toEqual([{
+      repoId: "acme/atlas",
+      prNumber: 7,
+      files: [expect.objectContaining({ path: "app/a.rb", checked: true, headHash: "h1" })],
+    }]);
+  });
+
   it("un-check retains the snapshot (delta base for M2)", () => {
     storage.putFileState("acme/atlas", 7, {
       checked: true, path: "app/a.rb",

--- a/packages/service/src/storage.ts
+++ b/packages/service/src/storage.ts
@@ -52,6 +52,8 @@ CREATE INDEX IF NOT EXISTS question_replies_by_question ON question_replies(ques
 
 export interface Storage {
   getReview(repoId: string, prNumber: number): ReviewState;
+  /** Reviews with file state, fetched together for repository-level progress summaries. */
+  listReviews(repoId: string): ReviewState[];
   putFileState(repoId: string, prNumber: number, input: PutFileState): FileCheckoff;
   getSnapshot(repoId: string, prNumber: number, path: string): { baseContent: string | null; headContent: string | null } | null;
   /** Records what the app knows about a pull request, so agents can be told which one they are on. */
@@ -123,6 +125,23 @@ export function openStorage(dbPath: string): Storage {
       const rid = reviewId(repoId, prNumber);
       const rows = db.prepare("SELECT path, checked, base_hash, head_hash, checked_at, machine FROM file_states WHERE review_id = ? ORDER BY path").all(rid) as Parameters<typeof rowToCheckoff>[0][];
       return { repoId, prNumber, files: rows.map(rowToCheckoff) };
+    },
+
+    listReviews(repoId) {
+      const rows = db.prepare(`
+        SELECT r.pr_number, fs.path, fs.checked, fs.base_hash, fs.head_hash, fs.checked_at, fs.machine
+        FROM reviews r
+        JOIN file_states fs ON fs.review_id = r.id
+        WHERE r.repo_id = ?
+        ORDER BY r.pr_number, fs.path
+      `).all(repoId) as Array<Parameters<typeof rowToCheckoff>[0] & { pr_number: number }>;
+      const reviews = new Map<number, FileCheckoff[]>();
+      for (const row of rows) {
+        const files = reviews.get(row.pr_number) ?? [];
+        files.push(rowToCheckoff(row));
+        reviews.set(row.pr_number, files);
+      }
+      return [...reviews].map(([prNumber, files]) => ({ repoId, prNumber, files }));
     },
 
     putFileState(repoId, prNumber, input) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -113,6 +113,14 @@ export interface PrSummary {
   headSha: string;
 }
 
+export interface ReviewProgress { done: number; total: number; }
+
+/** GitHub's pull request summary joined with content-derived review progress. */
+export interface PrListItem extends PrSummary {
+  /** null until at least one file has a retained review snapshot. */
+  reviewProgress: ReviewProgress | null;
+}
+
 export interface RepoEntry { repoId: string; url: string; }
 
 export interface PrFile {


### PR DESCRIPTION
## Summary

- derive Reviewing-dropdown progress from current git content and retained service snapshots
- batch reviewed pull request refs into one fetch and expose repository review states in one service request
- show accessible partial and complete progress consistently for standalone and stacked pull requests
- keep the active row synchronized after checkoff and refresh operations

## Readiness

- Simplify: clean
- Code review: clean, 0 findings
- Accessibility/UI audit: clean
- Adversarial review: skipped (low-risk changeset)

## Test plan

- `pnpm typecheck` — passed
- `pnpm test` — passed, 41 files / 279 tests
- `pnpm test:e2e` — the new `1/2 reviewed` row assertion passed; the sole run then failed because its cleanup clicked through the dropdown veil. Cleanup now uses Escape. Per the issue brief, the suite was not rerun.

Closes #63
