### PR TITLE
Default the notarization profile instead of demanding it

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -10,11 +10,12 @@ set -euo pipefail
 #
 # Prerequisites:
 #   - "Developer ID Application: Sevenview Studios Inc." in the keychain
-#   - Notarization credentials stored with `xcrun notarytool store-credentials`,
-#     and APPLE_KEYCHAIN_PROFILE naming that profile
+#   - Notarization credentials stored with
+#     `xcrun notarytool store-credentials outport-notarize`, or another name
+#     exported as APPLE_KEYCHAIN_PROFILE
 #   - gh authenticated
 #
-# Usage: APPLE_KEYCHAIN_PROFILE=<profile> bin/release 0.2.0
+# Usage: bin/release 0.2.0
 
 VERSION="${1:?Usage: bin/release VERSION}"
 TAG="v${VERSION}"
@@ -56,10 +57,11 @@ echo "==> Building, signing, and notarizing"
 # Emptied first: the upload below globs dist/, and artifacts left by an earlier version
 # would be uploaded to this release as if they belonged to it.
 rm -rf packages/app/dist
-# Named by the environment rather than here: a keychain profile is personal to the
-# machine holding the credentials, and this repository is public.
-: "${APPLE_KEYCHAIN_PROFILE:?set APPLE_KEYCHAIN_PROFILE to a notarytool keychain profile — create one with: xcrun notarytool store-credentials}"
-export APPLE_KEYCHAIN_PROFILE
+# A notarytool keychain profile name is a local label, not a credential: the
+# credentials it stands for stay in the machine's keychain. Naming the default here
+# means a machine that has the profile releases without any setup beyond the
+# keychain itself. Override it for a machine that stored them under another name.
+export APPLE_KEYCHAIN_PROFILE="${APPLE_KEYCHAIN_PROFILE:-outport-notarize}"
 pnpm --filter @gander/app run dist:mac
 
 # The tap is a separate repository and is updated manually after release verification.


### PR DESCRIPTION
`bin/release` refused to run without `APPLE_KEYCHAIN_PROFILE`, on the reasoning that a public repository should name no personal credential.

A notarytool keychain profile name is not a credential. It is a local label chosen at `xcrun notarytool store-credentials`; the credentials it stands for stay in the machine's keychain. Requiring it in the environment meant looking the name up on every machine that releases, and protected nothing. The Outport clients name theirs in the script for the same reason.

`bin/release` now defaults to `outport-notarize`. `APPLE_KEYCHAIN_PROFILE` still overrides it for a machine that stored the credentials under another name.

Releasing is now `bin/release <version>`.