### PR TITLE
Stop declaring a body on requests that have none

### DIFF
--- a/packages/app/src/main/service-client.test.ts
+++ b/packages/app/src/main/service-client.test.ts
@@ -47,3 +47,37 @@ describe("a failed request", () => {
     expect(error).not.toContain("{");
   });
 });
+
+describe("a request with no body", () => {
+  it("deletes without declaring a content type it is not sending", async () => {
+    // The service's own tests drive DELETE through app.inject, which sends no
+    // Content-Type — so the header the real client sets was never exercised, and every
+    // delete from the app failed against a real listener.
+    const seen: Array<string | undefined> = [];
+    const url = await serve((app) => {
+      app.delete("/api/reviews/:repoId/:prNumber/questions/:id", async (req, reply) => {
+        seen.push(req.headers["content-type"]);
+        return reply.code(204).send();
+      });
+    });
+    const client = createServiceClient(() => ({ url, token: "t" }));
+    await expect(client.deleteQuestion("acme/atlas", 1, 2)).resolves.toBeUndefined();
+    expect(seen).toEqual([undefined]);
+  });
+
+  it("still declares it when there is a body", async () => {
+    const seen: Array<string | undefined> = [];
+    const url = await serve((app) => {
+      app.post("/api/reviews/:repoId/:prNumber/questions", async (req, reply) => {
+        seen.push(req.headers["content-type"]);
+        return reply.code(201).send({
+          id: 1, path: "a.rb", line: null, text: "why?", state: "open", replies: [],
+          headSha: null, commitRef: null, note: null, createdAt: new Date().toISOString(),
+        });
+      });
+    });
+    const client = createServiceClient(() => ({ url, token: "t" }));
+    await client.addQuestion("acme/atlas", 1, { path: "a.rb", line: null, text: "why?", headSha: null });
+    expect(seen).toEqual(["application/json"]);
+  });
+});

--- a/packages/app/src/main/service-client.ts
+++ b/packages/app/src/main/service-client.ts
@@ -112,7 +112,11 @@ export function createServiceClient(connection: Connection): ServiceClient {
       && (options.reviewKey === undefined || !reviewsReadSinceRecovery.has(options.reviewKey))) {
       throw new ServiceConnectionError(STALE_SERVICE_DATA_WRITE_ERROR);
     }
-    const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+    // Content-Type only when something is being sent. Declaring JSON and sending nothing
+    // is a 400 from Fastify — "Body cannot be empty when content-type is set" — which is
+    // how every body-less DELETE failed.
+    const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
     let res: Response;
     try {
       res = await fetch(`${baseUrl}${path}`, { method, headers, body: body === undefined ? undefined : JSON.stringify(body) });


### PR DESCRIPTION
Deleting a question failed against the real service:

```
Gander service 400 on DELETE …/questions/2: Body cannot be empty when
content-type is set to 'application/json'
```

The client set `Content-Type: application/json` on every request, including the
ones it sends nothing with. Fastify rejects that.

## Why nothing caught it

The service's tests drive DELETE through `app.inject`, which sends no
`Content-Type` — so the route was covered and the request the app actually makes
was not. The new tests go through the client to a real listener and assert on the
header the server received, in both directions: absent with no body, present with
one.

Verified by reverting the fix — the delete test fails with the same message the
app showed.