### PR TITLE
Set the app id to com.clevertakes.gander

### DIFF
--- a/packages/app/electron-builder.yml
+++ b/packages/app/electron-builder.yml
@@ -1,4 +1,4 @@
-appId: ca.sevenview.gander
+appId: com.clevertakes.gander
 productName: Gander
 copyright: Copyright © 2026 Stephen Clarke
 


### PR DESCRIPTION
Moves the macOS bundle identifier off the Sevenview namespace — Gander is a personal project. Done now, before anyone outside this machine has it installed.

https://claude.ai/code/session_014mnrLdA3iKT64p1Hum4y25