### PR TITLE
Complete the Homebrew cask handoff

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -75,3 +75,4 @@ gh release upload "$TAG" dist/*.dmg dist/*.zip dist/*.blockmap dist/latest-mac.y
 
 echo "==> Published https://github.com/steveclarke/gander/releases/tag/${TAG}"
 echo "    The Linux AppImage follows from CI."
+echo "    After verifying the signed app, publish dist/gander.rb to steveclarke/homebrew-tap/Casks/gander.rb."

--- a/bin/release.test.ts
+++ b/bin/release.test.ts
@@ -35,6 +35,7 @@ describe("Homebrew cask release handoff", () => {
     expect(cask).toContain('version "1.2.3"');
     expect(cask).toContain('sha256 "3ba84e1d362618f0e9f45064634a1594485bca3298b8182b5a7eaa3fded4688f"');
     expect(cask).toContain("Gander-#{version}-arm64.dmg");
+    expect(cask).toContain("depends_on macos: :catalina");
     expect(cask).not.toContain("__VERSION__");
     expect(cask).not.toContain("__SHA256__");
   });

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -125,6 +125,11 @@ the release and its install/update path have been verified manually:
 3. Install the fully qualified cask from the tap and launch it before publishing
    the tap change.
 
+The cask is the installation and discovery path; Electron's consent-based updater
+owns routine upgrades. `auto_updates true` keeps an ordinary `brew upgrade` from
+replacing an app that updates itself. The tap still advances with each verified
+release so a fresh Homebrew installation receives the current version.
+
 Do not copy signing identities, notarization credentials, tokens, or keychain
 profile names into either repository. The generated cask contains only the
 public release URL and checksum.

--- a/packaging/homebrew/gander.rb.template
+++ b/packaging/homebrew/gander.rb.template
@@ -9,6 +9,7 @@ cask "gander" do
 
   auto_updates true
   depends_on arch: :arm64
+  depends_on macos: :catalina
 
   app "Gander.app"
 end


### PR DESCRIPTION
Completes the Homebrew handoff around the cask published in `steveclarke/homebrew-tap`.

- declares the generated cask's minimum macOS dependency so strict Homebrew audit accepts future releases
- covers that declaration in the release test
- prints the manual tap handoff after publishing a release
- records that Electron owns routine upgrades while the tap remains the installation and discovery path

Validation:

- `pnpm typecheck`
- `pnpm test` (50 files, 327 tests)
- `bash -n bin/release bin/render-homebrew-cask`
- `shellcheck bin/release bin/render-homebrew-cask`
- `git diff --check`
- Homebrew style, strict audit, isolated first install, signature, notarization, Gatekeeper, and launch acceptance against v0.1.10

Related to #75.
