### PR TITLE
Ask before deleting a question

### DIFF
--- a/packages/app/src/renderer/src/components/ConfirmDialog.vue
+++ b/packages/app/src/renderer/src/components/ConfirmDialog.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
+/**
+ * A modal for the one thing in this app that cannot be undone.
+ *
+ * Built on the native `<dialog>` rather than a floating div: it brings the focus trap,
+ * the backdrop, Escape, and the top layer with it, and none of those are worth
+ * reimplementing for a two-button question.
+ */
+
+const props = defineProps<{
+  open: boolean;
+  title: string;
+  detail?: string;
+  confirmLabel: string;
+}>();
+const emit = defineEmits<{ confirm: []; cancel: [] }>();
+
+const dialog = ref<HTMLDialogElement | null>(null);
+
+watch(() => props.open, (open) => {
+  const element = dialog.value;
+  if (element === null) return;
+  if (open && !element.open) element.showModal();
+  if (!open && element.open) element.close();
+});
+</script>
+
+<template>
+  <!-- `close` fires for Escape and for the backdrop, so cancelling never needs its own
+       key handling. -->
+  <dialog ref="dialog" class="confirm" @close="emit('cancel')" @cancel.prevent="emit('cancel')">
+    <h2>{{ title }}</h2>
+    <p v-if="detail" class="detail">{{ detail }}</p>
+    <div class="actions">
+      <button type="button" class="cancel" @click="emit('cancel')">Cancel</button>
+      <!-- Focused on open, matching the editor this app is modelled on: the reviewer
+           opened this dialog on purpose, and Escape is always the way out. -->
+      <button ref="confirmButton" type="button" class="danger" autofocus @click="emit('confirm')">
+        {{ confirmLabel }}
+      </button>
+    </div>
+  </dialog>
+</template>
+
+<style scoped>
+.confirm {
+  min-width: 340px; max-width: 460px; padding: 18px 20px 16px;
+  border: 1px solid var(--workbench-border); border-radius: 8px;
+  background: var(--panel-background); color: var(--workbench-foreground);
+  box-shadow: 0 16px 40px rgb(0 0 0 / .45);
+}
+.confirm::backdrop { background: rgb(0 0 0 / .45); }
+h2 { font-size: 14px; line-height: 1.35; }
+.detail { margin-top: 7px; color: var(--faint-foreground); font-size: 12px; line-height: 1.5; }
+.actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 18px; }
+button {
+  height: 28px; padding: 0 13px; border-radius: 5px; border: 1px solid var(--workbench-border);
+  background: var(--input-background); color: var(--workbench-foreground);
+  font: inherit; font-size: 12px; cursor: pointer;
+}
+button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.danger { border-color: var(--danger); background: var(--danger); color: var(--workbench-background); }
+</style>

--- a/packages/app/src/renderer/src/components/QuestionThread.vue
+++ b/packages/app/src/renderer/src/components/QuestionThread.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, shallowRef } from "vue";
 import type { Question } from "@gander/shared";
+import ConfirmDialog from "./ConfirmDialog.vue";
 import {
   Check,
   CheckCheck,
@@ -24,6 +25,18 @@ const emit = defineEmits<{
   delete: [questionId: number];
 }>();
 const draft = defineModel<string>({ default: "" });
+
+// Deleting a question is the only thing here that cannot be taken back: the text, the
+// line it was captured against, and any reasoning an agent replied with all go together.
+const confirmingDelete = shallowRef(false);
+
+const deleteDetail = computed(() => {
+  const replies = props.question.replies.length;
+  const thread = replies === 0
+    ? "The question"
+    : `The question and ${replies === 1 ? "its reply" : `its ${replies} replies`}`;
+  return `${thread} will be removed from the review. This cannot be undone.`;
+});
 
 // A keyed thread instance survives service refreshes, so a reviewer's disclosure
 // choice remains stable even when a reply replaces the Question object.
@@ -145,12 +158,21 @@ function formatTimestamp(value: string): string {
           class="delete"
           type="button"
           :aria-label="`Delete question ${question.id}`"
-          @click="emit('delete', question.id)"
+          @click="confirmingDelete = true"
         >
           <Trash2 :size="13" aria-hidden="true" />
           Delete
         </button>
       </div>
+
+      <ConfirmDialog
+        :open="confirmingDelete"
+        :title="`Delete this question?`"
+        :detail="deleteDetail"
+        confirm-label="Delete"
+        @cancel="confirmingDelete = false"
+        @confirm="confirmingDelete = false; emit('delete', question.id)"
+      />
     </section>
   </li>
 </template>

--- a/packages/app/src/renderer/src/components/QuestionsDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/QuestionsDrawer.test.ts
@@ -7,6 +7,19 @@ import type { Store } from "../store.js";
 import { pendingReveal } from "../selection.js";
 import QuestionsDrawer from "./QuestionsDrawer.vue";
 
+// jsdom ships the <dialog> element without showModal/close; Chromium, which is what the
+// app runs on, has both. Shimmed here rather than softened in the component, so the
+// production path stays the one the browser actually takes.
+if (typeof HTMLDialogElement !== "undefined" && !HTMLDialogElement.prototype.showModal) {
+  HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+    this.open = false;
+    this.dispatchEvent(new Event("close"));
+  };
+}
+
 const view = (questions: PrView["questions"]): PrView => ({
   pr: { number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" },
   files: [],
@@ -144,7 +157,34 @@ describe("QuestionsDrawer", () => {
     expect(addReviewerReply).toHaveBeenCalledWith(1, "A reviewer follow-up");
 
     await open.get("button[aria-label='Delete question 1']").trigger("click");
+    // The click opens the confirmation; nothing is deleted until it is answered.
+    expect(deleteQuestion).not.toHaveBeenCalled();
+    await open.get("dialog.confirm button.danger").trigger("click");
     expect(deleteQuestion).toHaveBeenCalledWith(1);
+  });
+
+  it("deletes nothing when the confirmation is dismissed", async () => {
+    const deleteQuestion = vi.fn(async () => {});
+    const drawerStore = store(questions, { deleteQuestion });
+    const wrapper = mount(QuestionsDrawer, { props: { store: drawerStore, dock: "right" } });
+    const open = wrapper.get("[data-question-id='1']");
+
+    await open.get("button[aria-label='Delete question 1']").trigger("click");
+    await open.get("dialog.confirm button.cancel").trigger("click");
+    expect(deleteQuestion).not.toHaveBeenCalled();
+
+    // And the dialog is available again rather than stuck shut.
+    await open.get("button[aria-label='Delete question 1']").trigger("click");
+    await open.get("dialog.confirm button.danger").trigger("click");
+    expect(deleteQuestion).toHaveBeenCalledWith(1);
+  });
+
+  it("counts what a delete would take with it", async () => {
+    const drawerStore = store(questions);
+    const wrapper = mount(QuestionsDrawer, { props: { store: drawerStore, dock: "right" } });
+    const open = wrapper.get("[data-question-id='1']");
+    await open.get("button[aria-label='Delete question 1']").trigger("click");
+    expect(open.get("dialog.confirm .detail").text()).toMatch(/cannot be undone/);
   });
 
   it("preserves an explicit disclosure choice when a reply refreshes the question", async () => {


### PR DESCRIPTION
Deleting a question was one click, on a control sitting beside Copy thread. It
takes the question, the line it was captured against, and any reasoning an agent
replied with — and nothing brings it back.

The modal names what goes: *"The question and its 2 replies will be removed from
the review. This cannot be undone."* Escape and the backdrop cancel. Delete is
focused on open, matching VS Code, since the reviewer opened the dialog on
purpose and Escape is always the way out.

Built on the native `<dialog>`: focus trap, backdrop, top layer and Escape all
come with it, and none are worth reimplementing for two buttons.

## Tests

- The delete button opens the dialog and deletes nothing
- Cancelling deletes nothing, and the dialog opens again afterwards rather than sticking shut
- Confirming deletes

jsdom ships `<dialog>` without `showModal`/`close`; Chromium has both. The tests
shim them rather than the component weakening to suit a browser it never runs in.