### PR TITLE
Isolate tests from the developer's git configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,9 @@ Real dependencies, never mocks: real throwaway git repositories
 (`main/fixtures.ts`), real SQLite files in temp dirs, real Fastify instances,
 real MCP clients. The E2E suite builds the app and drives the Electron window
 through WebDriverIO against an isolated service and a local GitHub fake — it
-needs no GitHub credentials and does not touch the dev stack.
+needs no GitHub credentials and does not touch the dev stack. `test/setup-git-env.ts`
+points git at an empty global and system config, so a developer's own git
+settings cannot change what the suite sees.
 
 Bugs that reached a person get a test that fails without the fix; prove it by
 reverting the fix.

--- a/test/setup-git-env.ts
+++ b/test/setup-git-env.ts
@@ -1,0 +1,7 @@
+// Tests drive real git, and git reads the developer's own configuration. A machine
+// carrying, say, `url.git@github.com:.insteadOf https://github.com/` makes
+// `git remote get-url` hand back a rewritten URL — which failed a registration test on
+// one machine and passed everywhere else. Point git at no configuration at all so the
+// suite sees the same git on every machine and in CI.
+process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+process.env.GIT_CONFIG_SYSTEM = "/dev/null";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,4 +3,5 @@ import vue from "@vitejs/plugin-vue";
 
 export default defineConfig({
   plugins: [vue()],
+  test: { setupFiles: ["./test/setup-git-env.ts"] },
 });


### PR DESCRIPTION
`repository-registration.test.ts` failed on my Mac Studio and passed everywhere else. The cause is a global `url.git@github.com:.insteadOf https://github.com/` — `git remote get-url` applies that rewrite, so the fixture's https remote came back as SSH.

The suite now sets `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null` in a setup file, so every real-git test sees the same git regardless of whose machine it runs on.

https://claude.ai/code/session_014mnrLdA3iKT64p1Hum4y25