### PR TITLE
Repair the Electron download on every install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,9 +73,12 @@ another worktree's port, token, config, database, or process.
 **Electron install trap:** Electron 33's extract-zip silently truncates under
 Node 24, leaving a `node_modules/electron/dist` of a few hundred KB while the
 install script exits 0. E2E then fails with `chromedriver ENOENT` or
-`DevToolsActivePort file doesn't exist`. `bin/setup` detects this and re-runs
-only the Electron download scripts under Node 22 via mise — rerun `bin/setup`
-rather than debugging the binaries.
+`DevToolsActivePort file doesn't exist`. The root `postinstall` hook runs
+`bin/repair-electron`, which detects this and re-runs only the Electron download
+scripts under Node 22 via mise, so every `pnpm install` repairs itself. If the
+binaries are broken anyway, run `bin/repair-electron` rather than debugging
+them. Both the script and the hook come out when Electron is upgraded past the
+broken extract-zip.
 
 ## Architecture
 

--- a/bin/repair-electron
+++ b/bin/repair-electron
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Electron 33's install script extracts its download with extract-zip, which under
+# Node 24 stops after the first archive entry and still exits 0 — leaving a few
+# hundred KB in node_modules/electron/dist. The failure surfaces much later, as
+# `Error: Electron uninstall` from bin/dev or `chromedriver ENOENT` from E2E.
+#
+# This runs from the root postinstall hook, so every pnpm install repairs itself
+# rather than only the ones that go through bin/setup. It is two --version calls
+# when the binaries are healthy.
+#
+# Delete this script, the postinstall hook, and the AGENTS.md note when Electron
+# is upgraded past the broken extract-zip. See issue #81.
+
+cd "$(dirname "$0")/.."
+
+electron_dir="packages/app/node_modules/electron"
+chromedriver_dir="packages/app/node_modules/electron-chromedriver"
+
+electron_works() {
+  packages/app/node_modules/.bin/electron --version >/dev/null 2>&1
+}
+
+chromedriver_works() {
+  packages/app/node_modules/.bin/chromedriver --version >/dev/null 2>&1
+}
+
+electron_works && chromedriver_works && exit 0
+
+if ! command -v mise >/dev/null 2>&1; then
+  echo "Electron's downloaded binaries are incomplete, and mise is required to repair them." >&2
+  exit 1
+fi
+if [[ ! -f "$electron_dir/install.js" || ! -f "$chromedriver_dir/download-chromedriver.js" ]]; then
+  echo "Electron's package installers are missing. Re-run pnpm install and try again." >&2
+  exit 1
+fi
+
+echo "==> Repairing Electron downloads with Node 22"
+# Keep pnpm on Node 24 for native modules; run only the official Electron download
+# scripts under Node 22.
+mise install node@22 >/dev/null
+
+if ! electron_works; then
+  rm -rf "${electron_dir:?}/dist"
+  rm -f "${electron_dir:?}/path.txt"
+  mise exec node@22 -- node "$electron_dir/install.js"
+fi
+
+if ! chromedriver_works; then
+  rm -rf "${chromedriver_dir:?}/bin"
+  mise exec node@22 -- node "$chromedriver_dir/download-chromedriver.js"
+fi
+
+if ! electron_works || ! chromedriver_works; then
+  echo "Electron or chromedriver is still incomplete after repair." >&2
+  exit 1
+fi

--- a/bin/setup
+++ b/bin/setup
@@ -5,55 +5,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-electron_works() {
-  packages/app/node_modules/.bin/electron --version >/dev/null 2>&1
-}
-
-chromedriver_works() {
-  packages/app/node_modules/.bin/chromedriver --version >/dev/null 2>&1
-}
-
-repair_electron_downloads() {
-  electron_works && chromedriver_works && return 0
-
-  local electron_dir="packages/app/node_modules/electron"
-  local chromedriver_dir="packages/app/node_modules/electron-chromedriver"
-
-  if ! command -v mise >/dev/null 2>&1; then
-    echo "Electron's downloaded binaries are incomplete, and mise is required to repair them." >&2
-    return 1
-  fi
-  if [[ ! -f "$electron_dir/install.js" || ! -f "$chromedriver_dir/download-chromedriver.js" ]]; then
-    echo "Electron's package installers are missing. Re-run pnpm install and try again." >&2
-    return 1
-  fi
-
-  echo "==> Repairing Electron downloads with Node 22"
-  # Electron 33's extract-zip step can silently stop after the first archive
-  # entry under Node 24. Keep pnpm on Node 24 for native modules, but run only
-  # the official Electron download scripts with Node 22.
-  mise install node@22 >/dev/null
-
-  if ! electron_works; then
-    rm -rf "${electron_dir:?}/dist"
-    rm -f "${electron_dir:?}/path.txt"
-    mise exec node@22 -- node "$electron_dir/install.js"
-  fi
-
-  if ! chromedriver_works; then
-    rm -rf "${chromedriver_dir:?}/bin"
-    mise exec node@22 -- node "$chromedriver_dir/download-chromedriver.js"
-  fi
-
-  if ! electron_works || ! chromedriver_works; then
-    echo "Electron or chromedriver is still incomplete after repair." >&2
-    return 1
-  fi
-}
-
 echo "==> Installing dependencies"
+# The root postinstall hook runs bin/repair-electron, so the Electron download
+# repair happens here too.
 pnpm install
-repair_electron_downloads
 
 echo "==> Allocating ports"
 if command -v outport > /dev/null 2>&1; then

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "postinstall": "bin/repair-electron",
     "test": "vitest run",
     "test:e2e": "pnpm --filter @gander/app test:e2e",
     "typecheck": "pnpm -r run typecheck"


### PR DESCRIPTION
Extracts `repair_electron_downloads` from `bin/setup` into `bin/repair-electron` and runs it from the root `postinstall` hook, so every install that rebuilds `node_modules` verifies the binaries instead of only the ones that go through `bin/setup`.

Verified live: adding a dependency triggered the hook, which found the binaries truncated and repaired them. `electron --version` and `chromedriver --version` both answer afterwards.

Closes #81

https://claude.ai/code/session_014mnrLdA3iKT64p1Hum4y25