### PR TITLE
Show the unresolved question count on a file row

### DIFF
--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -192,6 +192,58 @@ describe("FileTree", () => {
     expect(wrapper.findAll(".tnode.isdir .chev")).toHaveLength(3);
   });
 
+  it("counts unresolved questions on a file and leaves resolved ones out", () => {
+    const target = file("app/models/member.rb");
+    const other = file("app/models/local.rb");
+    const question = (id: number, path: string, state: "open" | "addressed" | "resolved") => ({
+      id,
+      path,
+      line: id,
+      text: `Question ${id}`,
+      state,
+      headSha: "b",
+      commitRef: null,
+      note: null,
+      createdAt: "2026-08-18T00:00:00.000Z",
+      replies: [],
+    });
+    const { store } = fakeStore(prView(1, [target, other], [
+      question(1, target.path, "open"),
+      question(2, target.path, "addressed"),
+      question(3, target.path, "resolved"),
+      question(4, other.path, "resolved"),
+    ]));
+    const wrapper = mount(FileTree, { props: { store, iconTheme: "catppuccin-mocha" } });
+
+    const marker = fileRow(wrapper, target.path).find(".qmark");
+    expect(marker.find(".qcount").text()).toBe("2");
+    expect(marker.attributes("title")).toBe("2 unresolved questions on this file");
+    // Its only question is resolved, so the file carries no marker at all.
+    expect(fileRow(wrapper, other.path).find(".qmark").exists()).toBe(false);
+  });
+
+  it("shows the marker without a number when a file has a single question", () => {
+    const target = file("app/models/member.rb");
+    const { store } = fakeStore(prView(1, [target], [{
+      id: 1,
+      path: target.path,
+      line: 1,
+      text: "Check this line",
+      state: "open" as const,
+      headSha: "b",
+      commitRef: null,
+      note: null,
+      createdAt: "2026-08-18T00:00:00.000Z",
+      replies: [],
+    }]));
+    const wrapper = mount(FileTree, { props: { store, iconTheme: "catppuccin-mocha" } });
+
+    const marker = fileRow(wrapper, target.path).find(".qmark");
+    expect(marker.exists()).toBe(true);
+    expect(marker.find(".qcount").exists()).toBe(false);
+    expect(marker.attributes("title")).toBe("1 unresolved question on this file");
+  });
+
   it("applies effective typography once at the root so every nested row inherits it", () => {
     const { store } = fakeStore(prView(1, treeFiles));
     const wrapper = mount(FileTree, {

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -34,13 +34,20 @@ const rootTypographyStyle = computed(() => depth.value === 0 && props.typography
 // instead of walking the subtree on every call.
 // FileTree renders itself recursively, so every level would otherwise re-scan the whole
 // question list per row.
+// Resolved questions are finished business, so they stop marking the file — otherwise a
+// heavily reviewed file wears the marker forever.
 const questionCounts = computed(() => {
   const map = new Map<string, number>();
   for (const q of props.store.view?.questions ?? []) {
-    if (q.path !== null) map.set(q.path, (map.get(q.path) ?? 0) + 1);
+    if (q.path !== null && q.state !== "resolved") map.set(q.path, (map.get(q.path) ?? 0) + 1);
   }
   return map;
 });
+
+function questionTitle(path: string): string {
+  const count = questionCounts.value.get(path) ?? 0;
+  return `${count} unresolved question${count === 1 ? "" : "s"} on this file`;
+}
 
 const dirStates = computed(() => {
   const map = new Map<string, "all" | "some" | "none">();
@@ -152,12 +159,12 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
         ><Check :size="12" :stroke-width="3" /></span>
         <FileIcon :src="fileIcon(node.file.path).src" :data-icon-id="fileIcon(node.file.path).id" />
         <span class="fname">{{ fileName(node.file.path) }}</span>
-        <MessageSquare
-          v-if="questionCounts.get(node.file.path)"
-          class="qmark"
-          :size="12"
-          :title="`${questionCounts.get(node.file.path)} question(s) on this file`"
-        />
+        <span v-if="questionCounts.get(node.file.path)" class="qmark" :title="questionTitle(node.file.path)">
+          <MessageSquare :size="12" />
+          <!-- The icon alone already says "one question"; the number earns its space only
+               once there is more than one. -->
+          <span v-if="questionCounts.get(node.file.path)! > 1" class="qcount">{{ questionCounts.get(node.file.path) }}</span>
+        </span>
         <span v-if="node.file.changedSince" class="delta-mark" title="Changed since your review" />
         <span class="st" :class="node.file.status">{{ node.file.status }}</span>
       </div>
@@ -183,6 +190,7 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
 .cb.on { border-color: var(--success); color: var(--success); }
 .cb.part { border-color: var(--success); color: var(--success); }
 .tnode.checked .fname { color: var(--faint-foreground); }
-.qmark { color: var(--accent); flex: none; }
+.qmark { display: inline-flex; align-items: center; gap: 2px; color: var(--accent); flex: none; }
+.qcount { font-size: 10px; line-height: 1; font-variant-numeric: tabular-nums; }
 .delta-mark { width: 7px; height: 7px; border-radius: 50%; background: var(--warning); flex: none; }
 </style>


### PR DESCRIPTION
The file tree already showed a comment icon on files carrying questions. Two changes:

- The count appears beside the icon when a file has more than one. A single question needs no number.
- Resolved questions no longer mark the file. Open and addressed still do — addressed means an agent says it handled it, which is exactly when you want to look.

https://claude.ai/code/session_014mnrLdA3iKT64p1Hum4y25