### PR TITLE
Make a forgotten contract bump a failing test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,11 @@ contract** — a route added or removed, a field the app comes to rely on. Leavi
 alone lets a stale service answer "the version you wanted", and the mismatch surfaces
 later as a 404 in the middle of a review.
 
+`packages/service/contract.json` records that contract — routes, payload schemas, MCP
+tools — and a test compares it against a running server, so a change fails until the
+version moves. After changing the contract deliberately: bump `SERVICE_VERSION`, then
+run `bin/contract-snapshot`. It refuses while the version is unchanged.
+
 **The repo is public.** No client names, private repo names, or real PR numbers
 in code, comments, commits, or issues.
 
@@ -46,6 +51,7 @@ in code, comments, commits, or issues.
 | Open a review in the running app | `bin/gander --repo owner/name [--pr 42]` |
 | Repair a config the settings schema has outgrown | `bin/fix-config` |
 | Update the service on its host | `bin/deploy` |
+| Re-record the contract after changing it | `bin/contract-snapshot` |
 | Build an unsigned app | `pnpm --filter @gander/app run dist:unsigned` |
 | Isolated working copy | `bin/worktree add <name>` |
 | Check this worktree's MCP bridge | `bin/mcp check` |

--- a/bin/contract-snapshot
+++ b/bin/contract-snapshot
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Re-record the contract snapshot after deliberately changing the contract.
+# It refuses unless SERVICE_VERSION moved too.
+
+cd "$(dirname "$0")/.."
+
+TSX=packages/service/node_modules/.bin/tsx
+[[ -x "$TSX" ]] || { echo "Dependencies are not installed. Run bin/setup first." >&2; exit 1; }
+
+exec "$(pwd)/$TSX" "$(pwd)/bin/contract-snapshot.ts" "$@"

--- a/bin/contract-snapshot.ts
+++ b/bin/contract-snapshot.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describeContract, surfaceOf, type Contract } from "../packages/service/src/contract.js";
+
+/**
+ * Re-records the contract snapshot.
+ *
+ * Refuses when the surface has changed and SERVICE_VERSION has not: updating the snapshot
+ * is the moment someone would otherwise sail past the version bump, so it is the moment to
+ * stop them.
+ */
+
+const SNAPSHOT = join(import.meta.dirname, "..", "packages", "service", "contract.json");
+
+const contract = await describeContract();
+const before: Contract | null = existsSync(SNAPSHOT)
+  ? (JSON.parse(readFileSync(SNAPSHOT, "utf8")) as Contract)
+  : null;
+
+if (before !== null) {
+  const surfaceChanged = JSON.stringify(surfaceOf(before)) !== JSON.stringify(surfaceOf(contract));
+  if (surfaceChanged && before.version === contract.version) {
+    console.error(
+      `The contract has changed and SERVICE_VERSION is still ${contract.version}.\n` +
+      "Bump SERVICE_VERSION in packages/shared/src/index.ts, then run this again.\n" +
+      "A version that does not move lets a stale service answer the version the app wanted.",
+    );
+    process.exit(1);
+  }
+  if (!surfaceChanged && before.version === contract.version) {
+    console.log("The snapshot already matches.");
+    process.exit(0);
+  }
+}
+
+writeFileSync(SNAPSHOT, `${JSON.stringify(contract, null, 2)}\n`);
+console.log(`Recorded the contract at version ${contract.version}.`);

--- a/packages/service/contract.json
+++ b/packages/service/contract.json
@@ -1,0 +1,709 @@
+{
+  "version": "0.2.0",
+  "routes": [
+    "DELETE /api/reviews/:repoId/:prNumber/questions/:id",
+    "DELETE /mcp",
+    "GET /api/reviews/:repoId",
+    "GET /api/reviews/:repoId/:prNumber",
+    "GET /api/reviews/:repoId/:prNumber/questions",
+    "GET /api/reviews/:repoId/:prNumber/snapshot",
+    "GET /healthz",
+    "GET /mcp",
+    "OPTIONS /mcp",
+    "PATCH /mcp",
+    "POST /api/reviews/:repoId/:prNumber/questions",
+    "POST /api/reviews/:repoId/:prNumber/questions/:id/replies",
+    "POST /mcp",
+    "PUT /api/reviews/:repoId/:prNumber/context",
+    "PUT /api/reviews/:repoId/:prNumber/files",
+    "PUT /mcp",
+    "QUERY /mcp",
+    "TRACE /mcp"
+  ],
+  "schemas": {
+    "FileCheckoffSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "checked": {
+          "type": "boolean"
+        },
+        "baseHash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "headHash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "checkedAt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "machine": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "path",
+        "checked",
+        "baseHash",
+        "headHash",
+        "checkedAt",
+        "machine"
+      ]
+    },
+    "FileStatusSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "enum": [
+        "A",
+        "M",
+        "D",
+        "R"
+      ]
+    },
+    "MarkAddressedSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "commitRef": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "note": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "commitRef",
+        "note"
+      ]
+    },
+    "NewQuestionReplySchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "text"
+      ]
+    },
+    "NewQuestionSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "path": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "line": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headSha": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "path",
+        "line",
+        "text",
+        "headSha"
+      ]
+    },
+    "OpenTargetSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "repoId": {
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$"
+        },
+        "prNumber": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "repoId",
+        "prNumber"
+      ]
+    },
+    "PrContextSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "headRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "title": {
+          "type": "string"
+        },
+        "headSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stackId": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "stackSize": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "stackPosition": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "headRef",
+        "title",
+        "headSha",
+        "stackId",
+        "stackSize",
+        "stackPosition"
+      ]
+    },
+    "PutFileStateSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "checked": {
+              "type": "boolean",
+              "const": true
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "baseHash": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "headHash": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "baseContent": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "headContent": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "machine": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "checked",
+            "path",
+            "baseHash",
+            "headHash",
+            "baseContent",
+            "headContent",
+            "machine"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "checked": {
+              "type": "boolean",
+              "const": false
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "checked",
+            "path"
+          ]
+        }
+      ]
+    },
+    "QuestionReplyAuthorSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "enum": [
+        "reviewer",
+        "agent"
+      ]
+    },
+    "QuestionReplySchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "author": {
+          "type": "string",
+          "enum": [
+            "reviewer",
+            "agent"
+          ]
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "createdAt": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "author",
+        "text",
+        "createdAt"
+      ]
+    },
+    "QuestionSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "line": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "addressed",
+            "resolved"
+          ]
+        },
+        "headSha": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "commitRef": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "note": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "createdAt": {
+          "type": "string"
+        },
+        "replies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "author": {
+                "type": "string",
+                "enum": [
+                  "reviewer",
+                  "agent"
+                ]
+              },
+              "text": {
+                "type": "string",
+                "minLength": 1
+              },
+              "createdAt": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "author",
+              "text",
+              "createdAt"
+            ]
+          }
+        }
+      },
+      "required": [
+        "id",
+        "path",
+        "line",
+        "text",
+        "state",
+        "headSha",
+        "commitRef",
+        "note",
+        "createdAt",
+        "replies"
+      ]
+    },
+    "QuestionStateSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "enum": [
+        "open",
+        "addressed",
+        "resolved"
+      ]
+    },
+    "ReviewStateSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "repoId": {
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$"
+        },
+        "prNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "checked": {
+                "type": "boolean"
+              },
+              "baseHash": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "headHash": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "checkedAt": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "machine": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "path",
+              "checked",
+              "baseHash",
+              "headHash",
+              "checkedAt",
+              "machine"
+            ]
+          }
+        }
+      },
+      "required": [
+        "repoId",
+        "prNumber",
+        "files"
+      ]
+    }
+  },
+  "mcpTools": [
+    {
+      "name": "get_review_questions",
+      "description": "Questions the reviewer has left on a pull request, with the file and line each one is about. Derive repo and branch from the working directory. Returns open questions by default — those are the ones still needing work. The response always counts open, addressed, and resolved questions so hidden states are visible. The response names the branch, title, and stack position of the pull request the questions belong to: check it matches the checkout being worked in, because a stacked pull request's sibling is a different branch with different questions.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repo": {
+            "type": "string",
+            "description": "Repository as \"owner/name\", e.g. \"acme/atlas\"."
+          },
+          "branch": {
+            "description": "The working branch. Use this when the pull request number is unknown.",
+            "type": "string"
+          },
+          "prNumber": {
+            "description": "Pull request number, if known.",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "includeAddressed": {
+            "description": "Also return questions already marked addressed. Defaults to false.",
+            "type": "boolean"
+          },
+          "includeResolved": {
+            "description": "Also return questions the reviewer has resolved. Defaults to false.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "repo"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "mark_question_addressed",
+      "description": "Record that a question has been acted on. Use it only once the work is actually done and committed. This does not resolve the question — the reviewer resolves it by re-reviewing the file.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Question id from get_review_questions."
+          },
+          "commitRef": {
+            "description": "Commit that addressed it.",
+            "type": "string"
+          },
+          "note": {
+            "description": "One line on what changed.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "reply_to_question",
+      "description": "Add an agent reply to a review question. Use this for clarification, reasoning, or a response that should remain with the review. Replying does not address or resolve the question and does not change its lifecycle state.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Question id from get_review_questions."
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The reply to add to the question thread."
+          }
+        },
+        "required": [
+          "id",
+          "text"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  ]
+}

--- a/packages/service/src/contract.test.ts
+++ b/packages/service/src/contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { SERVICE_VERSION } from "@gander/shared";
+import { describeContract, surfaceOf, type Contract } from "./contract.js";
+
+const SNAPSHOT = join(import.meta.dirname, "..", "contract.json");
+const recorded = JSON.parse(readFileSync(SNAPSHOT, "utf8")) as Contract;
+
+const WHAT_TO_DO = `
+The app-to-service contract has changed. That is fine — it just has to be declared:
+
+  1. Bump SERVICE_VERSION in packages/shared/src/index.ts
+  2. Run bin/contract-snapshot
+
+A version that does not move is worse than no version at all: a service without the
+change answers exactly the version the app expects, the connection check passes, and
+the mismatch turns up later as a 404 in the middle of a review.
+`;
+
+describe("the app-to-service contract", () => {
+  it("matches the recorded snapshot", async () => {
+    const current = await describeContract();
+    expect(surfaceOf(current), WHAT_TO_DO).toEqual(surfaceOf(recorded));
+  });
+
+  it("is recorded at the version the code claims", () => {
+    expect(recorded.version, WHAT_TO_DO).toBe(SERVICE_VERSION);
+  });
+});

--- a/packages/service/src/contract.ts
+++ b/packages/service/src/contract.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import * as shared from "@gander/shared";
+import { buildServer } from "./server.js";
+import { openStorage } from "./storage.js";
+
+/**
+ * Everything the app and an agent are promised, in a form a test can compare.
+ *
+ * `SERVICE_VERSION` only protects anyone if it moves when this surface moves, and nothing
+ * re-reads that rule while writing a route. Describing the surface makes forgetting it a
+ * failing test rather than a 404 in the middle of a review.
+ *
+ * Read from a running server rather than from a list kept by hand, because a list kept by
+ * hand is the same promise this exists to stop relying on.
+ */
+
+export interface Contract {
+  version: string;
+  /** Every HTTP route, as "METHOD /path". */
+  routes: string[];
+  /** Each exported payload schema as JSON Schema, so a field added or a rule loosened shows up. */
+  schemas: Record<string, unknown>;
+  /** The agent-facing tools: name, description, and accepted input. */
+  mcpTools: Array<{ name: string; description: string; inputSchema: unknown }>;
+}
+
+function schemas(): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(shared)) {
+    if (!name.endsWith("Schema")) continue;
+    // Everything exported under that suffix is a Zod schema; a future export that is not
+    // should fail here loudly rather than be skipped quietly.
+    out[name] = z.toJSONSchema(value as z.ZodType, { io: "input", unrepresentable: "any" });
+  }
+  return out;
+}
+
+export async function describeContract(): Promise<Contract> {
+  const dir = mkdtempSync(join(tmpdir(), "gander-contract-"));
+  const storage = openStorage(join(dir, "contract.db"));
+  const routes: string[] = [];
+  const server = buildServer({
+    storage,
+    token: "contract",
+    version: shared.SERVICE_VERSION,
+    onRoute: (method, path) => routes.push(`${method} ${path}`),
+  });
+
+  try {
+    const baseUrl = await server.listen({ host: "127.0.0.1", port: 0 });
+    const client = new Client({ name: "contract", version: "1.0.0" });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+        requestInit: { headers: { Authorization: "Bearer contract" } },
+      }),
+    );
+    const { tools } = await client.listTools();
+    await client.close();
+
+    return {
+      version: shared.SERVICE_VERSION,
+      routes: [...routes].sort(),
+      schemas: schemas(),
+      mcpTools: tools
+        .map((tool) => ({
+          name: tool.name,
+          description: tool.description ?? "",
+          inputSchema: tool.inputSchema,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    };
+  } finally {
+    await server.close();
+    storage.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** The surface without the version, which is what has to be identical between two releases. */
+export function surfaceOf(contract: Contract): Omit<Contract, "version"> {
+  const { version: _version, ...surface } = contract;
+  return surface;
+}

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -12,8 +12,24 @@ function parsePrNumber(raw: string, reply: FastifyReply): number | undefined {
   return n;
 }
 
-export function buildServer(opts: { storage: Storage; token: string; version: string }): FastifyInstance {
+export function buildServer(opts: {
+  storage: Storage;
+  token: string;
+  version: string;
+  /** Called for each route as it is registered. The contract snapshot reads the route table this way. */
+  onRoute?: (method: string, path: string) => void;
+}): FastifyInstance {
   const app = Fastify({ logger: false });
+
+  // Added before any route, because the hook only sees registrations that follow it.
+  if (opts.onRoute) {
+    const report = opts.onRoute;
+    app.addHook("onRoute", (route) => {
+      const methods = Array.isArray(route.method) ? route.method : [route.method];
+      // HEAD is generated for every GET; it is not a separate promise to anyone.
+      for (const method of methods) if (method !== "HEAD") report(method, route.path);
+    });
+  }
 
   app.get("/healthz", async () => ({ ok: true, version: opts.version }));
 


### PR DESCRIPTION
Closes #71.

`SERVICE_VERSION` only protects anyone if it moves when the contract moves, and
the first time that mattered it did not — a route was added, the constant stayed
put, and a service without that route answered exactly the version the app
expected. The connection check passed; the 404 arrived later, mid-review.

| Piece | |
|---|---|
| `packages/service/src/contract.ts` | Describes the surface: every route, every exported payload schema as JSON Schema, the MCP tools and their inputs |
| `packages/service/contract.json` | The recorded surface, and the version it belongs to |
| `contract.test.ts` | Compares a running server against the record, and says what to do when they differ |
| `bin/contract-snapshot` | Re-records — and refuses while `SERVICE_VERSION` is unchanged |

The description is read from a running server rather than a list kept by hand:
a list kept by hand is the same promise this exists to stop relying on. Routes
come from Fastify's own registration hook, tools from a real MCP client calling
`tools/list`.

## Proved, not assumed

Added a route without touching the version:

- the test failed, with `1. Bump SERVICE_VERSION in packages/shared/src/index.ts`
- `bin/contract-snapshot` refused: *"The contract has changed and SERVICE_VERSION is still 0.2.0."*
- bumping to 0.3.0 let the recorder through and the test pass
- reverting both restored the original snapshot exactly

304 unit tests pass, typecheck clean.

Together with `bin/deploy`, which refuses to finish when the running service
answers a different version than the checkout expects, the loop is closed: the
test catches a bump that never happened, the deploy catches a service that never
got the bump.