### PR TITLE
Harden service deployment and config recovery

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -5,8 +5,8 @@ set -euo pipefail
 #
 # The service runs from a clone rather than a published image, so deploying is a
 # pull and a rebuild. This does that, waits for the container to come back, and
-# checks that what is now running answers the contract version this checkout
-# expects — a service behind the app is the failure this is here to catch.
+# checks that what is now running answers the contract version in the deployed
+# ref — a partial or stale deployment is the failure this is here to catch.
 #
 # The host is not written down here: this repository is public, and a deployment
 # is the operator's. Set these once, in a shell profile or a password manager:
@@ -29,15 +29,16 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# What this checkout believes the service should answer.
-EXPECTED="$(sed -n 's/.*SERVICE_VERSION = "\([^"]*\)".*/\1/p' packages/shared/src/index.ts | head -1)"
-[[ -n "$EXPECTED" ]] || { echo "Could not read SERVICE_VERSION from packages/shared/src/index.ts" >&2; exit 1; }
-
 echo "==> Deploying ${REF} to ${HOST}:${REMOTE_PATH}"
 ssh "$HOST" bash -euo pipefail -s -- "$REMOTE_PATH" "$REF" <<'REMOTE'
 REMOTE_PATH="$1"
 REF="$2"
 cd "$REMOTE_PATH"
+if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
+  echo "Refusing to deploy from a checkout with local changes: ${REMOTE_PATH}" >&2
+  git status --short >&2
+  exit 1
+fi
 git fetch --quiet --all --tags
 git checkout --quiet "$REF"
 # A branch needs the fetched commits merged in; a tag left HEAD detached and is
@@ -49,11 +50,26 @@ echo "    now at $(git log --oneline -1)"
 docker compose up -d --build
 REMOTE
 
+# Read both facts from the deployed checkout and Compose project. This keeps tag
+# deployments independent of the caller's checkout and follows a non-default
+# GANDER_PUBLISH_PORT without duplicating its configuration here.
+DEPLOY_INFO="$(ssh "$HOST" bash -euo pipefail -s -- "$REMOTE_PATH" <<'REMOTE'
+cd "$1"
+EXPECTED="$(sed -n 's/.*SERVICE_VERSION = "\([^"]*\)".*/\1/p' packages/shared/src/index.ts | head -1)"
+[[ -n "$EXPECTED" ]] || { echo "Could not read the deployed SERVICE_VERSION" >&2; exit 1; }
+PUBLISHED="$(docker compose port gander 8390 | head -1)"
+PUBLISHED_PORT="${PUBLISHED##*:}"
+[[ "$PUBLISHED_PORT" =~ ^[0-9]+$ ]] || { echo "Could not determine the published service port from ${PUBLISHED}" >&2; exit 1; }
+printf '%s\t%s\n' "$EXPECTED" "$PUBLISHED_PORT"
+REMOTE
+)"
+IFS=$'\t' read -r EXPECTED PUBLISHED_PORT <<< "$DEPLOY_INFO"
+
 echo "==> Waiting for the service"
 for _ in $(seq 1 30); do
   # `|| true` because the whole point of the loop is that this fails for a few
   # seconds while the container starts, and set -e would take the script down with it.
-  REPORTED="$(ssh "$HOST" "curl -sf http://127.0.0.1:8390/healthz" 2>/dev/null \
+  REPORTED="$(ssh "$HOST" curl -sf "http://127.0.0.1:${PUBLISHED_PORT}/healthz" 2>/dev/null \
     | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' || true)"
   [[ -n "$REPORTED" ]] && break
   sleep 2
@@ -65,8 +81,8 @@ if [[ -z "${REPORTED:-}" ]]; then
 fi
 
 if [[ "$REPORTED" != "$EXPECTED" ]]; then
-  echo "The service answers contract version ${REPORTED}, this checkout expects ${EXPECTED}." >&2
-  echo "Deploy the ref that carries ${EXPECTED}, or check whether SERVICE_VERSION was bumped." >&2
+  echo "The service answers contract version ${REPORTED}, but ${REF} declares ${EXPECTED}." >&2
+  echo "The container may be stale; check its build and whether SERVICE_VERSION was bumped." >&2
   exit 1
 fi
 

--- a/bin/deploy.test.ts
+++ b/bin/deploy.test.ts
@@ -1,0 +1,82 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync, spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const command = join(dirname(fileURLToPath(import.meta.url)), "deploy");
+let dir: string;
+let remote: string;
+let fakeBin: string;
+let curlLog: string;
+let dockerLog: string;
+
+function executable(path: string, contents: string): void {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "gander-deploy-"));
+  remote = join(dir, "remote");
+  fakeBin = join(dir, "bin");
+  curlLog = join(dir, "curl.log");
+  dockerLog = join(dir, "docker.log");
+  execFileSync("mkdir", ["-p", join(remote, "packages/shared/src"), fakeBin]);
+  writeFileSync(join(remote, "packages/shared/src/index.ts"), 'export const SERVICE_VERSION = "0.1.0";\n');
+  execFileSync("git", ["init", "-q"], { cwd: remote });
+  execFileSync("git", ["add", "."], { cwd: remote });
+  execFileSync("git", ["-c", "user.name=Gander Test", "-c", "user.email=test@example.test", "commit", "-qm", "release"], { cwd: remote });
+  execFileSync("git", ["tag", "v0.1.0"], { cwd: remote });
+
+  executable(join(fakeBin, "ssh"), "#!/usr/bin/env bash\nset -euo pipefail\nshift\nexec \"$@\"\n");
+  executable(join(fakeBin, "docker"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
+if [[ "$1 $2" == "compose port" ]]; then printf '0.0.0.0:%s\\n' "$FAKE_PORT"; fi
+`);
+  executable(join(fakeBin, "curl"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "\${@: -1}" >> "$FAKE_CURL_LOG"
+printf '{"ok":true,"version":"%s"}\\n' "$FAKE_SERVICE_VERSION"
+`);
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function deploy(): ReturnType<typeof spawnSync> {
+  return spawnSync(command, ["--ref", "v0.1.0"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      GANDER_DEPLOY_HOST: "local-test",
+      GANDER_DEPLOY_PATH: remote,
+      FAKE_CURL_LOG: curlLog,
+      FAKE_DOCKER_LOG: dockerLog,
+      FAKE_PORT: "19420",
+      FAKE_SERVICE_VERSION: "0.1.0",
+    },
+  });
+}
+
+describe("bin/deploy", () => {
+  it("verifies a tag against its own version on its actual published port", () => {
+    const result = deploy();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("Serving contract version 0.1.0");
+    expect(readFileSync(curlLog, "utf8")).toContain("http://127.0.0.1:19420/healthz");
+  });
+
+  it("refuses to build a remote checkout with local changes", () => {
+    writeFileSync(join(remote, "packages/shared/src/index.ts"), 'export const SERVICE_VERSION = "changed";\n');
+
+    const result = deploy();
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Refusing to deploy from a checkout with local changes");
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+});

--- a/bin/fix-config.test.ts
+++ b/bin/fix-config.test.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadConfig } from "../packages/app/src/main/config.js";
+import { DEFAULT_APP_SETTINGS } from "../packages/app/src/settings.js";
+
+const command = join(dirname(fileURLToPath(import.meta.url)), "fix-config");
+let dir: string;
+let configPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "gander-fix-config-"));
+  configPath = join(dir, "config.json");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function run(): ReturnType<typeof spawnSync> {
+  return spawnSync(command, [configPath], { encoding: "utf8" });
+}
+
+describe("bin/fix-config", () => {
+  it("removes stale keys and writes a config the app can load", () => {
+    writeFileSync(configPath, JSON.stringify({
+      serviceUrl: "http://localhost:8390",
+      serviceToken: "token",
+      settings: DEFAULT_APP_SETTINGS,
+      repos: [],
+      zoomLevel: 2,
+    }));
+
+    const result = run();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(loadConfig(configPath).serviceUrl).toBe("http://localhost:8390");
+    expect(JSON.parse(readFileSync(configPath, "utf8"))).not.toHaveProperty("zoomLevel");
+    expect(existsSync(`${configPath}.bak`)).toBe(true);
+  });
+
+  it("does not replace the file when non-settings values remain invalid", () => {
+    const original = JSON.stringify({
+      serviceUrl: "not a URL",
+      serviceToken: "token",
+      settings: DEFAULT_APP_SETTINGS,
+      repos: [{ repoId: "not-a-repo", url: "https://example.test" }],
+    });
+    writeFileSync(configPath, original);
+
+    const result = run();
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/serviceUrl|repoId/);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(existsSync(`${configPath}.bak`)).toBe(false);
+  });
+});

--- a/bin/fix-config.ts
+++ b/bin/fix-config.ts
@@ -2,6 +2,7 @@ import { chmodSync, copyFileSync, existsSync, readFileSync, writeFileSync } from
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { AppSettingsSchema, DEFAULT_APP_SETTINGS } from "../packages/app/src/settings.js";
+import { ConfigSchema } from "../packages/app/src/main/config.js";
 
 const path = process.argv[2] ?? join(homedir(), ".config", "gander", "config.json");
 if (!existsSync(path)) {
@@ -51,7 +52,17 @@ const after: Json = {
   repos: Array.isArray(before.repos) ? before.repos : [],
 };
 
-const changed = JSON.stringify(before) !== JSON.stringify(after);
+const repaired = ConfigSchema.safeParse(after);
+if (!repaired.success) {
+  console.error(`Could not repair ${path}:`);
+  for (const issue of repaired.error.issues) {
+    console.error(`  ${issue.path.join(".") || "config"}: ${issue.message}`);
+  }
+  console.error("Fix those values by hand. The original file has not been changed.");
+  process.exit(1);
+}
+
+const changed = JSON.stringify(before) !== JSON.stringify(repaired.data);
 if (!changed) {
   console.log(`${path} already matches the current schema.`);
   process.exit(0);
@@ -59,9 +70,9 @@ if (!changed) {
 
 copyFileSync(path, `${path}.bak`);
 chmodSync(`${path}.bak`, 0o600);
-writeFileSync(path, `${JSON.stringify(after, null, 2)}\n`, { mode: 0o600 });
+writeFileSync(path, `${JSON.stringify(repaired.data, null, 2)}\n`, { mode: 0o600 });
 chmodSync(path, 0o600);
 
-const dropped = Object.keys(before).filter((k) => !(k in after));
+const dropped = Object.keys(before).filter((k) => !(k in repaired.data));
 console.log(`Repaired ${path} (previous kept as ${path}.bak)`);
 if (dropped.length > 0) console.log(`  dropped: ${dropped.join(", ")}`);

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -38,7 +38,7 @@ It is the only state; back up the volume and you have backed up every review.
 To update by hand: `git pull && docker compose up -d --build`.
 
 `bin/deploy` does the same over ssh, then waits for the container and checks that
-what came back answers the contract version the checkout expects — a service left
+what came back answers the contract version the deployed ref declares — a service left
 behind the app is the failure worth catching at deploy time rather than mid-review:
 
 ```bash

--- a/packages/app/src/main/config.ts
+++ b/packages/app/src/main/config.ts
@@ -9,7 +9,7 @@ import { AppSettingsSchema, DEFAULT_APP_SETTINGS, type AppSettings } from "../se
 // an arbitrary string into both a filesystem path (clone directory name) and a GitHub API URL.
 const RepoIdSchema = z.string().regex(/^[^/]+\/[^/]+$/, "must look like owner/repo");
 
-const ConfigSchema = z
+export const ConfigSchema = z
   .object({
     // Empty until the reviewer enters a connection. An installed app has no dev stack to
     // generate one, so it has to start unconfigured, show its settings, and be told —

--- a/packages/app/src/main/service-client.test.ts
+++ b/packages/app/src/main/service-client.test.ts
@@ -29,6 +29,18 @@ describe("a failed request", () => {
     await expect(client.getReview("acme/atlas", 1)).rejects.toThrow(/does not have GET .*older than this app/s);
   });
 
+  it("keeps the explanation from a resource 404", async () => {
+    const url = await serve((app) => {
+      app.get("/api/reviews/:repoId/:prNumber", async (_req, reply) => {
+        return reply.code(404).send({ error: "no review for that pull request" });
+      });
+    });
+    const client = createServiceClient(() => ({ url, token: "t" }));
+    const error = await client.getReview("acme/atlas", 1).catch((e: Error) => e.message);
+    expect(error).toContain("no review for that pull request");
+    expect(error).not.toContain("older than this app");
+  });
+
   it("says where to fix a rejected token", async () => {
     const url = await serve((app) => {
       app.get("/api/reviews/:repoId/:prNumber", async (_req, reply) => reply.code(401).send({ error: "nope" }));

--- a/packages/app/src/main/service-client.ts
+++ b/packages/app/src/main/service-client.ts
@@ -43,13 +43,20 @@ async function describeFailure(res: Response, method: string, baseUrl: string, p
   const body = (await res.text().catch(() => "")).trim();
   // Fastify reports its own errors as JSON; anything else is shown as it came.
   let detail = body;
+  let missingRoute = false;
   try {
-    const parsed = JSON.parse(body) as { message?: unknown; error?: unknown };
+    const parsed = JSON.parse(body) as { statusCode?: unknown; message?: unknown; error?: unknown };
     if (typeof parsed.message === "string") detail = parsed.message;
     else if (typeof parsed.error === "string") detail = parsed.error;
+    // A Fastify routing 404 means the connected service predates this app. Handlers also
+    // use 404 for missing review resources, and those must retain their own explanation.
+    missingRoute = parsed.statusCode === 404
+      && parsed.error === "Not Found"
+      && typeof parsed.message === "string"
+      && /^Route \S+:.+ not found$/.test(parsed.message);
   } catch { /* not JSON */ }
 
-  if (res.status === 404) {
+  if (res.status === 404 && missingRoute) {
     return `The review service at ${baseUrl} does not have ${method} ${path}. It is older than this app — update the service, or point this app at one that matches.`;
   }
   if (res.status === 401 || res.status === 403) {


### PR DESCRIPTION
## What changed

- verify deployments against the contract version declared by the deployed ref
- discover the service's actual Compose-published port instead of assuming 8390
- refuse to build from a dirty remote checkout
- distinguish missing Fastify routes from legitimate resource 404 responses
- validate the complete repaired config before replacing the original
- add real-Git deployment tests and config-repair regression coverage

## Why

The new deployment and recovery tooling could report false failures for tag deployments and custom ports, build source that did not match the requested ref, and write a config that the app still rejected. The client also described every 404 as service version skew even when a resource was genuinely missing.

## Impact

Deployments now verify the artifact that was actually requested and fail before building ambiguous source. Config repair leaves invalid originals untouched, and reviewer-facing errors retain useful resource details.

## Verification

- `CI=true pnpm typecheck`
- `CI=true pnpm test` - 311 tests passed
- `bin/contract-snapshot`
- `bash -n bin/deploy bin/fix-config`
- `shellcheck bin/deploy bin/fix-config`
