### PR TITLE
Modularize renderer styles

### DIFF
--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -23,7 +23,6 @@ import Splitter from "./components/Splitter.vue";
 import StackPosition from "./components/StackPosition.vue";
 import StatusBar from "./components/StatusBar.vue";
 import TargetBar from "./components/TargetBar.vue";
-import "./theme.css";
 
 type WorkbenchMode = "explorer" | "changes" | "pulls" | "settings";
 

--- a/packages/app/src/renderer/src/components/ConfirmDialog.vue
+++ b/packages/app/src/renderer/src/components/ConfirmDialog.vue
@@ -46,10 +46,6 @@ watch(() => props.open, (open) => {
 
 <style scoped>
 .confirm {
-  /* The browser centres a modal dialog with `margin: auto`, and theme.css resets margin
-     to 0 on every element — so without this the dialog sits in the top-left corner, over
-     the window controls. */
-  inset: 0; margin: auto;
   min-width: 340px; max-width: 460px; padding: 18px 20px 16px;
   border: 1px solid var(--workbench-border); border-radius: var(--radius-lg);
   background: var(--panel-background); color: var(--workbench-foreground);

--- a/packages/app/src/renderer/src/components/ConnectionSettings.vue
+++ b/packages/app/src/renderer/src/components/ConnectionSettings.vue
@@ -178,7 +178,7 @@ button:disabled { opacity: .55; cursor: default; }
 .working { display: flex; align-items: center; gap: 5px; }
 .spin { animation: spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
-.result.bad { color: var(--red, #e06c75); }
+.result.bad { color: var(--danger); }
 .result.warning { color: var(--warning); }
 code { font-family: var(--mono, monospace); font-size: 11px; }
 </style>

--- a/packages/app/src/renderer/src/components/EditorSettings.vue
+++ b/packages/app/src/renderer/src/components/EditorSettings.vue
@@ -76,20 +76,21 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <section class="editor-settings" aria-labelledby="editor-settings-title">
-    <header class="heading">
+  <section class="settings-page editor-settings" aria-labelledby="editor-settings-title">
+    <header class="settings-page-heading">
       <div>
-        <h2 id="editor-settings-title">Editor</h2>
-        <p>Typography for diffs, full-file views, and other code surfaces.</p>
+        <h2 id="editor-settings-title" class="settings-page-title">Editor</h2>
+        <p class="settings-description">Typography for diffs, full-file views, and other code surfaces.</p>
       </div>
-      <button class="reset" type="button" :disabled="store.busy" @click="reset">Use defaults</button>
+      <button class="settings-reset" type="button" :disabled="store.busy" @click="reset">Use defaults</button>
     </header>
 
-    <div class="setting">
-      <label for="editor-font-family">Font family</label>
-      <p>Controls <code>editor.fontFamily</code>. Keep fonts in fallback order, separated by commas.</p>
+    <div class="settings-field">
+      <label class="settings-label" for="editor-font-family">Font family</label>
+      <p class="settings-description">Controls <code class="settings-code">editor.fontFamily</code>. Keep fonts in fallback order, separated by commas.</p>
       <input
         id="editor-font-family"
+        class="settings-control settings-text-control"
         v-model="fontFamily"
         name="editor.fontFamily"
         spellcheck="false"
@@ -100,12 +101,13 @@ onBeforeUnmount(() => {
       />
     </div>
 
-    <div class="setting">
-      <label for="editor-font-size">Font size</label>
-      <p>Controls <code>editor.fontSize</code> in pixels. Use a value from 6 to 100.</p>
+    <div class="settings-field">
+      <label class="settings-label" for="editor-font-size">Font size</label>
+      <p class="settings-description">Controls <code class="settings-code">editor.fontSize</code> in pixels. Use a value from 6 to 100.</p>
       <div class="size-row">
         <input
           id="editor-font-size"
+          class="settings-control settings-text-control"
           v-model.number="fontSize"
           name="editor.fontSize"
           type="number"
@@ -120,32 +122,19 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
-    <div class="setting preview-setting">
-      <p id="editor-preview-label" class="setting-label">Preview</p>
+    <div class="settings-field preview-setting">
+      <p id="editor-preview-label" class="settings-label">Preview</p>
       <pre class="preview" aria-labelledby="editor-preview-label" :style="previewStyle"><code>const review = "ready";</code></pre>
     </div>
 
-    <p v-if="localError" class="error" role="alert">{{ localError }}</p>
+    <p v-if="localError" class="settings-error error" role="alert">{{ localError }}</p>
   </section>
 </template>
 
+<style scoped src="../styles/settings.css"></style>
+
 <style scoped>
-.editor-settings { height: 100%; overflow: auto; padding: 28px; }
-.heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; max-width: 820px; margin-bottom: 30px; }
-.heading h2 { color: var(--workbench-foreground); font-size: 20px; line-height: 1.25; }
-.heading p, .setting > p { color: var(--faint-foreground); font-size: 12px; }
-.reset { border: 0; background: none; color: var(--accent); cursor: pointer; font: inherit; font-size: 12px; white-space: nowrap; }
-.reset:disabled { cursor: default; opacity: .55; }
-.setting { max-width: 820px; margin-bottom: 26px; }
-.setting label, .setting-label { display: block; color: var(--workbench-foreground); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
-.setting code { color: var(--muted-foreground); font: 11.5px var(--mono); }
-.setting input {
-  width: 100%; min-width: 0; margin-top: 8px; padding: 8px 10px;
-  border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
-  outline: none; background: var(--input-background); color: var(--workbench-foreground); font: 13px/1.4 var(--mono);
-}
-.setting input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
-.setting input:disabled { opacity: .65; }
+.editor-settings { --settings-field-gap: 26px; }
 .size-row { display: flex; align-items: center; gap: 8px; width: 130px; color: var(--faint-foreground); }
 .preview-setting { margin-top: 34px; }
 .preview {
@@ -154,5 +143,5 @@ onBeforeUnmount(() => {
   color: var(--workbench-foreground); line-height: 1.5; white-space: nowrap;
 }
 .preview code { color: inherit; font: inherit; }
-.error { max-width: 820px; color: var(--danger); font-size: 12px; overflow-wrap: anywhere; }
+.error { max-width: 820px; }
 </style>

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -186,15 +186,10 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
   </div>
 </template>
 
+<style scoped src="../styles/tree.css"></style>
+
 <style scoped>
 .tree.root { padding: 8px 0; }
-.tnode { display: flex; align-items: center; gap: 6px; height: 22px; padding: 3px 12px 3px 0; box-sizing: border-box; cursor: pointer; white-space: nowrap; }
-.tnode:hover { background: var(--hover-background); }
-.tnode.sel { background: var(--selection-background); box-shadow: inset 2px 0 0 var(--accent); }
-.tnode .hierarchy-slot { width: 14px; flex: none; }
-.tnode .chev { flex: none; color: var(--faint-foreground); }
-.tnode .fname { font: inherit; overflow: hidden; text-overflow: ellipsis; }
-.tnode.isdir .fname { color: var(--muted-foreground); }
 .tnode .st { margin-left: auto; font: 11px var(--mono); flex: none; }
 .st.M { color: var(--warning); }
 .st.A { color: var(--success); }
@@ -203,7 +198,6 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
 .cb { width: 15px; height: 15px; flex: none; border: 1.5px solid var(--faint-foreground); border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 11px; color: transparent; }
 .cb.on { border-color: var(--success); color: var(--success); }
 .cb.part { border-color: var(--success); color: var(--success); }
-.review-slot { width: 15px; flex: none; }
 .tnode.checked .fname { color: var(--faint-foreground); }
 .note-mark { display: inline-flex; align-items: center; gap: 2px; color: var(--accent); flex: none; }
 .note-count { font-size: 10px; line-height: 1; font-variant-numeric: tabular-nums; }

--- a/packages/app/src/renderer/src/components/LocalFileTree.vue
+++ b/packages/app/src/renderer/src/components/LocalFileTree.vue
@@ -124,17 +124,11 @@ function folderIcon(entry: LocalFileEntry) {
   </div>
 </template>
 
+<style scoped src="../styles/tree.css"></style>
+
 <style scoped>
 .local-tree.root { height: 100%; overflow: auto; padding: 8px 0; box-sizing: border-box; }
-.tnode { width: 100%; display: flex; align-items: center; gap: 6px; height: 22px; padding: 3px 12px 3px 0; border: 0; background: none; box-sizing: border-box; color: var(--workbench-foreground); font: inherit; text-align: left; cursor: pointer; white-space: nowrap; }
-.tnode:hover { background: var(--hover-background); }
-.tnode:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.tnode.sel { background: var(--selection-background); box-shadow: inset 2px 0 0 var(--accent); }
-.tnode .hierarchy-slot { width: 14px; flex: none; }
-.tnode .chev { color: var(--faint-foreground); }
-.tnode .fname { overflow: hidden; text-overflow: ellipsis; }
-.tnode.isdir .fname { color: var(--muted-foreground); }
-.review-slot { width: 15px; flex: none; }
+.tnode { width: 100%; border: 0; background: none; color: var(--workbench-foreground); text-align: left; }
 .loading { color: var(--faint-foreground); animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 @media (prefers-reduced-motion: reduce) { .loading { animation: none; } }

--- a/packages/app/src/renderer/src/components/NoteCapture.vue
+++ b/packages/app/src/renderer/src/components/NoteCapture.vue
@@ -60,7 +60,7 @@ async function submit(): Promise<void> {
 .context b { color: var(--workbench-foreground); font-weight: 600; }
 .note { width: 100%; height: clamp(180px, 42vh, 420px); min-height: 120px; max-height: calc(100vh - 160px); background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-md); color: var(--workbench-foreground); caret-color: var(--accent); font: inherit; font-size: 14px; line-height: 1.6; padding: 14px 16px; resize: vertical; }
 .note::selection { background: var(--selection-background); }
-.note:focus { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
+.note:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
 .hint { font-size: 11px; color: var(--faint-foreground); }
 kbd { font: 10.5px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 1px 5px; }
 </style>

--- a/packages/app/src/renderer/src/components/NoteThread.vue
+++ b/packages/app/src/renderer/src/components/NoteThread.vue
@@ -225,7 +225,7 @@ function formatTimestamp(value: string): string {
 .reply-form { margin-top: 9px; }
 .reply-form label { display: block; margin-bottom: 4px; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
 .reply-form input { width: 100%; background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-md); color: var(--workbench-foreground); font: inherit; font-size: 12px; padding: 6px 8px; }
-.reply-form input:focus { outline: none; border-color: var(--accent); }
+.reply-form input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
 .reply-form input:disabled { color: var(--faint-foreground); }
 .thread-actions { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
 .thread-actions button { display: inline-flex; align-items: center; gap: 5px; border: 0; padding: 2px 0; background: none; color: var(--muted-foreground); font: inherit; font-size: 10.5px; cursor: pointer; }

--- a/packages/app/src/renderer/src/components/TreeTypographySettings.vue
+++ b/packages/app/src/renderer/src/components/TreeTypographySettings.vue
@@ -108,13 +108,13 @@ onBeforeUnmount(flushSave);
 </script>
 
 <template>
-  <section class="tree-typography" aria-labelledby="tree-typography-title">
-    <div class="section-heading">
+  <section class="settings-section tree-typography" aria-labelledby="tree-typography-title">
+    <div class="settings-section-heading">
       <div>
-        <h3 id="tree-typography-title">File tree typography</h3>
-        <p>Controls filenames and folders in the review tree.</p>
+        <h3 id="tree-typography-title" class="settings-section-title">File tree typography</h3>
+        <p class="settings-description">Controls filenames and folders in the review tree.</p>
       </div>
-      <button class="reset" type="button" :disabled="store.busy" @click="reset">Use default</button>
+      <button class="settings-reset" type="button" :disabled="store.busy" @click="reset">Use default</button>
     </div>
 
     <label class="inherit-setting">
@@ -127,15 +127,16 @@ onBeforeUnmount(flushSave);
       />
       <span>
         Inherit editor typography
-        <small>Use <code>editor.fontFamily</code> and <code>editor.fontSize</code> for the tree.</small>
+        <small>Use <code class="settings-code">editor.fontFamily</code> and <code class="settings-code">editor.fontSize</code> for the tree.</small>
       </span>
     </label>
 
-    <div class="setting">
-      <label for="tree-font-family">Font family</label>
-      <p>Controls <code>workbench.tree.fontFamily</code> when inheritance is off.</p>
+    <div class="settings-field">
+      <label class="settings-label" for="tree-font-family">Font family</label>
+      <p class="settings-description">Controls <code class="settings-code">workbench.tree.fontFamily</code> when inheritance is off.</p>
       <input
         id="tree-font-family"
+        class="settings-control settings-text-control"
         v-model="fontFamily"
         name="workbench.tree.fontFamily"
         spellcheck="false"
@@ -146,12 +147,13 @@ onBeforeUnmount(flushSave);
       />
     </div>
 
-    <div class="setting">
-      <label for="tree-font-size">Font size</label>
-      <p>Controls <code>workbench.tree.fontSize</code> in pixels when inheritance is off.</p>
+    <div class="settings-field">
+      <label class="settings-label" for="tree-font-size">Font size</label>
+      <p class="settings-description">Controls <code class="settings-code">workbench.tree.fontSize</code> in pixels when inheritance is off.</p>
       <div class="size-row">
         <input
           id="tree-font-size"
+          class="settings-control settings-text-control"
           v-model.number="fontSize"
           name="workbench.tree.fontSize"
           type="number"
@@ -166,42 +168,26 @@ onBeforeUnmount(flushSave);
       </div>
     </div>
 
-    <div class="setting preview-setting">
-      <p id="tree-preview-label" class="setting-label">Preview</p>
+    <div class="settings-field preview-setting">
+      <p id="tree-preview-label" class="settings-label">Preview</p>
       <div class="preview" aria-labelledby="tree-preview-label" :style="previewStyle">
         <span>src</span><span>components</span><span>FileTree.vue</span>
       </div>
     </div>
 
-    <p v-if="localError" class="error" role="alert">{{ localError }}</p>
+    <p v-if="localError" class="settings-error" role="alert">{{ localError }}</p>
   </section>
 </template>
 
+<style scoped src="../styles/settings.css"></style>
+
 <style scoped>
-.tree-typography { max-width: 820px; margin-top: 34px; padding-top: 28px; border-top: 1px solid var(--workbench-border); }
-.section-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; margin-bottom: 22px; }
-.section-heading h3 { color: var(--workbench-foreground); font-size: 15px; line-height: 1.3; }
-.section-heading p, .setting > p { color: var(--faint-foreground); font-size: 12px; }
-.reset { border: 0; background: none; color: var(--accent); cursor: pointer; font: inherit; font-size: 12px; white-space: nowrap; }
-.reset:disabled { cursor: default; opacity: .55; }
-.reset:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .inherit-setting { display: flex; align-items: flex-start; gap: 9px; margin-bottom: 24px; color: var(--workbench-foreground); font-size: 13px; cursor: pointer; }
 .inherit-setting input { margin-top: 2px; accent-color: var(--accent); }
 .inherit-setting small { display: block; margin-top: 2px; color: var(--faint-foreground); font-size: 12px; }
-.tree-typography code { color: var(--muted-foreground); font: 11.5px var(--mono); }
-.setting { margin-bottom: 22px; }
-.setting label, .setting-label { display: block; color: var(--workbench-foreground); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
-.setting > input, .size-row input {
-  width: 100%; min-width: 0; margin-top: 8px; padding: 8px 10px;
-  border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
-  outline: none; background: var(--input-background); color: var(--workbench-foreground); font: 13px/1.4 var(--mono);
-}
-.setting input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
-.setting input:disabled { opacity: .65; }
 .size-row { display: flex; align-items: center; gap: 8px; width: 130px; color: var(--faint-foreground); }
 .preview-setting { margin-top: 28px; }
 .preview { display: flex; flex-direction: column; gap: 2px; min-width: 0; overflow: hidden; margin-top: 8px; padding: 12px 14px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background); color: var(--workbench-foreground); white-space: nowrap; }
 .preview span:nth-child(2) { padding-left: 16px; }
 .preview span:nth-child(3) { padding-left: 32px; }
-.error { color: var(--danger); font-size: 12px; overflow-wrap: anywhere; }
 </style>

--- a/packages/app/src/renderer/src/components/WindowZoomSettings.vue
+++ b/packages/app/src/renderer/src/components/WindowZoomSettings.vue
@@ -59,24 +59,25 @@ onBeforeUnmount(flushSave);
 </script>
 
 <template>
-  <section class="window-zoom" aria-labelledby="window-zoom-title">
-    <div class="section-heading">
+  <section class="settings-section window-zoom" aria-labelledby="window-zoom-title">
+    <div class="settings-section-heading">
       <div>
-        <h3 id="window-zoom-title">Window zoom level</h3>
-        <p>Sets the default scale for every Gander window.</p>
+        <h3 id="window-zoom-title" class="settings-section-title">Window zoom level</h3>
+        <p class="settings-description">Sets the default scale for every Gander window.</p>
       </div>
-      <button class="reset" type="button" :disabled="store.busy" @click="reset">Use default</button>
+      <button class="settings-reset" type="button" :disabled="store.busy" @click="reset">Use default</button>
     </div>
 
-    <div class="setting">
-      <label for="window-zoom-level">Zoom level</label>
-      <p>
-        Controls <code>window.zoomLevel</code>. Each whole step changes the scale by 20%;
+    <div class="settings-field">
+      <label class="settings-label" for="window-zoom-level">Zoom level</label>
+      <p class="settings-description">
+        Controls <code class="settings-code">window.zoomLevel</code>. Each whole step changes the scale by 20%;
         decimals give finer control.
       </p>
       <div class="level-row">
         <input
           id="window-zoom-level"
+          class="settings-control settings-text-control"
           v-model.number="zoomLevel"
           name="window.zoomLevel"
           type="number"
@@ -92,29 +93,13 @@ onBeforeUnmount(flushSave);
       </div>
     </div>
 
-    <p v-if="localError" class="error" role="alert">{{ localError }}</p>
+    <p v-if="localError" class="settings-error" role="alert">{{ localError }}</p>
   </section>
 </template>
 
+<style scoped src="../styles/settings.css"></style>
+
 <style scoped>
-.window-zoom { max-width: 820px; margin-top: 34px; padding-top: 28px; border-top: 1px solid var(--workbench-border); }
-.section-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; margin-bottom: 22px; }
-.section-heading h3 { color: var(--workbench-foreground); font-size: 15px; line-height: 1.3; }
-.section-heading p, .setting > p { color: var(--faint-foreground); font-size: 12px; }
-.reset { border: 0; background: none; color: var(--accent); cursor: pointer; font: inherit; font-size: 12px; white-space: nowrap; }
-.reset:disabled { cursor: default; opacity: .55; }
-.reset:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.setting { margin-bottom: 22px; }
-.setting label { display: block; color: var(--workbench-foreground); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
-.setting code { color: var(--muted-foreground); font: 11.5px var(--mono); }
 .level-row { display: flex; align-items: center; gap: 9px; width: 150px; color: var(--muted-foreground); font-variant-numeric: tabular-nums; }
-.level-row input {
-  width: 100%; min-width: 0; margin-top: 8px; padding: 8px 10px;
-  border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
-  outline: none; background: var(--input-background); color: var(--workbench-foreground); font: 13px/1.4 var(--mono);
-}
-.level-row input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
-.level-row input:disabled { opacity: .65; }
 .level-row span { margin-top: 8px; }
-.error { color: var(--danger); font-size: 12px; overflow-wrap: anywhere; }
 </style>

--- a/packages/app/src/renderer/src/components/WorkbenchSettings.vue
+++ b/packages/app/src/renderer/src/components/WorkbenchSettings.vue
@@ -40,20 +40,21 @@ async function reset(): Promise<void> {
 </script>
 
 <template>
-  <section class="workbench-settings" aria-labelledby="workbench-settings-title">
-    <header class="heading">
+  <section class="settings-page workbench-settings" aria-labelledby="workbench-settings-title">
+    <header class="settings-page-heading">
       <div>
-        <h2 id="workbench-settings-title">Workbench</h2>
-        <p>Colors for Gander's interface and code surfaces.</p>
+        <h2 id="workbench-settings-title" class="settings-page-title">Workbench</h2>
+        <p class="settings-description">Colors for Gander's interface and code surfaces.</p>
       </div>
-      <button class="reset" type="button" :disabled="store.busy" @click="reset">Use default</button>
+      <button class="settings-reset" type="button" :disabled="store.busy" @click="reset">Use default</button>
     </header>
 
-    <div class="setting">
-      <label for="workbench-color-theme">Color theme</label>
-      <p>Controls <code>workbench.colorTheme</code>. Themes are bundled with Gander.</p>
+    <div class="settings-field">
+      <label class="settings-label" for="workbench-color-theme">Color theme</label>
+      <p class="settings-description">Controls <code class="settings-code">workbench.colorTheme</code>. Themes are bundled with Gander.</p>
       <select
         id="workbench-color-theme"
+        class="settings-control settings-select"
         name="workbench.colorTheme"
         :value="store.settings.workbench.colorTheme"
         :disabled="store.busy"
@@ -61,14 +62,15 @@ async function reset(): Promise<void> {
       >
         <option v-for="theme in themes" :key="theme.id" :value="theme.id">{{ theme.label }}</option>
       </select>
-      <p class="source">Source: {{ activeTheme.source }}</p>
+      <p class="settings-description source">Source: {{ activeTheme.source }}</p>
     </div>
 
-    <div class="setting">
-      <label for="workbench-icon-theme">File icon theme</label>
-      <p>Controls <code>workbench.iconTheme</code>. Icon themes are bundled with Gander.</p>
+    <div class="settings-field">
+      <label class="settings-label" for="workbench-icon-theme">File icon theme</label>
+      <p class="settings-description">Controls <code class="settings-code">workbench.iconTheme</code>. Icon themes are bundled with Gander.</p>
       <select
         id="workbench-icon-theme"
+        class="settings-control settings-select"
         name="workbench.iconTheme"
         :value="store.settings.workbench.iconTheme"
         :disabled="store.busy"
@@ -76,7 +78,7 @@ async function reset(): Promise<void> {
       >
         <option v-for="theme in iconThemes" :key="theme.id" :value="theme.id">{{ theme.label }}</option>
       </select>
-      <p class="source">Source: {{ activeIconTheme.source }}</p>
+      <p class="settings-description source">Source: {{ activeIconTheme.source }}</p>
     </div>
 
     <div class="swatches" role="img" :aria-label="`${activeTheme.label} color palette`">
@@ -88,23 +90,14 @@ async function reset(): Promise<void> {
   </section>
 </template>
 
+<style scoped src="../styles/settings.css"></style>
+
 <style scoped>
-.workbench-settings { height: 100%; overflow: auto; padding: 28px; }
-.heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; max-width: 820px; margin-bottom: 30px; }
-.heading h2 { color: var(--workbench-foreground); font-size: 20px; line-height: 1.25; }
-.heading p, .setting > p { color: var(--faint-foreground); font-size: 12px; }
-.reset { border: 0; background: none; color: var(--accent); cursor: pointer; font: inherit; font-size: 12px; white-space: nowrap; }
-.reset:disabled { cursor: default; opacity: .55; }
-.reset:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.setting { max-width: 820px; margin-bottom: 24px; }
-.setting label { display: block; color: var(--workbench-foreground); font-size: 13px; font-weight: 650; margin-bottom: 2px; }
-.setting code { color: var(--muted-foreground); font: 11.5px var(--mono); }
-.setting select {
+.settings-select {
   width: min(420px, 100%); margin-top: 8px; padding: 8px 34px 8px 10px;
   border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
-  outline: none; background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 13px;
+  background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 13px;
 }
-.setting select:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
 .source { margin-top: 7px; }
 .swatches { display: flex; width: min(420px, 100%); height: 36px; overflow: hidden; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); }
 .swatches span { flex: 1; min-width: 2px; }

--- a/packages/app/src/renderer/src/main.ts
+++ b/packages/app/src/renderer/src/main.ts
@@ -1,3 +1,6 @@
 import { createApp } from "vue";
 import App from "./App.vue";
+import "./styles/tokens.css";
+import "./styles/base.css";
+
 createApp(App).mount("#app");

--- a/packages/app/src/renderer/src/styles/base.css
+++ b/packages/app/src/renderer/src/styles/base.css
@@ -1,0 +1,13 @@
+* { box-sizing: border-box; }
+body, h1, h2, h3, p, pre, ul, ol { margin: 0; }
+ul, ol { padding: 0; }
+:where(button, input, textarea, select) { margin: 0; padding: 0; }
+html, body { height: 100%; }
+body {
+  background: var(--workbench-background); color: var(--workbench-foreground);
+  font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+code, pre { font-family: var(--editor-font-family); font-size: var(--editor-font-size); }
+/* The surfaces the browser draws for us still belong to the theme. */
+::selection { background: var(--selection-background); }
+:root { caret-color: var(--accent); }

--- a/packages/app/src/renderer/src/styles/settings.css
+++ b/packages/app/src/renderer/src/styles/settings.css
@@ -1,0 +1,114 @@
+.settings-page {
+  --settings-field-gap: 24px;
+  height: 100%;
+  overflow: auto;
+  padding: 28px;
+}
+
+.settings-page-heading,
+.settings-section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.settings-page-heading {
+  max-width: 820px;
+  margin-bottom: 30px;
+}
+
+.settings-page-title {
+  color: var(--workbench-foreground);
+  font-size: 20px;
+  line-height: 1.25;
+}
+
+.settings-description {
+  color: var(--faint-foreground);
+  font-size: 12px;
+}
+
+.settings-reset {
+  border: 0;
+  background: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.settings-reset:disabled {
+  cursor: default;
+  opacity: .55;
+}
+
+.settings-reset:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.settings-control:focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.settings-field {
+  max-width: 820px;
+  margin-bottom: var(--settings-field-gap);
+}
+
+.settings-label {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--workbench-foreground);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.settings-code {
+  color: var(--muted-foreground);
+  font: 11.5px var(--mono);
+}
+
+.settings-text-control {
+  width: 100%;
+  min-width: 0;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--workbench-border);
+  border-radius: var(--radius-md);
+  background: var(--input-background);
+  color: var(--workbench-foreground);
+  font: 13px/1.4 var(--mono);
+}
+
+.settings-text-control:disabled {
+  opacity: .65;
+}
+
+.settings-error {
+  color: var(--danger);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.settings-section {
+  --settings-field-gap: 22px;
+  max-width: 820px;
+  margin-top: 34px;
+  padding-top: 28px;
+  border-top: 1px solid var(--workbench-border);
+}
+
+.settings-section-heading {
+  margin-bottom: 22px;
+}
+
+.settings-section-title {
+  color: var(--workbench-foreground);
+  font-size: 15px;
+  line-height: 1.3;
+}

--- a/packages/app/src/renderer/src/styles/tokens.css
+++ b/packages/app/src/renderer/src/styles/tokens.css
@@ -37,13 +37,3 @@
   --radius-lg: 8px;
   --radius-pill: 999px;
 }
-* { box-sizing: border-box; margin: 0; padding: 0; }
-html, body { height: 100%; }
-body {
-  background: var(--workbench-background); color: var(--workbench-foreground);
-  font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-code, pre { font-family: var(--editor-font-family); font-size: var(--editor-font-size); }
-/* The surfaces the browser draws for us still belong to the theme. */
-::selection { background: var(--selection-background); }
-:root { caret-color: var(--accent); }

--- a/packages/app/src/renderer/src/styles/tree.css
+++ b/packages/app/src/renderer/src/styles/tree.css
@@ -1,0 +1,19 @@
+.tnode {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 3px 12px 3px 0;
+  cursor: pointer;
+  font: inherit;
+  white-space: nowrap;
+}
+
+.tnode:hover { background: var(--hover-background); }
+.tnode:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.tnode.sel { background: var(--selection-background); box-shadow: inset 2px 0 0 var(--accent); }
+.tnode .hierarchy-slot { width: 14px; flex: none; }
+.tnode .chev { color: var(--faint-foreground); }
+.tnode .fname { overflow: hidden; text-overflow: ellipsis; }
+.tnode.isdir .fname { color: var(--muted-foreground); }
+.review-slot { width: 15px; flex: none; }


### PR DESCRIPTION
## Summary

- split global renderer tokens and base rules into explicit entrypoint-owned stylesheets
- share repeated settings and file-tree styles while keeping component-specific CSS colocated
- standardize the touched focus states on `:focus-visible` and use the existing danger token consistently

## Why

The renderer's component-scoped CSS was generally healthy, but settings controls and the two file trees had begun duplicating the same visual contracts. This keeps Vue component ownership intact while giving those repeated patterns one source of truth.

## Validation

- `CI=true pnpm typecheck`
- `CI=true pnpm test` (51 files, 330 tests)
- `CI=true pnpm --filter @gander/app run build`
- `git diff --check origin/master...HEAD`
