### PR TITLE
Unify the workbench's visual constants

### DIFF
--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -432,10 +432,10 @@ onBeforeUnmount(() => {
 .context-title { min-width: 0; display: flex; align-items: baseline; gap: 7px; margin-right: auto; }
 .context-title strong { font-size: 12px; }
 .context-title span { min-width: 0; display: flex; align-items: center; gap: 5px; color: var(--muted-foreground); overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
-.context-toolbar button { min-height: 26px; display: flex; align-items: center; gap: 5px; padding: 3px 8px; border: 1px solid var(--workbench-border); border-radius: 5px; background: var(--elevated-background); color: var(--muted-foreground); font: inherit; cursor: pointer; }
+.context-toolbar button { min-height: 26px; display: flex; align-items: center; gap: 5px; padding: 3px 8px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--elevated-background); color: var(--muted-foreground); font: inherit; cursor: pointer; }
 .context-toolbar button:hover { color: var(--workbench-foreground); border-color: var(--faint-foreground); }
 .context-toolbar button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
-.context-toolbar button:disabled { opacity: .5; cursor: default; }
+.context-toolbar button:disabled { opacity: .55; cursor: default; }
 .progress { padding-inline: 4px; color: var(--faint-foreground); font-size: 11px; white-space: nowrap; }
 .work-surface { flex: 1; min-width: 0; min-height: 0; display: flex; background: var(--workbench-background); }
 .workspace { flex: 1; display: flex; min-width: 0; min-height: 0; }
@@ -451,7 +451,7 @@ onBeforeUnmount(() => {
 .welcome, .empty-state { margin: auto; max-width: 460px; padding: 40px; text-align: center; color: var(--muted-foreground); }
 .welcome h1, .empty-state h1 { margin: 0 0 10px; color: var(--workbench-foreground); font-size: 22px; letter-spacing: -.02em; }
 .welcome p, .empty-state p { margin: 0 0 22px; line-height: 1.55; }
-.welcome button, .empty-state button { min-height: 32px; padding: 6px 13px; border: 1px solid var(--accent); border-radius: 6px; background: var(--accent); color: var(--accent-foreground); font: inherit; cursor: pointer; }
+.welcome button, .empty-state button { min-height: 32px; padding: 6px 13px; border: 1px solid var(--accent); border-radius: var(--radius-md); background: var(--accent); color: var(--accent-foreground); font: inherit; cursor: pointer; }
 .welcome .text-action { display: block; margin: 14px auto 0; border: 0; background: none; color: var(--accent); }
 .welcome button:focus-visible, .empty-state button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } .view-sidebar { transition: none; } }

--- a/packages/app/src/renderer/src/components/ActivityRail.vue
+++ b/packages/app/src/renderer/src/components/ActivityRail.vue
@@ -26,7 +26,7 @@ button { position: relative; height: 48px; display: grid; place-items: center; b
 button:hover:not(:disabled) { color: var(--workbench-foreground); background: var(--hover-background); }
 button.active { color: var(--workbench-foreground); }
 button.active::before { content: ""; position: absolute; inset-block: 8px; inset-inline-start: 0; width: 2px; background: var(--accent); }
-button:disabled { opacity: .28; cursor: default; }
+button:disabled { opacity: .55; cursor: default; }
 button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .spacer { flex: 1; }
 </style>

--- a/packages/app/src/renderer/src/components/ConfirmDialog.vue
+++ b/packages/app/src/renderer/src/components/ConfirmDialog.vue
@@ -51,7 +51,7 @@ watch(() => props.open, (open) => {
      the window controls. */
   inset: 0; margin: auto;
   min-width: 340px; max-width: 460px; padding: 18px 20px 16px;
-  border: 1px solid var(--workbench-border); border-radius: 8px;
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-lg);
   background: var(--panel-background); color: var(--workbench-foreground);
   box-shadow: 0 16px 40px rgb(0 0 0 / .45);
 }
@@ -60,7 +60,7 @@ h2 { font-size: 14px; line-height: 1.35; }
 .detail { margin-top: 7px; color: var(--faint-foreground); font-size: 12px; line-height: 1.5; }
 .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 18px; }
 button {
-  height: 28px; padding: 0 13px; border-radius: 5px; border: 1px solid var(--workbench-border);
+  height: 28px; padding: 0 13px; border-radius: var(--radius-md); border: 1px solid var(--workbench-border);
   background: var(--input-background); color: var(--workbench-foreground);
   font: inherit; font-size: 12px; cursor: pointer;
 }

--- a/packages/app/src/renderer/src/components/ConnectionSettings.vue
+++ b/packages/app/src/renderer/src/components/ConnectionSettings.vue
@@ -163,15 +163,15 @@ async function run(action: "test" | "save"): Promise<void> {
 .heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 20px; }
 .heading h2 { color: var(--workbench-foreground); font-size: 15px; }
 .heading p, .setting p { color: var(--faint-foreground); font-size: 11.5px; }
-.override { margin-bottom: 18px; padding: 9px 11px; border-radius: 6px; background: var(--input-background); color: var(--muted-foreground); font-size: 11.5px; line-height: 1.5; }
+.override { margin-bottom: 18px; padding: 9px 11px; border-radius: var(--radius-md); background: var(--input-background); color: var(--muted-foreground); font-size: 11.5px; line-height: 1.5; }
 .setting { margin-bottom: 18px; max-width: 560px; }
 .setting label { display: block; margin-bottom: 3px; color: var(--workbench-foreground); font-size: 12.5px; }
 .setting p { margin-bottom: 7px; }
-input { width: 100%; height: 30px; padding: 0 9px; border: 1px solid var(--workbench-border); border-radius: 5px; background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 12.5px; }
+input { width: 100%; height: 30px; padding: 0 9px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 12.5px; }
 input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .actions { display: flex; align-items: center; gap: 8px; }
 hr { margin: 26px 0 22px; max-width: 560px; border: 0; border-top: 1px solid var(--workbench-border); }
-button { height: 28px; padding: 0 12px; border: 1px solid var(--workbench-border); border-radius: 5px; background: var(--input-background); color: var(--workbench-foreground); cursor: pointer; font: inherit; font-size: 12px; }
+button { height: 28px; padding: 0 12px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background); color: var(--workbench-foreground); cursor: pointer; font: inherit; font-size: 12px; }
 button.primary { border-color: var(--accent); background: var(--accent); color: var(--workbench-background); }
 button:disabled { opacity: .55; cursor: default; }
 .result, .working { color: var(--muted-foreground); font-size: 11.5px; }

--- a/packages/app/src/renderer/src/components/DiffPane.vue
+++ b/packages/app/src/renderer/src/components/DiffPane.vue
@@ -358,7 +358,7 @@ onBeforeUnmount(dispose);
   display: flex;
   gap: 2px;
   background: var(--input-background);
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   padding: 2px;
   flex: none;
 }
@@ -371,7 +371,7 @@ onBeforeUnmount(dispose);
   background: none;
   border: none;
   color: var(--muted-foreground);
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 .tabs button.active {
@@ -386,7 +386,7 @@ onBeforeUnmount(dispose);
   border: 1px solid var(--workbench-border);
   background: var(--elevated-background);
   color: var(--workbench-foreground);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: 4px 12px;
   font-size: 12px;
   cursor: pointer;
@@ -434,7 +434,7 @@ onBeforeUnmount(dispose);
   justify-content: center;
   padding: 1px;
   border: 1px solid var(--workbench-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--elevated-background);
   color: var(--workbench-foreground);
   font: 700 16px/1 var(--mono);

--- a/packages/app/src/renderer/src/components/EditorSettings.vue
+++ b/packages/app/src/renderer/src/components/EditorSettings.vue
@@ -141,7 +141,7 @@ onBeforeUnmount(() => {
 .setting code { color: var(--muted-foreground); font: 11.5px var(--mono); }
 .setting input {
   width: 100%; min-width: 0; margin-top: 8px; padding: 8px 10px;
-  border: 1px solid var(--workbench-border); border-radius: 6px;
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
   outline: none; background: var(--input-background); color: var(--workbench-foreground); font: 13px/1.4 var(--mono);
 }
 .setting input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
@@ -150,7 +150,7 @@ onBeforeUnmount(() => {
 .preview-setting { margin-top: 34px; }
 .preview {
   min-width: 0; overflow: hidden; margin-top: 8px; padding: 14px;
-  border: 1px solid var(--workbench-border); border-radius: 6px; background: var(--input-background);
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background);
   color: var(--workbench-foreground); line-height: 1.5; white-space: nowrap;
 }
 .preview code { color: inherit; font: inherit; }

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -200,7 +200,7 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
 .st.A { color: var(--success); }
 .st.D { color: var(--danger); }
 .st.R { color: var(--info); }
-.cb { width: 15px; height: 15px; flex: none; border: 1.5px solid var(--faint-foreground); border-radius: 4px; display: flex; align-items: center; justify-content: center; font-size: 11px; color: transparent; }
+.cb { width: 15px; height: 15px; flex: none; border: 1.5px solid var(--faint-foreground); border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 11px; color: transparent; }
 .cb.on { border-color: var(--success); color: var(--success); }
 .cb.part { border-color: var(--success); color: var(--success); }
 .review-slot { width: 15px; flex: none; }

--- a/packages/app/src/renderer/src/components/FullFilePane.vue
+++ b/packages/app/src/renderer/src/components/FullFilePane.vue
@@ -37,7 +37,7 @@ onBeforeUnmount(dispose);
 
 <style scoped>
 .pane { height: 100%; min-width: 0; min-height: 0; display: flex; flex-direction: column; }
-header { height: 36px; box-sizing: border-box; display: flex; align-items: center; padding-inline: 14px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); font: 12.5px var(--mono); }
+header { height: 35px; box-sizing: border-box; display: flex; align-items: center; padding-inline: 14px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); font: 12.5px var(--mono); }
 .directory { color: var(--faint-foreground); }
 .editor { flex: 1; min-height: 0; }
 .empty { flex: 1; display: grid; place-items: center; color: var(--faint-foreground); }

--- a/packages/app/src/renderer/src/components/ImageDiff.vue
+++ b/packages/app/src/renderer/src/components/ImageDiff.vue
@@ -47,7 +47,7 @@ const hasImageCandidate = computed(() => [props.preview.base, props.preview.head
 <style scoped>
 .image-diff { display: flex; flex: 1; min-width: 0; min-height: 0; flex-direction: column; }
 .toolbar { display: flex; flex: none; justify-content: flex-end; gap: 2px; padding: 5px 10px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); }
-.toolbar button { border: 0; border-radius: 4px; padding: 3px 8px; background: transparent; color: var(--muted-foreground); font-size: 11px; cursor: pointer; }
+.toolbar button { border: 0; border-radius: var(--radius-sm); padding: 3px 8px; background: transparent; color: var(--muted-foreground); font-size: 11px; cursor: pointer; }
 .toolbar button:hover, .toolbar button.active { background: var(--elevated-background); color: var(--workbench-foreground); }
 .toolbar button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .sides { display: flex; flex: 1; min-width: 0; min-height: 0; }

--- a/packages/app/src/renderer/src/components/QuestionCapture.vue
+++ b/packages/app/src/renderer/src/components/QuestionCapture.vue
@@ -55,12 +55,12 @@ async function submit(): Promise<void> {
 
 <style scoped>
 .capture { position: fixed; inset: 0; background: var(--overlay-background); display: flex; align-items: center; justify-content: center; padding: clamp(16px, 8vh, 72px) clamp(16px, 5vw, 72px); z-index: 50; }
-.panel { width: min(960px, 100%); max-height: 100%; background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: 10px; padding: 20px; display: flex; flex-direction: column; gap: 14px; box-shadow: 0 18px 50px var(--workbench-shadow); }
+.panel { width: min(960px, 100%); max-height: 100%; background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-lg); padding: 20px; display: flex; flex-direction: column; gap: 14px; box-shadow: 0 18px 50px var(--workbench-shadow); }
 .context { font-size: 13px; color: var(--faint-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .context b { color: var(--workbench-foreground); font-weight: 600; }
-.question { width: 100%; height: clamp(180px, 42vh, 420px); min-height: 120px; max-height: calc(100vh - 160px); background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 7px; color: var(--workbench-foreground); caret-color: var(--accent); font: inherit; font-size: 14px; line-height: 1.6; padding: 14px 16px; resize: vertical; }
+.question { width: 100%; height: clamp(180px, 42vh, 420px); min-height: 120px; max-height: calc(100vh - 160px); background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-md); color: var(--workbench-foreground); caret-color: var(--accent); font: inherit; font-size: 14px; line-height: 1.6; padding: 14px 16px; resize: vertical; }
 .question::selection { background: var(--selection-background); }
-.question:focus { outline: 2px solid var(--focus-ring); outline-offset: 1px; border-color: var(--accent); }
+.question:focus { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
 .hint { font-size: 11px; color: var(--faint-foreground); }
-kbd { font: 10.5px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: 4px; padding: 1px 5px; }
+kbd { font: 10.5px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 1px 5px; }
 </style>

--- a/packages/app/src/renderer/src/components/QuestionThread.vue
+++ b/packages/app/src/renderer/src/components/QuestionThread.vue
@@ -194,7 +194,7 @@ function formatTimestamp(value: string): string {
 .location:disabled { color: var(--faint-foreground); cursor: default; }
 .state {
   display: inline-flex; align-items: center; gap: 3px; flex: none;
-  border: 1px solid var(--workbench-border); border-radius: 999px; padding: 1px 5px;
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-pill); padding: 1px 5px;
   color: var(--faint-foreground); font: 600 9px var(--mono); letter-spacing: .35px; text-transform: uppercase;
 }
 .state.open { color: var(--accent); }
@@ -209,7 +209,7 @@ function formatTimestamp(value: string): string {
 .chevron { color: var(--faint-foreground); transition: transform 120ms ease; }
 .chevron.expanded { transform: rotate(180deg); }
 .thread-body { padding: 1px 10px 11px; }
-.question-message, .agent-update, .replies { min-width: 0; border-radius: 6px; }
+.question-message, .agent-update, .replies { min-width: 0; border-radius: var(--radius-md); }
 .question-message { padding: 9px 10px; background: var(--input-background); border: 1px solid var(--workbench-border); }
 .agent-update, .replies { margin: 8px 0 0 12px; padding: 9px 10px; border-left: 1px solid var(--accent); background: color-mix(in srgb, var(--accent) 6%, transparent); }
 .replies { border-left-color: var(--workbench-border); background: transparent; }
@@ -217,14 +217,14 @@ function formatTimestamp(value: string): string {
 .message-heading h3, .replies > h3, .author { margin: 0; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
 .agent-update .message-heading h3, .author.agent { color: var(--accent); }
 .message-heading time { min-width: 0; color: var(--faint-foreground); font-size: 9.5px; text-align: right; }
-.message-heading code { overflow: hidden; max-width: 45%; padding: 1px 5px; border-radius: 4px; background: var(--badge-background); color: var(--muted-foreground); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.message-heading code { overflow: hidden; max-width: 45%; padding: 1px 5px; border-radius: var(--radius-sm); background: var(--badge-background); color: var(--muted-foreground); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
 .message-text { margin: 4px 0 0; min-width: 0; color: var(--workbench-foreground); font-size: 12.5px; line-height: 1.5; overflow-wrap: anywhere; white-space: pre-wrap; }
 .replies ol { list-style: none; margin: 7px 0 0; padding: 0; }
 .reply { padding: 8px 0; border-top: 1px solid var(--workbench-border); }
 .reply:last-child { padding-bottom: 0; }
 .reply-form { margin-top: 9px; }
 .reply-form label { display: block; margin-bottom: 4px; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
-.reply-form input { width: 100%; background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: 6px; color: var(--workbench-foreground); font: inherit; font-size: 12px; padding: 6px 8px; }
+.reply-form input { width: 100%; background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-md); color: var(--workbench-foreground); font: inherit; font-size: 12px; padding: 6px 8px; }
 .reply-form input:focus { outline: none; border-color: var(--accent); }
 .reply-form input:disabled { color: var(--faint-foreground); }
 .thread-actions { display: flex; align-items: center; gap: 12px; margin-top: 8px; }

--- a/packages/app/src/renderer/src/components/QuestionsDrawer.vue
+++ b/packages/app/src/renderer/src/components/QuestionsDrawer.vue
@@ -142,10 +142,10 @@ async function copyAll(): Promise<void> {
 .drawer { container: questions / inline-size; display: flex; flex-direction: column; background: var(--panel-background); border-left: 1px solid var(--workbench-border); overflow: hidden auto; }
 header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--workbench-border); color: var(--muted-foreground); flex: none; }
 .title { margin: 0; font-size: 12px; font-weight: 600; letter-spacing: .3px; text-transform: uppercase; }
-.count { font: 11px var(--mono); background: var(--badge-background); border-radius: 9px; padding: 1px 7px; }
+.count { font: 11px var(--mono); background: var(--badge-background); border-radius: var(--radius-pill); padding: 1px 7px; }
 .add, .copy-all {
   display: flex; align-items: center; gap: 4px;
-  background: none; border: 1px solid var(--workbench-border); border-radius: 5px;
+  background: none; border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
   color: var(--workbench-foreground); padding: 3px 7px; font: inherit; font-size: 11px; cursor: pointer;
 }
 .copy-all { margin-left: auto; }
@@ -160,14 +160,14 @@ header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; borde
 .empty p { margin-bottom: 10px; }
 .empty button {
   display: flex; align-items: center; gap: 6px;
-  background: var(--accent); border: 1px solid var(--accent); border-radius: 6px;
+  background: var(--accent); border: 1px solid var(--accent); border-radius: var(--radius-md);
   color: var(--accent-foreground); padding: 5px 9px; font: inherit; font-size: 12px; font-weight: 600; cursor: pointer;
 }
 .empty button kbd { color: var(--workbench-foreground); }
 .add:focus-visible, .copy-all:focus-visible, .empty button:focus-visible, .close:focus-visible {
   outline: 2px solid var(--accent); outline-offset: 2px;
 }
-kbd { font: 11px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: 4px; padding: 1px 5px; }
+kbd { font: 11px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 1px 5px; }
 
 ul { list-style: none; margin: 0; padding: 0; }
 @container questions (max-width: 330px) {

--- a/packages/app/src/renderer/src/components/ReviewingList.vue
+++ b/packages/app/src/renderer/src/components/ReviewingList.vue
@@ -101,7 +101,7 @@ function select(prNumber: number): void {
   margin: 5px 8px;
   padding: 4px 0;
   border: 1px solid var(--workbench-border);
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--badge-background) 45%, transparent);
 }
 .stack-heading {
@@ -130,7 +130,7 @@ function select(prNumber: number): void {
   cursor: pointer;
 }
 .stack-group .sw-item { padding-inline: 10px; }
-.sw-item:hover { background: var(--selection-background); }
+.sw-item:hover { background: var(--hover-background); }
 .sw-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .sw-item .num { font: 12px var(--mono); color: var(--muted-foreground); }
 .sw-item .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/packages/app/src/renderer/src/components/SettingsPane.vue
+++ b/packages/app/src/renderer/src/components/SettingsPane.vue
@@ -195,10 +195,10 @@ onBeforeUnmount(() => {
 .title h1 { color: var(--workbench-foreground); font-size: 16px; line-height: 1.25; }
 .title p, .json-heading p { color: var(--faint-foreground); font-size: 11.5px; }
 .title-actions, .view-switcher { display: flex; align-items: center; gap: 4px; }
-.view-switcher { padding: 2px; border-radius: 7px; background: var(--input-background); }
+.view-switcher { padding: 2px; border-radius: var(--radius-md); background: var(--input-background); }
 .view-switcher button, .close {
   display: flex; align-items: center; justify-content: center; gap: 6px;
-  height: 28px; border: 0; border-radius: 5px; background: transparent;
+  height: 28px; border: 0; border-radius: var(--radius-md); background: transparent;
   color: var(--muted-foreground); cursor: pointer; font: inherit; font-size: 12px;
 }
 .view-switcher button { padding: 0 10px; }
@@ -208,8 +208,8 @@ onBeforeUnmount(() => {
 .close:hover { background: var(--hover-background); color: var(--workbench-foreground); }
 .settings-body { display: grid; grid-template-columns: 190px 1fr; min-width: 0; min-height: 0; }
 .categories { padding: 18px 10px; border-right: 1px solid var(--workbench-border); background: var(--secondary-panel-background); }
-.categories > p { padding: 0 10px 8px; color: var(--faint-foreground); font-size: 10.5px; font-weight: 700; letter-spacing: .7px; text-transform: uppercase; }
-.category { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border: 0; border-radius: 5px; background: transparent; color: var(--muted-foreground); cursor: pointer; font: inherit; text-align: left; }
+.categories > p { padding: 0 10px 8px; color: var(--faint-foreground); font-size: 10px; font-weight: 700; letter-spacing: .55px; text-transform: uppercase; }
+.category { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border: 0; border-radius: var(--radius-md); background: transparent; color: var(--muted-foreground); cursor: pointer; font: inherit; text-align: left; }
 .category.active { background: var(--selection-background); color: var(--workbench-foreground); }
 .content { min-width: 0; min-height: 0; overflow: hidden; }
 .json-view { display: grid; grid-template-rows: auto 1fr; height: 100%; min-width: 0; min-height: 0; }

--- a/packages/app/src/renderer/src/components/SwitcherDropdown.vue
+++ b/packages/app/src/renderer/src/components/SwitcherDropdown.vue
@@ -22,5 +22,5 @@ const emit = defineEmits<{ close: [] }>();
 
 <style scoped>
 .veil { position: fixed; inset: 0; z-index: 30; }
-.dd { position: fixed; top: 51px; background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: 0 0 12px 12px; box-shadow: 0 20px 50px var(--workbench-shadow); max-height: 65vh; overflow: auto; z-index: 31; min-width: 320px; }
+.dd { position: fixed; top: 51px; background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: 0 0 var(--radius-lg) var(--radius-lg); box-shadow: 0 20px 50px var(--workbench-shadow); max-height: 65vh; overflow: auto; z-index: 31; min-width: 320px; }
 </style>

--- a/packages/app/src/renderer/src/components/TargetBar.vue
+++ b/packages/app/src/renderer/src/components/TargetBar.vue
@@ -132,12 +132,13 @@ onBeforeUnmount(() => {
 .target-status { -webkit-app-region: no-drag; align-self: center; margin-left: 10px; color: var(--faint-foreground); font-size: 11px; }
 .drag-fill { min-width: 40px; flex: 1; }
 .target-trigger:focus-visible, .picker-row:focus-visible, .open-folder:focus-visible, .repository-action:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.target-picker { -webkit-app-region: no-drag; position: absolute; inset-block-start: 37px; inset-inline-start: var(--target-picker-offset, 0); width: min(420px, calc(100vw - 24px)); max-height: min(620px, calc(100vh - 72px)); overflow: auto; padding: 8px 0; border: 1px solid var(--workbench-border); border-radius: 0 0 8px 8px; background: var(--elevated-background); box-shadow: 0 14px 34px rgba(0, 0, 0, .36); }
+.target-picker { -webkit-app-region: no-drag; position: absolute; inset-block-start: 37px; inset-inline-start: var(--target-picker-offset, 0); width: min(420px, calc(100vw - 24px)); max-height: min(620px, calc(100vh - 72px)); overflow: auto; padding: 8px 0; border: 1px solid var(--workbench-border); border-radius: 0 0 var(--radius-lg) var(--radius-lg); background: var(--elevated-background); box-shadow: 0 14px 34px rgba(0, 0, 0, .36); }
 .draggable .target-picker { --target-picker-offset: 78px; }
 .target-picker section + section { margin-top: 7px; padding-top: 7px; border-top: 1px solid var(--workbench-border); }
-.target-picker h2 { margin: 0; padding: 5px 12px 4px; color: var(--faint-foreground); font-size: 9px; font-weight: 700; letter-spacing: .55px; text-transform: uppercase; }
+.target-picker h2 { margin: 0; padding: 5px 12px 4px; color: var(--faint-foreground); font-size: 10px; font-weight: 700; letter-spacing: .55px; text-transform: uppercase; }
 .picker-row, .open-folder, .repository-action { width: 100%; display: grid; grid-template-columns: 17px minmax(90px, auto) minmax(0, 1fr); align-items: center; gap: 8px; min-height: 30px; padding: 5px 12px; border: 0; background: none; color: var(--muted-foreground); text-align: left; font: inherit; cursor: pointer; }
-.picker-row:hover, .picker-row.selected, .open-folder:hover, .repository-action:hover { background: var(--selection-background); color: var(--workbench-foreground); }
+.picker-row.selected { background: var(--selection-background); color: var(--workbench-foreground); }
+.picker-row:hover, .open-folder:hover, .repository-action:hover { background: var(--hover-background); color: var(--workbench-foreground); }
 .picker-row small { overflow: hidden; color: var(--faint-foreground); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
 .picker-row span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .picker-row.selected span { color: var(--workbench-foreground); font-weight: 650; }

--- a/packages/app/src/renderer/src/components/TreeTypographySettings.vue
+++ b/packages/app/src/renderer/src/components/TreeTypographySettings.vue
@@ -193,14 +193,14 @@ onBeforeUnmount(flushSave);
 .setting label, .setting-label { display: block; color: var(--workbench-foreground); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
 .setting > input, .size-row input {
   width: 100%; min-width: 0; margin-top: 8px; padding: 8px 10px;
-  border: 1px solid var(--workbench-border); border-radius: 6px;
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
   outline: none; background: var(--input-background); color: var(--workbench-foreground); font: 13px/1.4 var(--mono);
 }
 .setting input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
 .setting input:disabled { opacity: .65; }
 .size-row { display: flex; align-items: center; gap: 8px; width: 130px; color: var(--faint-foreground); }
 .preview-setting { margin-top: 28px; }
-.preview { display: flex; flex-direction: column; gap: 2px; min-width: 0; overflow: hidden; margin-top: 8px; padding: 12px 14px; border: 1px solid var(--workbench-border); border-radius: 6px; background: var(--input-background); color: var(--workbench-foreground); white-space: nowrap; }
+.preview { display: flex; flex-direction: column; gap: 2px; min-width: 0; overflow: hidden; margin-top: 8px; padding: 12px 14px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background); color: var(--workbench-foreground); white-space: nowrap; }
 .preview span:nth-child(2) { padding-left: 16px; }
 .preview span:nth-child(3) { padding-left: 32px; }
 .error { color: var(--danger); font-size: 12px; overflow-wrap: anywhere; }

--- a/packages/app/src/renderer/src/components/WindowZoomSettings.vue
+++ b/packages/app/src/renderer/src/components/WindowZoomSettings.vue
@@ -110,7 +110,7 @@ onBeforeUnmount(flushSave);
 .level-row { display: flex; align-items: center; gap: 9px; width: 150px; color: var(--muted-foreground); font-variant-numeric: tabular-nums; }
 .level-row input {
   width: 100%; min-width: 0; margin-top: 8px; padding: 8px 10px;
-  border: 1px solid var(--workbench-border); border-radius: 6px;
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
   outline: none; background: var(--input-background); color: var(--workbench-foreground); font: 13px/1.4 var(--mono);
 }
 .level-row input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }

--- a/packages/app/src/renderer/src/components/WorkbenchSettings.vue
+++ b/packages/app/src/renderer/src/components/WorkbenchSettings.vue
@@ -101,11 +101,11 @@ async function reset(): Promise<void> {
 .setting code { color: var(--muted-foreground); font: 11.5px var(--mono); }
 .setting select {
   width: min(420px, 100%); margin-top: 8px; padding: 8px 34px 8px 10px;
-  border: 1px solid var(--workbench-border); border-radius: 6px;
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
   outline: none; background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 13px;
 }
 .setting select:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
 .source { margin-top: 7px; }
-.swatches { display: flex; width: min(420px, 100%); height: 36px; overflow: hidden; border: 1px solid var(--workbench-border); border-radius: 6px; }
+.swatches { display: flex; width: min(420px, 100%); height: 36px; overflow: hidden; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); }
 .swatches span { flex: 1; min-width: 2px; }
 </style>

--- a/packages/app/src/renderer/src/components/ZoomControl.vue
+++ b/packages/app/src/renderer/src/components/ZoomControl.vue
@@ -95,7 +95,7 @@ function reset(): void {
 .zoom-trigger {
   anchor-name: --zoom-trigger;
   display: flex; align-items: center; gap: 4px; height: 22px; padding: 0 4px;
-  border: 0; border-radius: 3px; background: transparent; color: var(--faint-foreground);
+  border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground);
   cursor: pointer; font: inherit; font-variant-numeric: tabular-nums;
 }
 .zoom-trigger:hover, .zoom-trigger:focus-visible { background: var(--hover-background); color: var(--workbench-foreground); }
@@ -103,7 +103,7 @@ function reset(): void {
 .percentage { min-width: 3.25ch; text-align: end; }
 .zoom-toolbar {
   position: fixed; position-anchor: --zoom-trigger; position-area: block-start span-inline-start;
-  margin: 0 0 7px; padding: 5px; border: 1px solid var(--workbench-border); border-radius: 7px;
+  margin: 0 0 7px; padding: 5px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
   overflow: visible;
   background: var(--elevated-background); color: var(--workbench-foreground);
   box-shadow: 0 6px 18px var(--workbench-shadow);
@@ -117,7 +117,7 @@ function reset(): void {
 }
 .zoom-toolbar button {
   position: relative; display: flex; align-items: center; justify-content: center; gap: 6px;
-  min-width: 28px; height: 28px; padding: 0 7px; border: 0; border-radius: 4px;
+  min-width: 28px; height: 28px; padding: 0 7px; border: 0; border-radius: var(--radius-sm);
   background: transparent; color: var(--workbench-foreground); cursor: pointer; font: inherit;
 }
 .zoom-toolbar button:hover:not(:disabled) { background: var(--hover-background); }

--- a/packages/app/src/renderer/src/theme.css
+++ b/packages/app/src/renderer/src/theme.css
@@ -30,6 +30,12 @@
   --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
   --editor-font-family: 'JetBrainsMono NF', 'FiraCode NF', 'Jetbrains Mono', 'Fira Code', Consolas, 'Courier New', monospace;
   --editor-font-size: 16px;
+  /* Three steps, so a control, a card, and a dialog never disagree by a pixel:
+     small controls and badges, buttons and panels, floating surfaces. */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-pill: 999px;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html, body { height: 100%; }
@@ -38,3 +44,6 @@ body {
   font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 code, pre { font-family: var(--editor-font-family); font-size: var(--editor-font-size); }
+/* The surfaces the browser draws for us still belong to the theme. */
+::selection { background: var(--selection-background); }
+:root { caret-color: var(--accent); }


### PR DESCRIPTION
Follow-on from the mono/UI font mismatch — same class of drift, found by scanning the renderer's CSS.

| Discrepancy | Before | Now |
|---|---|---|
| Corner radius | nine values, 3px to 12px | `--radius-sm/md/lg/pill` tokens |
| Pane header height | 36px in FullFilePane, 35px everywhere else | 35px |
| Section label | 9px, 10px, and 10.5px with two tracking values | 10px / 700 / .55px |
| Row hover | picker rows and the PR list used the *selected* colour on hover | `--hover-background`; selected keeps `--selection-background` |
| Disabled button | .28, .5, .55 | .55 |
| Focus ring | QuestionCapture used the translucent `--focus-ring` as its outline | solid `--accent`, as everywhere else |
| Text selection and caret | themed only inside QuestionCapture | themed globally |

Unit tests and typecheck pass. The E2E suite is red on master already (6 failures, unrelated to this) — same 6 before and after these changes.

https://claude.ai/code/session_014mnrLdA3iKT64p1Hum4y25