### PR TITLE
Clear recovered service errors

### DIFF
--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -493,6 +493,26 @@ describe("store", () => {
       expect(store.serviceStatus).toEqual({ state: "unreachable", reason: "network down" });
     });
 
+    it("clears a recovered read-only connection error without hiding a failed change", async () => {
+      const unreachable = { state: "unreachable" as const, reason: "Could not reach http://service: fetch failed" };
+      let connected = false;
+      const store = createStore(fakeApi({
+        serviceStatus: async () => connected
+          ? { state: "connected", serviceVersion: "0.1.0", supportedVersion: "0.1.0" }
+          : unreachable,
+      }));
+
+      await store.checkService();
+      store.error = unreachable.reason;
+      connected = true;
+      await store.checkService();
+      expect(store.error).toBeNull();
+
+      store.error = `${unreachable.reason} This change was not saved and will not be retried.`;
+      await store.checkService();
+      expect(store.error).toContain("not saved");
+    });
+
     it("shows cached mode immediately when refresh falls back while the service is down", async () => {
       let status: "connected" | "unreachable" = "connected";
       const store = createStore(fakeApi({

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -116,7 +116,17 @@ export function createStore(api: GanderApi): Store {
       });
     },
     async checkService() {
+      const previous = store.serviceStatus;
       store.serviceStatus = await api.serviceStatus();
+      // A read can fail during launch and leave exactly the health-check reason in the
+      // banner. Once that same connection recovers, the warning is stale. Failed writes
+      // append their no-retry consequence, so the exact match deliberately leaves those
+      // visible until the reviewer dismisses them or starts another action.
+      if ((store.serviceStatus.state === "connected" || store.serviceStatus.state === "newer")
+        && previous.state === "unreachable"
+        && store.error === previous.reason) {
+        store.error = null;
+      }
     },
     dismissError() {
       store.error = null;


### PR DESCRIPTION
Fixes the recurring stale service banner seen in the installed app.

A transient read during launch could leave the exact health-check failure in the error banner. Later health checks correctly marked the service connected, but intentionally sticky error handling kept the obsolete banner forever. The store now clears only that exact recovered read error. Failed writes retain their longer no-retry warning and remain visible.

Validation:

- regression test failed before the fix and passed afterward
- `pnpm typecheck`
- `pnpm test` (50 files, 328 tests)
- 120 requests through Electron 33's embedded Node runtime completed without a live service failure

