### PR TITLE
Add consent-based in-place updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@
 
 <p align="center">A desktop app for reviewing code diffs, branches, and pull requests.</p>
 
+## Install
+
+Packaged releases are available from [GitHub Releases](https://github.com/steveclarke/gander/releases):
+
+- On Apple silicon macOS, open the versioned `.dmg` and drag Gander to Applications.
+- On Linux, download the versioned `.AppImage`, make it executable, and run it.
+
+The macOS Homebrew cask is prepared but its separate personal tap has not been
+published yet. Once that manual tap setup is complete, the install command will be:
+
+```
+brew install --cask steveclarke/gander/gander
+```
+
+Packaged macOS and AppImage builds check GitHub Releases once at launch. An
+update downloads in the background, then Gander asks before restarting and
+installing it. Choosing **Later** does not install the update when Gander quits.
+Use **Gander → Check for Updates…** on macOS or **Help → Check for Updates…** on
+Linux to check immediately. Development builds never contact the update feed.
+
 ## Getting started
 
 ```

--- a/bin/release
+++ b/bin/release
@@ -60,10 +60,18 @@ rm -rf packages/app/dist
 export APPLE_KEYCHAIN_PROFILE
 pnpm --filter @gander/app run dist:mac
 
+# The tap is a separate repository and is updated manually after release verification.
+# Generate the exact, checksummed cask it needs as a release asset so that handoff does
+# not require reconstructing artifact names or trusting an unverified checksum.
+bin/render-homebrew-cask \
+  "$VERSION" \
+  "packages/app/dist/Gander-${VERSION}-arm64.dmg" \
+  "packages/app/dist/gander.rb"
+
 # Globbed rather than named: electron-builder decides the artifact names, and a
 # renamed default here would fail the release after it had already been tagged.
 cd packages/app
-gh release upload "$TAG" dist/*.dmg dist/*.zip dist/*.blockmap dist/latest-mac.yml
+gh release upload "$TAG" dist/*.dmg dist/*.zip dist/*.blockmap dist/latest-mac.yml dist/gander.rb
 
 echo "==> Published https://github.com/steveclarke/gander/releases/tag/${TAG}"
 echo "    The Linux AppImage follows from CI."

--- a/bin/release.test.ts
+++ b/bin/release.test.ts
@@ -1,0 +1,54 @@
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const sourceRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "gander-cask-test-"));
+  mkdirSync(join(root, "bin"));
+  mkdirSync(join(root, "packaging/homebrew"), { recursive: true });
+  copyFileSync(join(sourceRoot, "bin/render-homebrew-cask"), join(root, "bin/render-homebrew-cask"));
+  copyFileSync(join(sourceRoot, "packaging/homebrew/gander.rb.template"), join(root, "packaging/homebrew/gander.rb.template"));
+  chmodSync(join(root, "bin/render-homebrew-cask"), 0o755);
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+describe("Homebrew cask release handoff", () => {
+  it("pins the versioned release DMG and its checksum", () => {
+    const dmg = join(root, "Gander-1.2.3-arm64.dmg");
+    const output = join(root, "dist/gander.rb");
+    writeFileSync(dmg, "signed release bytes");
+
+    const result = spawnSync(join(root, "bin/render-homebrew-cask"), ["1.2.3", dmg, output], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const cask = readFileSync(output, "utf8");
+    expect(cask).toContain('version "1.2.3"');
+    expect(cask).toContain('sha256 "3ba84e1d362618f0e9f45064634a1594485bca3298b8182b5a7eaa3fded4688f"');
+    expect(cask).toContain("Gander-#{version}-arm64.dmg");
+    expect(cask).not.toContain("__VERSION__");
+    expect(cask).not.toContain("__SHA256__");
+  });
+
+  it("refuses an artifact name that cannot match the cask URL", () => {
+    const dmg = join(root, "some-build.dmg");
+    writeFileSync(dmg, "release bytes");
+
+    const result = spawnSync(join(root, "bin/render-homebrew-cask"), ["1.2.3", dmg, join(root, "gander.rb")], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Expected the release DMG to be named Gander-1.2.3-arm64.dmg");
+  });
+});

--- a/bin/render-homebrew-cask
+++ b/bin/render-homebrew-cask
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:?Usage: bin/render-homebrew-cask VERSION DMG OUTPUT}"
+DMG="${2:?Usage: bin/render-homebrew-cask VERSION DMG OUTPUT}"
+OUTPUT="${3:?Usage: bin/render-homebrew-cask VERSION DMG OUTPUT}"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Invalid release version: $VERSION" >&2
+  exit 1
+fi
+if [[ ! -f "$DMG" ]]; then
+  echo "DMG does not exist: $DMG" >&2
+  exit 1
+fi
+
+EXPECTED="Gander-${VERSION}-arm64.dmg"
+if [[ "$(basename "$DMG")" != "$EXPECTED" ]]; then
+  echo "Expected the release DMG to be named $EXPECTED" >&2
+  exit 1
+fi
+
+SHA256="$(shasum --algorithm 256 "$DMG" | awk '{print $1}')"
+mkdir -p "$(dirname "$OUTPUT")"
+
+sed \
+  -e "s/__VERSION__/${VERSION}/g" \
+  -e "s/__SHA256__/${SHA256}/g" \
+  "$(dirname "$0")/../packaging/homebrew/gander.rb.template" > "$OUTPUT"
+
+echo "Rendered $OUTPUT"

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -60,8 +60,11 @@ development.
 ## Still open
 
 - Local branch/worktree viewer (stateless, no review state)
-- Packaging: signing, notarization, and the Homebrew cask. Gander runs only from
-  a development checkout.
+
+Packaged macOS and Linux releases are published on GitHub. Packaged builds check
+those release manifests for updates and ask before restarting to install. The
+repository also generates a checksummed Homebrew cask handoff; publishing and
+verifying the separate personal tap remains a manual release task.
 
 Interface work and the agent reply channel are tracked as GitHub issues.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -83,3 +83,37 @@ builds and notarizes the macOS artifacts on the maintainer's machine, and
 uploads them. The Linux AppImage is built by GitHub Actions when the release is
 published. macOS signing stays local because the certificate belongs in a
 keychain rather than in a public repository's secrets.
+
+The packaged app uses the `latest-mac.yml` and `latest-linux.yml` files from the
+release. It checks once after opening its first window and also offers a manual
+check in the native application menu. Updates download automatically, but
+`autoInstallOnAppQuit` is disabled: the reviewer must choose **Restart and
+Install** after the download completes. Development builds and unsigned
+directory builds, which have no generated `app-update.yml`, do not initialize
+the updater; Linux additionally requires the `APPIMAGE` runtime path.
+
+The first real update between two signed releases still needs manual acceptance
+on both platforms. On macOS, verify that the old and new builds use the same
+Developer ID identity and that the downloaded update installs after consent. On
+Linux, launch the old AppImage as an AppImage (so `APPIMAGE` is present), accept
+the update, and verify the file and running version changed. A local unsigned
+build or a successful unit test is not evidence for either cross-version path.
+
+### Homebrew cask handoff
+
+`bin/release` renders `packages/app/dist/gander.rb` from the versioned macOS DMG,
+pins its SHA-256, and uploads it as a release asset. The cask deliberately uses
+the DMG for installation; the ZIP remains the macOS updater artifact.
+
+The personal tap is a separate public repository and is not managed here. After
+the release and its install/update path have been verified manually:
+
+1. Copy the release's `gander.rb` into `Casks/gander.rb` in the tap.
+2. Run `brew style --cask Casks/gander.rb` and
+   `brew audit --cask --strict Casks/gander.rb` there.
+3. Install the fully qualified cask from the tap and launch it before publishing
+   the tap change.
+
+Do not copy signing identities, notarization credentials, tokens, or keychain
+profile names into either repository. The generated cask contains only the
+public release URL and checksum.

--- a/packages/app/electron-builder.yml
+++ b/packages/app/electron-builder.yml
@@ -14,6 +14,8 @@ files:
   - package.json
 
 mac:
+  # Keep release metadata on the current `files` format supported by electron-updater.
+  electronUpdaterCompatibility: ">= 2.16"
   category: public.app-category.developer-tools
   target:
     - target: dmg
@@ -30,6 +32,7 @@ dmg:
   title: Gander
 
 linux:
+  electronUpdaterCompatibility: ">= 2.16"
   category: Development
   # Without this the binary is named from the package, and "@gander/app" flattens to
   # "@ganderapp" — not a name a file path can carry.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@gander/shared": "workspace:*",
+    "electron-updater": "^6.8.9",
     "lucide-vue-next": "^1.0.0",
     "monaco-editor": "^0.52.0",
     "vue": "^3.5.0",

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, shell } from "electron";
 import { hostname } from "node:os";
 import { join } from "node:path";
+import { existsSync } from "node:fs";
 import { repoIdFromUrl, type OpenTarget, type RepoEntry } from "@gander/shared";
 import { connectionIsFromEnvironment, loadConfig, resolveServiceConnection, saveConfig, type GanderConfig } from "./config.js";
 import { checkConnection } from "./connection.js";
@@ -15,6 +16,7 @@ import { buildMenuTemplate } from "./menu.js";
 import { updateNativeWindowTheme, windowAppearance } from "./window-appearance.js";
 import { linkedWorktreeLabel } from "./development-context.js";
 import { createZoomController, type ZoomController } from "./zoom-controller.js";
+import { loadUpdateController, supportsInPlaceUpdates, type UpdateController } from "./updates.js";
 
 let zoomController: ZoomController;
 
@@ -113,7 +115,7 @@ async function bootstrap(): Promise<GanderConfig> {
   return cfg;
 }
 
-function installMenu(): void {
+function installMenu(updates: UpdateController | null): void {
   const openSettings = (): void => {
     const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
     win?.webContents.send("gander:openSettings");
@@ -122,8 +124,46 @@ function installMenu(): void {
     openSettings,
     setZoom: zoomController.set,
     currentZoom: zoomController.current,
+    checkForUpdates: updates?.checkManually,
   });
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+async function initializeUpdates(): Promise<UpdateController | null> {
+  const updateConfigExists = existsSync(join(process.resourcesPath, "app-update.yml"));
+  if (!supportsInPlaceUpdates(app.isPackaged, process.platform, process.env.APPIMAGE, updateConfigExists)) return null;
+
+  try {
+    return await loadUpdateController({
+      currentVersion: () => app.getVersion(),
+      showUpToDate: async (version) => {
+        await dialog.showMessageBox({
+          type: "info",
+          title: "Gander is up to date",
+          message: `Gander ${version} is the latest version.`,
+        });
+      },
+      confirmRestart: async (version) => {
+        const result = await dialog.showMessageBox({
+          type: "info",
+          title: "Gander update ready",
+          message: `Gander ${version} has been downloaded.`,
+          detail: "Restart Gander now to install it, or choose Later to keep reviewing.",
+          buttons: ["Restart and Install", "Later"],
+          defaultId: 0,
+          cancelId: 1,
+          noLink: true,
+        });
+        return result.response === 0;
+      },
+      showError: (message) => dialog.showErrorBox("Gander update failed", message),
+    });
+  } catch (error) {
+    // Updating is release infrastructure, not a condition for reviewing. Keep the
+    // packaged app usable while making a broken updater visible.
+    dialog.showErrorBox("Gander update failed", (error as Error).message);
+    return null;
+  }
 }
 
 async function createWindow(cfg: GanderConfig): Promise<void> {
@@ -215,8 +255,10 @@ app.whenReady().then(async () => {
     app.exit(1);
     return;
   }
-  installMenu();
   await createWindow(cfg);
+  const updates = await initializeUpdates();
+  installMenu(updates);
+  updates?.checkAtStartup();
 
   try {
     const stop = await startOpenServer({ socketPath: socketPath(), onTarget: deliver });

--- a/packages/app/src/main/menu.test.ts
+++ b/packages/app/src/main/menu.test.ts
@@ -56,4 +56,26 @@ describe("application menu", () => {
     );
     expect(callbacks.setZoom).toHaveBeenLastCalledWith(0);
   });
+
+  it("offers update checks in the native platform menu when updates are active", () => {
+    const macActions = { ...actions(), checkForUpdates: vi.fn() };
+    const macTemplate = buildMenuTemplate("darwin", "Gander", macActions);
+    const macItem = submenu(macTemplate[0]!).find((item) => item.label === "Check for Updates…");
+    macItem?.click?.({} as Electron.MenuItem, undefined, {} as Electron.KeyboardEvent);
+    expect(macActions.checkForUpdates).toHaveBeenCalledOnce();
+
+    const linuxActions = { ...actions(), checkForUpdates: vi.fn() };
+    const linuxTemplate = buildMenuTemplate("linux", "Gander", linuxActions);
+    const help = linuxTemplate.find((item) => item.label === "Help");
+    const linuxItem = submenu(help!).find((item) => item.label === "Check for Updates…");
+    linuxItem?.click?.({} as Electron.MenuItem, undefined, {} as Electron.KeyboardEvent);
+    expect(linuxActions.checkForUpdates).toHaveBeenCalledOnce();
+  });
+
+  it("omits update commands when the updater is inactive", () => {
+    const template = buildMenuTemplate("darwin", "Gander", actions());
+
+    expect(submenu(template[0]!).some((item) => item.label === "Check for Updates…")).toBe(false);
+    expect(template.some((item) => item.label === "Help")).toBe(false);
+  });
 });

--- a/packages/app/src/main/menu.ts
+++ b/packages/app/src/main/menu.ts
@@ -5,6 +5,7 @@ interface MenuActions {
   openSettings(): void;
   setZoom(level: number): void;
   currentZoom(): number;
+  checkForUpdates?: () => void;
 }
 
 export function buildMenuTemplate(
@@ -24,6 +25,9 @@ export function buildMenuTemplate(
         label: appName,
         submenu: [
           { role: "about" },
+          ...(actions.checkForUpdates
+            ? [{ label: "Check for Updates…", click: actions.checkForUpdates } satisfies MenuItemConstructorOptions]
+            : []),
           { type: "separator" },
           settingsItem,
           { type: "separator" },
@@ -45,6 +49,10 @@ export function buildMenuTemplate(
         ],
       };
 
+  const helpMenu: MenuItemConstructorOptions[] = actions.checkForUpdates && platform !== "darwin"
+    ? [{ label: "Help", submenu: [{ label: "Check for Updates…", click: actions.checkForUpdates }] }]
+    : [];
+
   return [
     applicationMenu,
     { role: "editMenu" },
@@ -63,5 +71,6 @@ export function buildMenuTemplate(
       ],
     },
     { role: "windowMenu" },
+    ...helpMenu,
   ];
 }

--- a/packages/app/src/main/updates.test.ts
+++ b/packages/app/src/main/updates.test.ts
@@ -1,0 +1,89 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import type { AppUpdater } from "electron-updater";
+import { createUpdateController, supportsInPlaceUpdates } from "./updates.js";
+
+function setup() {
+  const events = new EventEmitter();
+  const updater = {
+    autoDownload: false,
+    autoInstallOnAppQuit: true,
+    checkForUpdates: vi.fn(async () => null),
+    on: events.on.bind(events),
+    quitAndInstall: vi.fn(),
+  } as unknown as Pick<AppUpdater, "autoDownload" | "autoInstallOnAppQuit" | "checkForUpdates" | "on" | "quitAndInstall">;
+  const prompts = {
+    currentVersion: vi.fn(() => "1.2.3"),
+    showUpToDate: vi.fn(async () => undefined),
+    confirmRestart: vi.fn(async () => false),
+    showError: vi.fn(),
+  };
+  const controller = createUpdateController(updater, prompts);
+  return { controller, events, prompts, updater };
+}
+
+describe("in-place update support", () => {
+  it("runs only in packaged macOS and AppImage builds", () => {
+    expect(supportsInPlaceUpdates(false, "darwin", undefined, true)).toBe(false);
+    expect(supportsInPlaceUpdates(false, "linux", "/tmp/Gander.AppImage", true)).toBe(false);
+    expect(supportsInPlaceUpdates(true, "darwin", undefined, false)).toBe(false);
+    expect(supportsInPlaceUpdates(true, "darwin", undefined, true)).toBe(true);
+    expect(supportsInPlaceUpdates(true, "linux", undefined, true)).toBe(false);
+    expect(supportsInPlaceUpdates(true, "linux", "/tmp/Gander.AppImage", true)).toBe(true);
+    expect(supportsInPlaceUpdates(true, "win32", undefined, true)).toBe(false);
+  });
+
+  it("downloads updates but never installs them silently on quit", () => {
+    const { updater } = setup();
+
+    expect(updater.autoDownload).toBe(true);
+    expect(updater.autoInstallOnAppQuit).toBe(false);
+  });
+
+  it("keeps the startup check quiet when the current version is latest", async () => {
+    const { controller, events, prompts, updater } = setup();
+
+    controller.checkAtStartup();
+    events.emit("update-not-available", { version: "1.2.3" });
+    await Promise.resolve();
+
+    expect(updater.checkForUpdates).toHaveBeenCalledOnce();
+    expect(prompts.showUpToDate).not.toHaveBeenCalled();
+  });
+
+  it("confirms a manual check when the current version is latest", async () => {
+    const { controller, events, prompts } = setup();
+
+    controller.checkManually();
+    events.emit("update-not-available", { version: "1.2.3" });
+    await Promise.resolve();
+
+    expect(prompts.showUpToDate).toHaveBeenCalledWith("1.2.3");
+  });
+
+  it("restarts only after the user consents to install a downloaded update", async () => {
+    const { events, prompts, updater } = setup();
+    prompts.confirmRestart.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    events.emit("update-downloaded", { version: "1.3.0" });
+    await Promise.resolve();
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+
+    events.emit("update-downloaded", { version: "1.3.0" });
+    await Promise.resolve();
+    expect(updater.quitAndInstall).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces updater failures once even when the event and promise report the same error", async () => {
+    const { controller, events, prompts, updater } = setup();
+    const failure = new Error("latest-mac.yml returned 503");
+    updater.checkForUpdates = vi.fn(async () => { throw failure; });
+
+    controller.checkManually();
+    events.emit("error", failure);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(prompts.showError).toHaveBeenCalledOnce();
+    expect(prompts.showError).toHaveBeenCalledWith("latest-mac.yml returned 503");
+  });
+});

--- a/packages/app/src/main/updates.ts
+++ b/packages/app/src/main/updates.ts
@@ -1,0 +1,83 @@
+import type { AppUpdater, UpdateDownloadedEvent, UpdateInfo } from "electron-updater";
+
+interface UpdatePrompts {
+  currentVersion(): string;
+  showUpToDate(version: string): Promise<void>;
+  confirmRestart(version: string): Promise<boolean>;
+  showError(message: string): void;
+}
+
+type Updater = Pick<
+  AppUpdater,
+  "autoDownload" | "autoInstallOnAppQuit" | "checkForUpdates" | "on" | "quitAndInstall"
+>;
+
+export interface UpdateController {
+  checkAtStartup(): void;
+  checkManually(): void;
+}
+
+export function supportsInPlaceUpdates(
+  isPackaged: boolean,
+  platform: NodeJS.Platform,
+  appImagePath: string | undefined,
+  updateConfigExists: boolean,
+): boolean {
+  if (!isPackaged || !updateConfigExists) return false;
+  if (platform === "darwin") return true;
+  // electron-updater can update the AppImage itself, but an unpacked Linux build
+  // has no artifact to replace. APPIMAGE is set by the AppImage runtime.
+  return platform === "linux" && Boolean(appImagePath);
+}
+
+export function createUpdateController(updater: Updater, prompts: UpdatePrompts): UpdateController {
+  let manualCheck = false;
+  const reportedErrors = new WeakSet<Error>();
+
+  // Downloading does not alter the running app. Installation always remains an
+  // explicit reviewer choice, including when the app later quits.
+  updater.autoDownload = true;
+  updater.autoInstallOnAppQuit = false;
+
+  const reportError = (error: Error): void => {
+    manualCheck = false;
+    if (reportedErrors.has(error)) return;
+    reportedErrors.add(error);
+    prompts.showError(error.message);
+  };
+
+  updater.on("error", reportError);
+  updater.on("update-not-available", (_info: UpdateInfo) => {
+    if (!manualCheck) return;
+    manualCheck = false;
+    void prompts.showUpToDate(prompts.currentVersion()).catch(reportError);
+  });
+  updater.on("update-available", (_info: UpdateInfo) => {
+    manualCheck = false;
+  });
+  updater.on("update-downloaded", (info: UpdateDownloadedEvent) => {
+    void prompts.confirmRestart(info.version).then((restart) => {
+      if (restart) updater.quitAndInstall();
+    }).catch(reportError);
+  });
+
+  const check = (manual: boolean): void => {
+    manualCheck ||= manual;
+    void updater.checkForUpdates().catch((error: unknown) => {
+      reportError(error instanceof Error ? error : new Error(String(error)));
+    });
+  };
+
+  return {
+    checkAtStartup: () => check(false),
+    checkManually: () => check(true),
+  };
+}
+
+export async function loadUpdateController(prompts: UpdatePrompts): Promise<UpdateController> {
+  // electron-updater is CommonJS. Its documented ESM interop path is a default
+  // import followed by destructuring rather than a named import.
+  const electronUpdater = await import("electron-updater");
+  const { autoUpdater } = electronUpdater.default;
+  return createUpdateController(autoUpdater, prompts);
+}

--- a/packaging/homebrew/gander.rb.template
+++ b/packaging/homebrew/gander.rb.template
@@ -1,0 +1,14 @@
+cask "gander" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  url "https://github.com/steveclarke/gander/releases/download/v#{version}/Gander-#{version}-arm64.dmg"
+  name "Gander"
+  desc "Review code diffs, branches, and pull requests"
+  homepage "https://github.com/steveclarke/gander"
+
+  auto_updates true
+  depends_on arch: :arm64
+
+  app "Gander.app"
+end

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@gander/shared':
         specifier: workspace:*
         version: link:../shared
+      electron-updater:
+        specifier: ^6.8.9
+        version: 6.8.9(supports-color@8.1.1)
       lucide-vue-next:
         specifier: ^1.0.0
         version: 1.0.0(vue@3.5.41(typescript@5.9.3))
@@ -2520,6 +2523,9 @@ packages:
   electron-to-chromium@1.5.406:
     resolution: {integrity: sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-vite@3.1.0:
     resolution: {integrity: sha512-M7aAzaRvSl5VO+6KN4neJCYLHLpF/iWo5ztchI/+wMxIieDZQqpbCYfaEHHHPH6eupEzfvZdLYdPdmvGqoVe0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3433,8 +3439,15 @@ packages:
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flattendeep@4.4.0:
     resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.pickby@4.6.0:
     resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
@@ -4452,6 +4465,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -7505,6 +7521,19 @@ snapshots:
 
   electron-to-chromium@1.5.406: {}
 
+  electron-updater@6.8.9(supports-color@8.1.1):
+    dependencies:
+      builder-util-runtime: 9.7.0(supports-color@8.1.1)
+      fs-extra: 10.1.0
+      js-yaml: 4.3.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-vite@3.1.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
@@ -8565,7 +8594,11 @@ snapshots:
 
   lodash.clonedeep@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flattendeep@4.4.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.pickby@4.6.0: {}
 
@@ -9662,6 +9695,8 @@ snapshots:
       semver: 5.7.2
 
   tiny-invariant@1.3.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,10 @@
 packages:
   - "packages/*"
+# electron-vite and electron-updater resolve Electron from their installed package
+# locations. Make the app's Electron dependency available at the workspace root
+# instead of relying on an incidental transitive hoist.
+publicHoistPattern:
+  - electron
 allowBuilds:
   '@modelcontextprotocol/inspector': true
   better-sqlite3: true


### PR DESCRIPTION
## Summary

- wire `electron-updater` to the existing GitHub release manifests for packaged macOS and Linux AppImage builds
- check once after startup and from the native menu, download in the background, and require explicit consent before restart/install
- keep development and unsigned directory builds off the update feed, surface updater errors, and cover platform, consent, and error policy with tests
- generate a checksum-pinned Homebrew cask asset from each signed DMG and document installation plus the separate tap handoff

Closes #46.

## Readiness

- Simplify: clean; one unnecessary type predicate removed
- Code review: clean; release safety, consent, platform guards, error paths, scope, and maintainability reviewed
- Adversarial review: skipped; release/dependency risk reviewed inline
- Finalize: clean

## Test plan

- `pnpm typecheck` — passed for shared, service, and app
- `pnpm test` — 43 files and 287 tests passed
- `pnpm --store-dir /Users/steve/Library/pnpm/store/v11 install --offline --frozen-lockfile` — passed
- `bash -n bin/release bin/render-homebrew-cask` — passed
- generated cask `ruby -c` — passed
- `pnpm --filter @gander/app run dist:unsigned` — passed; unsigned macOS app packaged with signing and notarization disabled

E2E was not run: its unpackaged Electron process intentionally does not initialize the updater, so it would not exercise this behavior.

## Manual release and tap verification

This PR does not publish a release or tap and does not claim a cross-version update succeeded. After two applicable releases exist, manually verify:

- a signed/notarized macOS build updates to a newer build signed by the same Developer ID after consent
- an older AppImage replaces itself and launches the newer version after consent
- the generated `gander.rb` is copied into the separate personal tap, passes `brew style` and `brew audit`, installs, and launches before that tap change is published

No release, tag, signing, notarization, artifact upload, or external tap mutation was performed here.
