### PR TITLE
Deploy the service with a script that checks what came back

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ in code, comments, commits, or issues.
 | Electron E2E | `pnpm test:e2e` |
 | Open a review in the running app | `bin/gander --repo owner/name [--pr 42]` |
 | Repair a config the settings schema has outgrown | `bin/fix-config` |
+| Update the service on its host | `bin/deploy` |
 | Build an unsigned app | `pnpm --filter @gander/app run dist:unsigned` |
 | Isolated working copy | `bin/worktree add <name>` |
 | Check this worktree's MCP bridge | `bin/mcp check` |

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update the review service on its host.
+#
+# The service runs from a clone rather than a published image, so deploying is a
+# pull and a rebuild. This does that, waits for the container to come back, and
+# checks that what is now running answers the contract version this checkout
+# expects — a service behind the app is the failure this is here to catch.
+#
+# The host is not written down here: this repository is public, and a deployment
+# is the operator's. Set these once, in a shell profile or a password manager:
+#
+#   GANDER_DEPLOY_HOST   ssh destination, e.g. docker.example.internal
+#   GANDER_DEPLOY_PATH   the checkout on that host (default /home/deploy/docker/gander)
+#
+# Usage: bin/deploy [--ref BRANCH_OR_TAG]
+
+cd "$(dirname "$0")/.."
+
+HOST="${GANDER_DEPLOY_HOST:?set GANDER_DEPLOY_HOST to the ssh destination running the service}"
+REMOTE_PATH="${GANDER_DEPLOY_PATH:-/home/deploy/docker/gander}"
+REF="master"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref) REF="${2:?--ref needs a branch or tag}"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# What this checkout believes the service should answer.
+EXPECTED="$(sed -n 's/.*SERVICE_VERSION = "\([^"]*\)".*/\1/p' packages/shared/src/index.ts | head -1)"
+[[ -n "$EXPECTED" ]] || { echo "Could not read SERVICE_VERSION from packages/shared/src/index.ts" >&2; exit 1; }
+
+echo "==> Deploying ${REF} to ${HOST}:${REMOTE_PATH}"
+ssh "$HOST" bash -euo pipefail -s -- "$REMOTE_PATH" "$REF" <<'REMOTE'
+REMOTE_PATH="$1"
+REF="$2"
+cd "$REMOTE_PATH"
+git fetch --quiet --all --tags
+git checkout --quiet "$REF"
+# A branch needs the fetched commits merged in; a tag left HEAD detached and is
+# already exactly where it belongs.
+if git symbolic-ref -q HEAD >/dev/null; then
+  git merge --quiet --ff-only "origin/${REF}"
+fi
+echo "    now at $(git log --oneline -1)"
+docker compose up -d --build
+REMOTE
+
+echo "==> Waiting for the service"
+for _ in $(seq 1 30); do
+  # `|| true` because the whole point of the loop is that this fails for a few
+  # seconds while the container starts, and set -e would take the script down with it.
+  REPORTED="$(ssh "$HOST" "curl -sf http://127.0.0.1:8390/healthz" 2>/dev/null \
+    | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' || true)"
+  [[ -n "$REPORTED" ]] && break
+  sleep 2
+done
+
+if [[ -z "${REPORTED:-}" ]]; then
+  echo "The service did not answer /healthz. Check: ssh ${HOST} 'cd ${REMOTE_PATH} && docker compose logs --tail 50'" >&2
+  exit 1
+fi
+
+if [[ "$REPORTED" != "$EXPECTED" ]]; then
+  echo "The service answers contract version ${REPORTED}, this checkout expects ${EXPECTED}." >&2
+  echo "Deploy the ref that carries ${EXPECTED}, or check whether SERVICE_VERSION was bumped." >&2
+  exit 1
+fi
+
+echo "==> Serving contract version ${REPORTED}"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,7 +35,18 @@ curl -s http://127.0.0.1:8390/healthz     # {"ok":true,"version":"..."}
 The database is a SQLite file on the `gander-data` volume, at `/data/gander.db`.
 It is the only state; back up the volume and you have backed up every review.
 
-To update: `git pull && docker compose up -d --build`.
+To update by hand: `git pull && docker compose up -d --build`.
+
+`bin/deploy` does the same over ssh, then waits for the container and checks that
+what came back answers the contract version the checkout expects — a service left
+behind the app is the failure worth catching at deploy time rather than mid-review:
+
+```bash
+export GANDER_DEPLOY_HOST=docker.example.internal   # ssh destination
+export GANDER_DEPLOY_PATH=/home/deploy/docker/gander  # optional, this is the default
+bin/deploy                 # master
+bin/deploy --ref v0.2.0    # a tag
+```
 
 ## Point the app at it
 


### PR DESCRIPTION
Updating the service was ssh, cd, `git pull`, `docker compose up -d --build`, and
reading the output. `bin/deploy` does that for a branch or a tag, waits for the
container, and refuses to call it done unless the running service answers the
contract version the checkout expects.

```bash
export GANDER_DEPLOY_HOST=docker.example.internal
bin/deploy                 # master
bin/deploy --ref v0.2.0    # a tag
```

The host is named by the environment rather than written down here: a deployment
belongs to whoever runs it, and this repository is public.

## Verified against the real host

- A deploy from master pulls, rebuilds, and reports `Serving contract version 0.1.0`
- The same script run from a checkout expecting `0.2.0` stops: *"The service answers contract version 0.1.0, this checkout expects 0.2.0."*

That second case is the failure that reached a review this morning — the app had
a route the deployed service did not — caught at deploy time instead.