### PR TITLE
Let the service image build past the Electron repair hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,20 @@ remarks to coding agents over MCP.
 
 `docs/deploy.md` covers running the service on a host.
 
-The approved design spec is binding and is kept outside this repository — on the
-maintainer's machines at `~/src/backstage/gander/specs/`. Read it before changing
-behaviour. `docs/STATE.md` says where the project stands. Interface work and the
-agent reply channel are GitHub issues.
+**This repository is public, so everything specific to the maintainer's instance
+lives outside it**, on the maintainer's machines at `~/src/backstage/gander/`.
+Look there first for anything this repository does not answer — a host name, a
+credential reference, a release step, the binding design.
+
+| Path | Holds |
+|---|---|
+| `specs/` | The approved design spec. Binding. Read it before changing behaviour. |
+| `infrastructure.md` | This deployment: host, path, container, volume, URL, proxy and DNS, the 1Password reference for the token, and per-machine setup |
+| `releasing.md` | The release procedure and what the signing machine provides |
+| `plans/`, `briefs/`, `mockups/` | Implementation plans, briefs, and the reference mockup |
+
+`docs/STATE.md` says where the project stands. Interface work and the agent reply
+channel are GitHub issues.
 
 Settings are validated strictly, so a config written by an earlier version stops
 the app from starting. While the shape is still settling there are no migrations:
@@ -49,7 +59,7 @@ in code, comments, commits, or issues.
 | Typecheck (all packages) | `pnpm typecheck` |
 | Open a review in the running app | `bin/gander --repo owner/name [--pr 42]` |
 | Repair a config the settings schema has outgrown | `bin/fix-config` |
-| Update the service on its host | `bin/deploy` |
+| Update the service on its host | `bin/deploy` (host and path in `~/src/backstage/gander/infrastructure.md`) |
 | Re-record the contract after changing it | `bin/contract-snapshot` |
 | Build an unsigned app | `pnpm --filter @gander/app run dist:unsigned` |
 | Isolated working copy | `bin/worktree add <name>` |

--- a/bin/repair-electron
+++ b/bin/repair-electron
@@ -18,6 +18,12 @@ cd "$(dirname "$0")/.."
 electron_dir="packages/app/node_modules/electron"
 chromedriver_dir="packages/app/node_modules/electron-chromedriver"
 
+# An install that leaves out the app package has no Electron to repair — the
+# service image builds `--filter @gander/service...`, and this hook still runs at
+# the workspace root. Exiting here keeps that build from failing on a repair it
+# does not need.
+[[ -d "$electron_dir" ]] || exit 0
+
 electron_works() {
   packages/app/node_modules/.bin/electron --version >/dev/null 2>&1
 }

--- a/bin/repair-electron.test.ts
+++ b/bin/repair-electron.test.ts
@@ -1,0 +1,32 @@
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const appRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "gander-repair-"));
+  mkdirSync(join(root, "bin"), { recursive: true });
+  copyFileSync(join(appRoot, "bin/repair-electron"), join(root, "bin/repair-electron"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("bin/repair-electron", () => {
+  // The service image installs `--filter @gander/service...`, which leaves out the
+  // app package entirely while still running the workspace root's postinstall hook.
+  // Failing there broke `docker compose up --build` and so every deployment.
+  it("succeeds when the app package was never installed", () => {
+    const result = spawnSync(join(root, "bin/repair-electron"), [], { encoding: "utf8" });
+
+    expect(`${result.stdout}${result.stderr}`).toBe("");
+    expect(result.status).toBe(0);
+  });
+});

--- a/packages/service/Dockerfile
+++ b/packages/service/Dockerfile
@@ -17,6 +17,8 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/shared/package.json packages/shared/
 COPY packages/service/package.json packages/service/
+# The workspace root's postinstall hook runs even for a service-only install.
+COPY bin/repair-electron bin/
 RUN pnpm install --frozen-lockfile --filter @gander/service...
 
 FROM node:24-slim AS runtime


### PR DESCRIPTION
## The bug

Every deployment was broken. The workspace root's `postinstall` hook runs for every install, including the service image's `pnpm install --frozen-lockfile --filter @gander/service...`. That install leaves out the app package, so `bin/repair-electron` found no Electron to repair, printed "Electron's package installers are missing", and exited 1 — failing the Docker build before the service was ever built.

`bin/deploy` surfaced it as:

```
failed to solve: process "/bin/sh -c pnpm install --frozen-lockfile --filter @gander/service..." did not complete successfully: exit code: 1
```

## The fix

`bin/repair-electron` exits 0 when `packages/app/node_modules/electron` is absent — an install without the app package has nothing to repair. The Dockerfile copies the script in, since the hook runs whether or not the file is in the image.

## Test

`bin/repair-electron.test.ts` runs the script from a root with no app package and expects a silent exit 0. It fails without the fix, with the "package installers are missing" message.

## Also

Points `AGENTS.md` at `~/src/backstage/gander/` for anything specific to the maintainer's instance — deploy host, credential reference, release procedure — rather than naming only the design spec. The repository is public and does not record those values, and the old text named `specs/` alone.