### PR TITLE
Say what a failed request means

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,12 @@ the app from starting. While the shape is still settling there are no migrations
 `bin/fix-config` keeps the values the schema still knows, fills in the new ones,
 and drops the rest.
 
+`SERVICE_VERSION` in `@gander/shared` is the app-to-service contract version, and the
+app checks it when it connects. **Bump it in the same change that alters the
+contract** — a route added or removed, a field the app comes to rely on. Leaving it
+alone lets a stale service answer "the version you wanted", and the mismatch surfaces
+later as a 404 in the middle of a review.
+
 **The repo is public.** No client names, private repo names, or real PR numbers
 in code, comments, commits, or issues.
 

--- a/packages/app/src/main/connection.test.ts
+++ b/packages/app/src/main/connection.test.ts
@@ -82,13 +82,17 @@ describe("checkConnection", () => {
   });
 
   it("allows a newer service with an explicit warning state", async () => {
-    const url = await serve("good-token", "0.2.0");
+    // Derived rather than written down: the contract version moves whenever the contract
+    // does, and a literal here would fail the next time it did.
+    const [major] = SERVICE_VERSION.split(".");
+    const newer = `${Number(major) + 1}.0.0`;
+    const url = await serve("good-token", newer);
     await expect(checkConnection(url, "good-token")).resolves.toEqual({
       ok: true,
-      version: "0.2.0",
+      version: newer,
       compatibility: "newer",
     });
-    await expect(checkServiceStatus(url)).resolves.toMatchObject({ state: "newer", serviceVersion: "0.2.0" });
+    await expect(checkServiceStatus(url)).resolves.toMatchObject({ state: "newer", serviceVersion: newer });
   });
 
   it("rejects a version that cannot participate in the compatibility policy", () => {

--- a/packages/app/src/main/service-client.test.ts
+++ b/packages/app/src/main/service-client.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { SERVICE_VERSION } from "@gander/shared";
+import { createServiceClient } from "./service-client.js";
+
+const servers: FastifyInstance[] = [];
+afterEach(async () => {
+  await Promise.allSettled(servers.map((s) => s.close()));
+  servers.length = 0;
+});
+
+/**
+ * A real server that passes the version handshake, so each test exercises the failure it
+ * is about rather than the connection check in front of it.
+ */
+async function serve(routes: (app: FastifyInstance) => void): Promise<string> {
+  const app = Fastify({ logger: false });
+  servers.push(app);
+  app.get("/healthz", async () => ({ ok: true, version: SERVICE_VERSION }));
+  routes(app);
+  return app.listen({ host: "127.0.0.1", port: 0 });
+}
+
+describe("a failed request", () => {
+  it("reads a 404 as a service older than the app", async () => {
+    // No route at all: what a service that predates one answers.
+    const url = await serve(() => {});
+    const client = createServiceClient(() => ({ url, token: "t" }));
+    await expect(client.getReview("acme/atlas", 1)).rejects.toThrow(/does not have GET .*older than this app/s);
+  });
+
+  it("says where to fix a rejected token", async () => {
+    const url = await serve((app) => {
+      app.get("/api/reviews/:repoId/:prNumber", async (_req, reply) => reply.code(401).send({ error: "nope" }));
+    });
+    const client = createServiceClient(() => ({ url, token: "wrong" }));
+    await expect(client.getReview("acme/atlas", 1)).rejects.toThrow(/rejected this app's token.*Settings/s);
+  });
+
+  it("keeps the server's own explanation, without the JSON around it", async () => {
+    const url = await serve((app) => {
+      app.get("/api/reviews/:repoId/:prNumber", async (_req, reply) => reply.code(500).send({ message: "disk is full" }));
+    });
+    const client = createServiceClient(() => ({ url, token: "t" }));
+    const error = await client.getReview("acme/atlas", 1).catch((e: Error) => e.message);
+    expect(error).toContain("disk is full");
+    expect(error).not.toContain("{");
+  });
+});

--- a/packages/app/src/main/service-client.ts
+++ b/packages/app/src/main/service-client.ts
@@ -31,6 +31,36 @@ const SnapshotSchema = z.object({
  */
 export type Connection = () => { url: string; token: string };
 
+/**
+ * What a failed request means, in a sentence a reader can act on.
+ *
+ * The reviewer is mid-review, not debugging: a status code, a method, a URL and a JSON
+ * body is a wall of text that says nothing about what to do. A 404 in particular is worth
+ * naming, because on a route this app knows exists it means the service is older than the
+ * app rather than anything being missing.
+ */
+async function describeFailure(res: Response, method: string, baseUrl: string, path: string): Promise<string> {
+  const body = (await res.text().catch(() => "")).trim();
+  // Fastify reports its own errors as JSON; anything else is shown as it came.
+  let detail = body;
+  try {
+    const parsed = JSON.parse(body) as { message?: unknown; error?: unknown };
+    if (typeof parsed.message === "string") detail = parsed.message;
+    else if (typeof parsed.error === "string") detail = parsed.error;
+  } catch { /* not JSON */ }
+
+  if (res.status === 404) {
+    return `The review service at ${baseUrl} does not have ${method} ${path}. It is older than this app — update the service, or point this app at one that matches.`;
+  }
+  if (res.status === 401 || res.status === 403) {
+    return `The review service at ${baseUrl} rejected this app's token. Check it in Settings → Connection.`;
+  }
+  if (res.status >= 500) {
+    return `The review service failed on ${method} ${path}${detail === "" ? "" : `: ${detail}`}. Its log will say why.`;
+  }
+  return `The review service refused ${method} ${path}${detail === "" ? "" : `: ${detail}`}.`;
+}
+
 export function createServiceClient(connection: Connection): ServiceClient {
   let checkedConnection: { url: string; status: ServiceStatus } | null = null;
   let recoveryReadRequired = false;
@@ -92,7 +122,7 @@ export function createServiceClient(connection: Connection): ServiceClient {
       const consequence = method === "GET" ? "" : " This change was not saved and will not be retried.";
       throw new ServiceConnectionError(`Gander service unreachable at ${baseUrl}: ${(err as Error).message}.${consequence}`);
     }
-    if (!res.ok) throw new Error(`Gander service ${res.status} on ${method} ${baseUrl}${path}: ${await res.text()}`);
+    if (!res.ok) throw new Error(await describeFailure(res, method, baseUrl, path));
     // 204 has no body — reading it as JSON would throw on a successful delete.
     if (res.status === 204) return undefined;
     return res.json();

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { PrView } from "@gander/shared";
 import type { GanderApi } from "./api.js";
-import { createStore } from "./store.js";
+import { createStore, readable } from "./store.js";
 import { DEFAULT_APP_SETTINGS } from "../../settings.js";
 
 const prView = (checkedPaths: string[] = []): PrView => ({
@@ -307,5 +307,11 @@ describe("store", () => {
       expect(store.view?.files).toHaveLength(2);
       expect(store.serviceStatus).toEqual({ state: "unreachable", reason: "network down" });
     });
+  });
+
+  it("shows the message without Electron's IPC wrapper", () => {
+    expect(readable("Error invoking remote method 'gander:listPrs': Error: The review service at http://x does not have GET /api/reviews/a%2Fb."))
+      .toBe("The review service at http://x does not have GET /api/reviews/a%2Fb.");
+    expect(readable("plain trouble")).toBe("plain trouble");
   });
 });

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -45,6 +45,19 @@ export interface Store {
   progress(): { done: number; total: number };
 }
 
+/**
+ * The message without Electron's plumbing in front of it.
+ *
+ * An error thrown in the main process arrives wrapped: "Error invoking remote method
+ * 'gander:listPrs': Error: ...". That tells the reviewer which IPC channel failed, in a
+ * banner whose only job is to say what went wrong.
+ */
+export function readable(message: string): string {
+  return message
+    .replace(/^Error invoking remote method '[^']*':\s*/, "")
+    .replace(/^(?:Error|TypeError):\s*/, "");
+}
+
 export function createStore(api: GanderApi): Store {
   function syncCurrentProgress(): void {
     if (!store.view) return;
@@ -225,7 +238,7 @@ export function createStore(api: GanderApi): Store {
     try {
       await fn();
     } catch (err) {
-      store.error = (err as Error).message;
+      store.error = readable((err as Error).message);
       // Failed service writes already surface above; update the persistent status too.
       // This is only a health read, never a retry of the authored-state mutation.
       await store.checkService();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,7 +1,19 @@
 import { z } from "zod";
 
 /** The service API version this workspace implements and the desktop app understands. */
-export const SERVICE_VERSION = "0.1.0";
+/**
+ * The version of the wire contract between the app and the service, checked when the app
+ * connects.
+ *
+ * **Bump this in the same change that alters the contract** — a route added or removed, a
+ * field a response gains that the app relies on, a payload shape the service starts
+ * requiring. It is the only thing that lets a running app tell a service that is behind it
+ * from one that is level with it. Leaving it alone means a stale service answers "the
+ * version you wanted", and the mismatch surfaces later as a 404 in the middle of a review.
+ *
+ * Not the app's release version: releases happen far more often than the contract moves.
+ */
+export const SERVICE_VERSION = "0.2.0";
 
 export const FileStatusSchema = z.enum(["A", "M", "D", "R"]);
 export type FileStatus = z.infer<typeof FileStatusSchema>;


### PR DESCRIPTION
A service a day behind the app produced this, in a banner over the review:

```
Error invoking remote method 'gander:listPrs': Error: Gander service 404 on GET
https://…/api/reviews/myunio%2Funio: {"message":"Route GET:… not found","error":"Not
Found","statusCode":404}
```

Three faults in one line: Electron's IPC wrapper is in front of it, the body is
dumped as JSON, and nothing says what a 404 on a route this app knows actually
means — that the service is older than the app.

| Failure | Now reads |
|---|---|
| 404 | "The review service at … does not have GET …. It is older than this app — update the service, or point this app at one that matches." |
| 401/403 | "… rejected this app's token. Check it in Settings → Connection." |
| 5xx | "The review service failed on GET …: disk is full. Its log will say why." |

The renderer strips `Error invoking remote method '…':` before anything reaches
the banner.

## Why the handshake did not catch it

`SERVICE_VERSION` is one constant shared by both sides, and nothing bumped it
when the repo-level route landed — so a service without that route truthfully
answered the version the app expected, and the check passed. It is bumped here,
and the rule is written into AGENTS.md next to the public-repo rule: move it in
the same change that moves the contract.

302 unit tests pass, typecheck clean. The new tests run against real Fastify
instances answering 404, 401 and 500.