### PR TITLE
Review a pull request from the keyboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,10 +119,11 @@ reviewed", not "unchanged".
 
 **Keyboard** is one table: `renderer/src/keymap.ts` lists every binding, and both the
 handler in `App.vue` and the `?` sheet read it, so a key cannot be added without the help
-learning about it. Tree collapse state and the visible-file order live in
-`renderer/src/tree-nav.ts` rather than inside `FileTree.vue`, which renders itself
-recursively — keyboard movement needs one answer to what is visible. Keys that change the
-tree's shape act only while the tree holds focus.
+learning about it. `renderer/src/tree-nav.ts` holds the cursor, the collapse state, and the
+row order, rather than `FileTree.vue`, which renders itself recursively — keyboard movement
+needs one answer to what is visible. The cursor walks directories as well as files and is
+separate from the selected file, because a directory has nothing to show in the diff:
+passing over one leaves the reader on the file they were already reading.
 
 **Note lifecycle:** `open` (reviewer captures with `n`) → `addressed` (agent,
 over MCP, with optional commit ref and summary) → `resolved` (reviewer re-checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,13 @@ marker, and the snapshot becomes the base for the delta diff. An un-check
 deliberately *retains* the snapshot — absence of a snapshot means "never
 reviewed", not "unchanged".
 
+**Keyboard** is one table: `renderer/src/keymap.ts` lists every binding, and both the
+handler in `App.vue` and the `?` sheet read it, so a key cannot be added without the help
+learning about it. Tree collapse state and the visible-file order live in
+`renderer/src/tree-nav.ts` rather than inside `FileTree.vue`, which renders itself
+recursively — keyboard movement needs one answer to what is visible. Keys that change the
+tree's shape act only while the tree holds focus.
+
 **Note lifecycle:** `open` (reviewer captures with `n`) → `addressed` (agent,
 over MCP, with optional commit ref and summary) → `resolved` (reviewer re-checks
 the file). Resolution is always the reviewer's act; no MCP tool may resolve

--- a/bin/gander
+++ b/bin/gander
@@ -25,8 +25,8 @@ const socketPath = process.env.GANDER_APP_SOCKET;
 // Everything after the -- separator, which is what keeps node from reading --repo as
 // an option of its own.
 const argv = process.argv.slice(1);
-// The checkout this ran in travels with the request: the app registers a repository
-// from a checkout's origin, and this is standing in one.
+// The checkout this ran in travels with the request: a repository is registered from
+// the origin of a checkout, and this command is standing in one.
 const socket = connect(socketPath, () => socket.write(JSON.stringify({ argv, from: process.cwd() }) + "\n"));
 let out = "";
 socket.setEncoding("utf8");

--- a/bin/gander
+++ b/bin/gander
@@ -25,7 +25,9 @@ const socketPath = process.env.GANDER_APP_SOCKET;
 // Everything after the -- separator, which is what keeps node from reading --repo as
 // an option of its own.
 const argv = process.argv.slice(1);
-const socket = connect(socketPath, () => socket.write(JSON.stringify({ argv }) + "\n"));
+// The checkout this ran in travels with the request: the app registers a repository
+// from a checkout's origin, and this is standing in one.
+const socket = connect(socketPath, () => socket.write(JSON.stringify({ argv, from: process.cwd() }) + "\n"));
 let out = "";
 socket.setEncoding("utf8");
 socket.on("data", (chunk) => { out += chunk; });

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -6,7 +6,7 @@ import { type LocalView, type OpenTarget, type RepoEntry } from "@gander/shared"
 import { connectionIsFromEnvironment, loadConfig, resolveServiceConnection, saveConfig, type GanderConfig } from "./config.js";
 import { checkConnection } from "./connection.js";
 import { parseOpenTarget } from "./cli.js";
-import { createGitEngine } from "./git.js";
+import { createGitEngine, type GitEngine } from "./git.js";
 import { checkGithubToken, listOpenPrs, resolveGithubToken } from "./github.js";
 import { startOpenServer } from "./open-socket.js";
 import { createReviewer } from "./review.js";
@@ -18,7 +18,7 @@ import { linkedWorktreeLabel } from "./development-context.js";
 import { createZoomController, type ZoomController } from "./zoom-controller.js";
 import { watchLocalView, type LocalViewWatcher } from "./local-viewer.js";
 import { loadUpdateController, supportsInPlaceUpdates, type UpdateController } from "./updates.js";
-import { assertRepositoryRegistered, repositoryFromLocalPath } from "./repository-registration.js";
+import { assertRepositoryRegistered, registerFromCheckout, repositoryFromLocalPath } from "./repository-registration.js";
 
 let zoomController: ZoomController;
 const localWatchers = new Map<number, LocalViewWatcher>();
@@ -46,7 +46,7 @@ function requireOpenWorktree(senderId: number, path: string): void {
   }
 }
 
-async function bootstrap(): Promise<GanderConfig> {
+async function bootstrap(): Promise<{ cfg: GanderConfig; git: GitEngine }> {
   const cfg = loadConfig();
   const git = createGitEngine(join(app.getPath("userData"), "clones"));
   // Resolved per request rather than captured: the reviewer can enter or change the
@@ -216,7 +216,7 @@ async function bootstrap(): Promise<GanderConfig> {
     zoomController.apply(settings.window.zoomLevel);
   });
 
-  return cfg;
+  return { cfg, git };
 }
 
 function installMenu(updates: UpdateController | null): void {
@@ -352,8 +352,9 @@ try {
 
 app.whenReady().then(async () => {
   let cfg: GanderConfig;
+  let git: GitEngine;
   try {
-    cfg = await bootstrap();
+    ({ cfg, git } = await bootstrap());
     if (launchTarget !== null) assertRepositoryRegistered(cfg.repos, launchTarget.repoId);
   } catch (err) {
     dialog.showErrorBox("Gander failed to start", (err as Error).message);
@@ -368,8 +369,11 @@ app.whenReady().then(async () => {
   try {
     const stop = await startOpenServer({
       socketPath: socketPath(),
-      onTarget: (target) => {
-        assertRepositoryRegistered(cfg.repos, target.repoId);
+      onTarget: async (target, from) => {
+        // An agent that just pushed a branch should not need the reviewer to click through
+        // a folder dialog first. The request carries the checkout it came from, which is
+        // the same evidence the picker collects.
+        if (await registerFromCheckout(git, cfg.repos, target.repoId, from) !== null) saveConfig(cfg);
         deliver(target);
       },
     });

--- a/packages/app/src/main/open-socket.test.ts
+++ b/packages/app/src/main/open-socket.test.ts
@@ -81,7 +81,7 @@ describe("open server", () => {
   });
 
   it("takes over a socket file a crashed run left behind", async () => {
-    const second = await startOpenServer({ socketPath, onTarget: (t) => delivered.push(t) });
+    const second = await startOpenServer({ socketPath, onTarget: (t) => { delivered.push(t); } });
     await send(["--repo", "acme/atlas"]);
     expect(delivered).toHaveLength(1);
     second();

--- a/packages/app/src/main/open-socket.ts
+++ b/packages/app/src/main/open-socket.ts
@@ -17,20 +17,32 @@ import { parseOpenTarget } from "./cli.js";
 
 interface OpenServerOptions {
   socketPath: string;
-  onTarget(target: OpenTarget): void;
+  /**
+   * `from` is the working directory the client ran in. Registration takes its identity
+   * from a checkout's origin, and `bin/gander` always runs inside one, so a request can
+   * carry the checkout that names the repository it is asking for.
+   */
+  onTarget(target: OpenTarget, from: string | null): Promise<void> | void;
 }
 
-function readRequest(raw: string): string[] {
+interface OpenRequest {
+  argv: string[];
+  from: string | null;
+}
+
+function readRequest(raw: string): OpenRequest {
   const body: unknown = JSON.parse(raw);
   if (typeof body !== "object" || body === null) throw new Error("expected a JSON object");
   const argv = (body as { argv?: unknown }).argv;
   if (!Array.isArray(argv) || argv.some((a) => typeof a !== "string")) {
     throw new Error("expected an argv array of strings");
   }
-  return argv as string[];
+  const from = (body as { from?: unknown }).from;
+  if (from !== undefined && typeof from !== "string") throw new Error("expected from to be a string");
+  return { argv: argv as string[], from: from ?? null };
 }
 
-function handle(socket: Socket, onTarget: (target: OpenTarget) => void): void {
+function handle(socket: Socket, onTarget: OpenServerOptions["onTarget"]): void {
   let buffer = "";
   socket.setEncoding("utf8");
   socket.on("data", (chunk: string) => {
@@ -41,14 +53,17 @@ function handle(socket: Socket, onTarget: (target: OpenTarget) => void): void {
     if (end === -1) return;
     const line = buffer.slice(0, end);
     buffer = "";
-    try {
-      const target = parseOpenTarget(readRequest(line));
-      if (target === null) throw new Error("no repository named: pass --repo owner/name");
-      onTarget(target);
-      socket.end(`${JSON.stringify({ ok: true, target })}\n`);
-    } catch (err) {
-      socket.end(`${JSON.stringify({ error: (err as Error).message })}\n`);
-    }
+    void (async () => {
+      try {
+        const request = readRequest(line);
+        const target = parseOpenTarget(request.argv);
+        if (target === null) throw new Error("no repository named: pass --repo owner/name");
+        await onTarget(target, request.from);
+        socket.end(`${JSON.stringify({ ok: true, target })}\n`);
+      } catch (err) {
+        socket.end(`${JSON.stringify({ error: (err as Error).message })}\n`);
+      }
+    })();
   });
   // A client that dies mid-request must not take the app down with it.
   socket.on("error", () => socket.destroy());

--- a/packages/app/src/main/repository-registration.test.ts
+++ b/packages/app/src/main/repository-registration.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createGitEngine } from "./git.js";
 import { makeFixtureRepo } from "./fixtures.js";
-import { repositoryFromLocalPath } from "./repository-registration.js";
+import { registerFromCheckout, repositoryFromLocalPath } from "./repository-registration.js";
+import type { RepoEntry } from "@gander/shared";
 
 const paths: string[] = [];
 afterEach(() => {
@@ -38,5 +39,39 @@ describe("local repository registration", () => {
 
     await expect(repositoryFromLocalPath(git, fixture.dir, "acme/atlas"))
       .rejects.toThrow("That folder belongs to acme/beacon, not acme/atlas");
+  });
+
+  // bin/gander runs inside a checkout, so asking it to open a pull request should not
+  // require the reviewer to click through a folder dialog first.
+  it("registers an unseen repository from the checkout the request came from", async () => {
+    const { fixture, git } = await repositoryFixture("acme/atlas");
+    const repos: RepoEntry[] = [];
+
+    const added = await registerFromCheckout(git, repos, "acme/atlas", fixture.dir);
+
+    expect(added).toEqual({ repoId: "acme/atlas", url: "https://github.com/acme/atlas.git", localPath: realpathSync(fixture.dir) });
+    expect(repos).toHaveLength(1);
+  });
+
+  it("leaves an already registered repository alone", async () => {
+    const { fixture, git } = await repositoryFixture("acme/atlas");
+    const repos: RepoEntry[] = [{ repoId: "acme/atlas", url: "https://github.com/acme/atlas.git", localPath: "/elsewhere" }];
+
+    await expect(registerFromCheckout(git, repos, "acme/atlas", fixture.dir)).resolves.toBeNull();
+    expect(repos[0]!.localPath).toBe("/elsewhere");
+  });
+
+  it("refuses a checkout that belongs to another repository", async () => {
+    const { fixture, git } = await repositoryFixture("acme/beacon");
+
+    await expect(registerFromCheckout(git, [], "acme/atlas", fixture.dir))
+      .rejects.toThrow("That folder belongs to acme/beacon, not acme/atlas");
+  });
+
+  it("still asks for a folder when the request names no checkout", async () => {
+    const { git } = await repositoryFixture("acme/atlas");
+
+    await expect(registerFromCheckout(git, [], "acme/atlas", null))
+      .rejects.toThrow("acme/atlas is not registered. Open one of its checkout folders first.");
   });
 });

--- a/packages/app/src/main/repository-registration.ts
+++ b/packages/app/src/main/repository-registration.ts
@@ -25,3 +25,26 @@ export function assertRepositoryRegistered(repos: RepoEntry[], repoId: string): 
     throw new Error(`${repoId} is not registered. Open one of its checkout folders first.`);
   }
 }
+
+/**
+ * Registers `repoId` from the checkout a command was run in, when the app has not seen it
+ * before. Identity still comes from that checkout's origin, so this is the same
+ * registration the folder picker performs — only the folder comes from the caller, which
+ * is already standing in one, rather than from a dialog.
+ *
+ * Returns the entry when one was added, so the caller knows to save its config.
+ */
+export async function registerFromCheckout(
+  git: Pick<GitEngine, "worktreeRoot" | "originUrl">,
+  repos: RepoEntry[],
+  repoId: string,
+  checkoutPath: string | null,
+): Promise<RepoEntry | null> {
+  if (repos.some((repo) => repo.repoId === repoId)) return null;
+  if (checkoutPath === null) {
+    throw new Error(`${repoId} is not registered. Open one of its checkout folders first.`);
+  }
+  const entry = await repositoryFromLocalPath(git, checkoutPath, repoId);
+  repos.push(entry);
+  return entry;
+}

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -10,7 +10,7 @@ import { effectiveTreeTypography } from "../../settings.js";
 import { currentLine } from "./selection.js";
 import type { NoteTarget } from "./selection.js";
 import type { PrFile } from "@gander/shared";
-import { bindingFor, type Command } from "./keymap.js";
+import { bindingFor, isPrefix, type Command, type Prefix } from "./keymap.js";
 import { collapsedDirs, cursor, edge, filesAt, nextUnmarked, parentOf, rowAt, step } from "./tree-nav.js";
 import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../zoom.js";
 import ActivityRail from "./components/ActivityRail.vue";
@@ -357,9 +357,21 @@ watch(() => store.selectedPath, (path) => {
   if (path !== null && rowAt(store.files(), cursor.value)?.type !== "dir") cursor.value = path;
 });
 
+// The half-typed prefix of a two-key binding. Cleared by whatever comes next, so a `g`
+// followed by anything other than the key that completes a chord does nothing at all.
+let pending: Prefix | null = null;
+
 function onKey(event: KeyboardEvent): void {
   if (isTyping(event.target as HTMLElement | null)) return;
-  const binding = bindingFor(event);
+  const started = isPrefix(event, pending);
+  if (started !== null) {
+    pending = started;
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
+  const binding = bindingFor(event, pending);
+  pending = null;
   if (binding === null) return;
   // Everything but the panel toggles is about a pull request under review; in the local
   // viewer there is no checkoff, no note, and no delta to reach.

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -11,7 +11,7 @@ import { currentLine } from "./selection.js";
 import type { NoteTarget } from "./selection.js";
 import type { PrFile } from "@gander/shared";
 import { bindingFor, type Command } from "./keymap.js";
-import { cursor, edge, filesAt, nextUnmarked, rowAt, step, toggleCollapsed } from "./tree-nav.js";
+import { collapsedDirs, cursor, edge, filesAt, nextUnmarked, parentOf, rowAt, step } from "./tree-nav.js";
 import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../zoom.js";
 import ActivityRail from "./components/ActivityRail.vue";
 import ConfirmDialog from "./components/ConfirmDialog.vue";
@@ -266,8 +266,18 @@ function runCommand(command: Command): boolean {
     case "last-file":
       return moveTo(edge(files, command === "first-file" ? "first" : "last"));
     case "toggle-directory": {
-      if (at !== null && rowAt(files, at)?.type === "dir") toggleCollapsed(at);
-      return true;
+      if (at === null) return true;
+      // Opening a directory is how a reviewer says "let me look in here", so the cursor
+      // goes in with it. On anything else the same key closes the directory the cursor is
+      // inside and steps out to it, which is the way back.
+      if (rowAt(files, at)?.type === "dir" && collapsedDirs.has(at)) {
+        collapsedDirs.delete(at);
+        return moveTo(step(files, at, 1));
+      }
+      const dir = rowAt(files, at)?.type === "dir" ? at : parentOf(files, at);
+      if (dir === null) return true;
+      collapsedDirs.add(dir);
+      return moveTo(dir);
     }
     case "dismiss": {
       if (!helpOpen.value) return false;

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
 import type { OpenTarget } from "@gander/shared";
 import { MessageSquare, Plus, RefreshCw, X } from "lucide-vue-next";
 import { api } from "./api.js";
@@ -9,6 +9,9 @@ import { notesDock, notesHeight, notesWidth, treeWidth } from "./layout.js";
 import { effectiveTreeTypography } from "../../settings.js";
 import { currentLine } from "./selection.js";
 import type { NoteTarget } from "./selection.js";
+import type { PrFile } from "@gander/shared";
+import { bindingFor, type Command } from "./keymap.js";
+import { collapsedDirectoryAfter, collapsedDirs, directoryOf, edge, nextUnchecked, step, treeFocus } from "./tree-nav.js";
 import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../zoom.js";
 import ActivityRail from "./components/ActivityRail.vue";
 import ConfirmDialog from "./components/ConfirmDialog.vue";
@@ -18,6 +21,7 @@ import LocalSidebar from "./components/LocalSidebar.vue";
 import PullRequestSidebar from "./components/PullRequestSidebar.vue";
 import NoteCapture from "./components/NoteCapture.vue";
 import NotesDrawer from "./components/NotesDrawer.vue";
+import KeymapHelp from "./components/KeymapHelp.vue";
 import SettingsPane from "./components/SettingsPane.vue";
 import Splitter from "./components/Splitter.vue";
 import StackPosition from "./components/StackPosition.vue";
@@ -35,6 +39,8 @@ const unconfigured = ref(false);
 const noteTarget = shallowRef<NoteTarget | null>(null);
 const drawerOpen = ref(false);
 const treeVisible = ref(true);
+const helpOpen = ref(false);
+const diffPane = ref<InstanceType<typeof DiffPane> | null>(null);
 const treeScrolling = shallowRef(false);
 const zoomLevel = shallowRef(DEFAULT_ZOOM_LEVEL);
 const settingsCategory = shallowRef<"workbench" | "editor" | "connection">("workbench");
@@ -245,21 +251,116 @@ function isTyping(target: HTMLElement | null): boolean {
   return target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
 }
 
+// Selection is the app's cursor, so the keys that move it work wherever the reviewer is
+// looking. Nothing here is editable, so single letters are safe; isTyping guards the note
+// input and the settings fields, which are the only places a letter means itself.
+function runCommand(command: Command): boolean {
+  const files = store.files();
+  const selected = store.selectedPath;
+
+  switch (command) {
+    case "next-file":
+    case "previous-file": {
+      const next = step(files, selected, command === "next-file" ? 1 : -1);
+      if (next !== null) store.select(next);
+      return true;
+    }
+    case "first-file":
+    case "last-file": {
+      const next = edge(files, command === "first-file" ? "first" : "last");
+      if (next !== null) store.select(next);
+      return true;
+    }
+    case "collapse": {
+      // The row the cursor sits on is about to fold away, so the cursor steps out with it,
+      // onto the file above the directory rather than into a hidden row.
+      const dir = selected === null ? null : directoryOf(files, selected);
+      if (dir === null) return true;
+      const above = step(files, selected, -1);
+      collapsedDirs.add(dir);
+      const landing = above !== null && !above.startsWith(`${dir}/`) ? above : edge(files, "first");
+      if (landing !== null) store.select(landing);
+      return true;
+    }
+    case "expand": {
+      const dir = collapsedDirectoryAfter(files, selected);
+      if (dir !== null) collapsedDirs.delete(dir);
+      return true;
+    }
+    case "focus-tree": {
+      treeFocus.active = true;
+      (document.querySelector(".view-sidebar .tnode.sel") as HTMLElement | null)?.focus();
+      return true;
+    }
+    case "focus-diff": {
+      if (helpOpen.value) { helpOpen.value = false; return true; }
+      if (!treeFocus.active) return false;
+      treeFocus.active = false;
+      (document.activeElement as HTMLElement | null)?.blur();
+      return true;
+    }
+    case "toggle-checked": {
+      const file = reviewFileAt(selected);
+      if (file !== null) void store.setChecked(file.path, !file.checked);
+      return true;
+    }
+    case "check-and-advance": {
+      const file = reviewFileAt(selected);
+      if (file === null) return true;
+      const next = nextUnchecked(files, file.path);
+      if (!file.checked) void store.setChecked(file.path, true);
+      if (next !== null && next !== file.path) store.select(next);
+      return true;
+    }
+    case "next-change":
+      diffPane.value?.goToChange("next");
+      return true;
+    case "previous-change":
+      diffPane.value?.goToChange("previous");
+      return true;
+    case "delta-view":
+      diffPane.value?.showDelta();
+      return true;
+    case "capture-note":
+      openNote();
+      return true;
+    case "toggle-notes":
+      drawerOpen.value = !drawerOpen.value;
+      return true;
+    case "toggle-tree":
+      treeVisible.value = !treeVisible.value;
+      return true;
+    case "help":
+      helpOpen.value = !helpOpen.value;
+      return true;
+  }
+}
+
+// Keyboard movement can leave the cursor outside the scrolled area, where the reviewer
+// cannot see what they selected. Follow it; a mouse click is already in view.
+watch(() => store.selectedPath, async () => {
+  await nextTick();
+  document.querySelector(".view-sidebar .tnode.sel")?.scrollIntoView({ block: "nearest" });
+});
+
+function reviewFileAt(path: string | null): PrFile | null {
+  if (path === null) return null;
+  const file = store.files().find((f) => f.path === path);
+  return file !== undefined && "checked" in file ? file as PrFile : null;
+}
+
 function onKey(event: KeyboardEvent): void {
-  const target = event.target as HTMLElement | null;
-  if (isTyping(target)) return;
-  if (event.key === "b" && (event.metaKey || event.ctrlKey)) {
-    event.preventDefault();
-    event.stopPropagation();
-    treeVisible.value = !treeVisible.value;
-    return;
-  }
-  if (event.metaKey || event.ctrlKey || event.altKey) return;
-  if (event.key === "n" && store.view && activeMode.value === "pulls") {
-    event.preventDefault();
-    event.stopPropagation();
-    openNote();
-  }
+  if (isTyping(event.target as HTMLElement | null)) return;
+  const binding = bindingFor(event);
+  if (binding === null) return;
+  // Everything but the panel toggles is about a pull request under review; in the local
+  // viewer there is no checkoff, no note, and no delta to reach.
+  const reviewing = store.view !== null && activeMode.value === "pulls";
+  if (!reviewing && binding.group !== "Panels") return;
+  if (binding.treeOnly === true && !treeFocus.active) return;
+  if (!runCommand(binding.command)) return;
+  event.preventDefault();
+  event.stopPropagation();
 }
 window.addEventListener("keydown", onKey, true);
 
@@ -315,6 +416,8 @@ onBeforeUnmount(() => {
         v-if="treeVisible && activeMode !== 'settings'"
         class="view-sidebar"
         :class="{ scrolling: treeScrolling }"
+        @focusin="treeFocus.active = true"
+        @focusout="treeFocus.active = false"
         :style="{ width: `${treeWidth}px` }"
       >
         <LocalSidebar
@@ -396,7 +499,7 @@ onBeforeUnmount(() => {
               <p>Choose a pull request or stack from the sidebar to begin reviewing.</p>
             </div>
             <div v-else class="workspace" :class="notesDock">
-              <DiffPane :store="store" :editor-settings="editorSettings.settings.editor" class="diff" @add-note="openNote" />
+              <DiffPane ref="diffPane" :store="store" :editor-settings="editorSettings.settings.editor" class="diff" @add-note="openNote" />
               <template v-if="drawerOpen">
                 <Splitter v-model="notesSize" :orientation="notesDock === 'right' ? 'vertical' : 'horizontal'" :min="notesDock === 'right' ? 220 : 120" :max="700" inverted />
                 <NotesDrawer
@@ -425,6 +528,7 @@ onBeforeUnmount(() => {
       @open-zoom-settings="openSettings('workbench')"
     />
     <NoteCapture :store="store" :target="noteTarget" @close="noteTarget = null" />
+    <KeymapHelp v-if="helpOpen" @close="helpOpen = false" />
     <ConfirmDialog
       :open="repoPendingRemoval !== null"
       title="Remove repository?"

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -11,7 +11,7 @@ import { currentLine } from "./selection.js";
 import type { NoteTarget } from "./selection.js";
 import type { PrFile } from "@gander/shared";
 import { bindingFor, type Command } from "./keymap.js";
-import { collapsedDirectoryAfter, collapsedDirs, directoryOf, edge, nextUnchecked, step, treeFocus } from "./tree-nav.js";
+import { collapsedDirs, cursor, edge, filesAt, nextUnmarked, parentOf, rowAt, step } from "./tree-nav.js";
 import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../zoom.js";
 import ActivityRail from "./components/ActivityRail.vue";
 import ConfirmDialog from "./components/ConfirmDialog.vue";
@@ -256,63 +256,44 @@ function isTyping(target: HTMLElement | null): boolean {
 // input and the settings fields, which are the only places a letter means itself.
 function runCommand(command: Command): boolean {
   const files = store.files();
-  const selected = store.selectedPath;
+  const at = cursor.value ?? store.selectedPath;
 
   switch (command) {
     case "next-file":
-    case "previous-file": {
-      const next = step(files, selected, command === "next-file" ? 1 : -1);
-      if (next !== null) store.select(next);
-      return true;
-    }
+    case "previous-file":
+      return moveTo(step(files, at, command === "next-file" ? 1 : -1));
     case "first-file":
-    case "last-file": {
-      const next = edge(files, command === "first-file" ? "first" : "last");
-      if (next !== null) store.select(next);
-      return true;
-    }
+    case "last-file":
+      return moveTo(edge(files, command === "first-file" ? "first" : "last"));
     case "collapse": {
-      // The row the cursor sits on is about to fold away, so the cursor steps out with it,
-      // onto the file above the directory rather than into a hidden row.
-      const dir = selected === null ? null : directoryOf(files, selected);
-      if (dir === null) return true;
-      const above = step(files, selected, -1);
-      collapsedDirs.add(dir);
-      const landing = above !== null && !above.startsWith(`${dir}/`) ? above : edge(files, "first");
-      if (landing !== null) store.select(landing);
-      return true;
+      // On an open directory this closes it; anywhere else it steps out to the directory
+      // that contains the row, which is how an explorer's left arrow behaves.
+      if (at !== null && rowAt(files, at)?.type === "dir" && !collapsedDirs.has(at)) {
+        collapsedDirs.add(at);
+        return true;
+      }
+      return moveTo(at === null ? null : parentOf(files, at));
     }
     case "expand": {
-      const dir = collapsedDirectoryAfter(files, selected);
-      if (dir !== null) collapsedDirs.delete(dir);
+      if (at !== null && rowAt(files, at)?.type === "dir") collapsedDirs.delete(at);
       return true;
     }
-    case "focus-tree": {
-      treeFocus.active = true;
-      (document.querySelector(".view-sidebar .tnode.sel") as HTMLElement | null)?.focus();
-      return true;
-    }
-    case "focus-diff": {
-      if (helpOpen.value) { helpOpen.value = false; return true; }
-      if (!treeFocus.active) return false;
-      treeFocus.active = false;
-      (document.activeElement as HTMLElement | null)?.blur();
+    case "dismiss": {
+      if (!helpOpen.value) return false;
+      helpOpen.value = false;
       return true;
     }
     case "toggle-checked": {
-      const file = reviewFileAt(selected);
-      if (file !== null) void store.setChecked(file.path, !file.checked);
+      mark(at, null);
       return true;
     }
     case "mark-and-advance":
     case "mark-and-retreat": {
-      const file = reviewFileAt(selected);
-      if (file === null) return true;
-      // Read before marking: once this file is checked it would no longer be a candidate,
-      // and the search would skip over where the reviewer actually is.
-      const next = nextUnchecked(files, file.path, command === "mark-and-advance" ? 1 : -1);
-      if (!file.checked) void store.setChecked(file.path, true);
-      if (next !== null && next !== file.path) store.select(next);
+      // Read before marking: once this row is marked it is no longer a candidate, and the
+      // search would step over where the reviewer actually is.
+      const next = nextUnmarked(files, at, command === "mark-and-advance" ? 1 : -1);
+      mark(at, true);
+      if (next !== null && next !== at) moveTo(next);
       return true;
     }
     case "next-change":
@@ -339,18 +320,41 @@ function runCommand(command: Command): boolean {
   }
 }
 
+/**
+ * Moves the cursor, and opens the row when it is a file. A directory has nothing to show,
+ * so passing over one leaves the reader looking at the file they were already reading.
+ */
+function moveTo(path: string | null): boolean {
+  if (path === null) return true;
+  cursor.value = path;
+  if (rowAt(store.files(), path)?.type === "file") store.select(path);
+  return true;
+}
+
+/** Marks a row: one file, or every file under a directory. `checked` null means toggle. */
+function mark(path: string | null, checked: boolean | null): void {
+  const under = filesAt(store.files(), path).filter((file): file is PrFile => "checked" in file);
+  if (under.length === 0) return;
+  const next = checked ?? under.some((file) => !file.checked);
+  const changing = under.filter((file) => file.checked !== next).map((file) => file.path);
+  if (changing.length === 0) return;
+  if (changing.length === 1) void store.setChecked(changing[0]!, next);
+  else void store.setCheckedMany(changing, next);
+}
+
+
 // Keyboard movement can leave the cursor outside the scrolled area, where the reviewer
-// cannot see what they selected. Follow it; a mouse click is already in view.
-watch(() => store.selectedPath, async () => {
+// cannot see what they are on. Follow it; a mouse click is already in view.
+watch(cursor, async () => {
   await nextTick();
-  document.querySelector(".view-sidebar .tnode.sel")?.scrollIntoView({ block: "nearest" });
+  document.querySelector(".view-sidebar .tnode.cur")?.scrollIntoView({ block: "nearest" });
 });
 
-function reviewFileAt(path: string | null): PrFile | null {
-  if (path === null) return null;
-  const file = store.files().find((f) => f.path === path);
-  return file !== undefined && "checked" in file ? file as PrFile : null;
-}
+// A file opened by any other route — a click, a note, opening the pull request — becomes
+// where the keyboard continues from.
+watch(() => store.selectedPath, (path) => {
+  if (path !== null && rowAt(store.files(), cursor.value)?.type !== "dir") cursor.value = path;
+});
 
 function onKey(event: KeyboardEvent): void {
   if (isTyping(event.target as HTMLElement | null)) return;
@@ -360,7 +364,6 @@ function onKey(event: KeyboardEvent): void {
   // viewer there is no checkoff, no note, and no delta to reach.
   const reviewing = store.view !== null && activeMode.value === "pulls";
   if (!reviewing && binding.group !== "Panels") return;
-  if (binding.treeOnly === true && !treeFocus.active) return;
   if (!runCommand(binding.command)) return;
   event.preventDefault();
   event.stopPropagation();
@@ -419,8 +422,6 @@ onBeforeUnmount(() => {
         v-if="treeVisible && activeMode !== 'settings'"
         class="view-sidebar"
         :class="{ scrolling: treeScrolling }"
-        @focusin="treeFocus.active = true"
-        @focusout="treeFocus.active = false"
         :style="{ width: `${treeWidth}px` }"
       >
         <LocalSidebar

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -304,10 +304,13 @@ function runCommand(command: Command): boolean {
       if (file !== null) void store.setChecked(file.path, !file.checked);
       return true;
     }
-    case "check-and-advance": {
+    case "mark-and-advance":
+    case "mark-and-retreat": {
       const file = reviewFileAt(selected);
       if (file === null) return true;
-      const next = nextUnchecked(files, file.path);
+      // Read before marking: once this file is checked it would no longer be a candidate,
+      // and the search would skip over where the reviewer actually is.
+      const next = nextUnchecked(files, file.path, command === "mark-and-advance" ? 1 : -1);
       if (!file.checked) void store.setChecked(file.path, true);
       if (next !== null && next !== file.path) store.select(next);
       return true;

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -11,7 +11,7 @@ import { currentLine } from "./selection.js";
 import type { NoteTarget } from "./selection.js";
 import type { PrFile } from "@gander/shared";
 import { bindingFor, type Command } from "./keymap.js";
-import { collapsedDirs, cursor, edge, filesAt, nextUnmarked, parentOf, rowAt, step } from "./tree-nav.js";
+import { cursor, edge, filesAt, nextUnmarked, rowAt, step, toggleCollapsed } from "./tree-nav.js";
 import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../zoom.js";
 import ActivityRail from "./components/ActivityRail.vue";
 import ConfirmDialog from "./components/ConfirmDialog.vue";
@@ -265,17 +265,8 @@ function runCommand(command: Command): boolean {
     case "first-file":
     case "last-file":
       return moveTo(edge(files, command === "first-file" ? "first" : "last"));
-    case "collapse": {
-      // On an open directory this closes it; anywhere else it steps out to the directory
-      // that contains the row, which is how an explorer's left arrow behaves.
-      if (at !== null && rowAt(files, at)?.type === "dir" && !collapsedDirs.has(at)) {
-        collapsedDirs.add(at);
-        return true;
-      }
-      return moveTo(at === null ? null : parentOf(files, at));
-    }
-    case "expand": {
-      if (at !== null && rowAt(files, at)?.type === "dir") collapsedDirs.delete(at);
+    case "toggle-directory": {
+      if (at !== null && rowAt(files, at)?.type === "dir") toggleCollapsed(at);
       return true;
     }
     case "dismiss": {

--- a/packages/app/src/renderer/src/components/DiffPane.vue
+++ b/packages/app/src/renderer/src/components/DiffPane.vue
@@ -15,6 +15,7 @@ import type { PrFile } from "@gander/shared";
 
 const props = defineProps<{ store: Store; editorSettings: EditorSettings }>();
 const emit = defineEmits<{ addNote: [target: NoteTarget] }>();
+
 const host = ref<HTMLElement | null>(null);
 const view = ref<"diff" | "full" | "since">("diff");
 
@@ -34,6 +35,17 @@ let editor: monaco.editor.IStandaloneDiffEditor | monaco.editor.IStandaloneCodeE
 let models: monaco.editor.ITextModel[] = [];
 let lineAction: HTMLButtonElement | null = null;
 let lineActionLine: number | null = null;
+// The keymap reaches the two things only this component can do: the tab set, and Monaco's
+// own change-to-change navigation. Exposed rather than lifted, because both belong to the
+// editor instance this component owns.
+defineExpose({
+  showDelta(): void {
+    if (canShowDelta.value) view.value = view.value === "since" ? "diff" : "since";
+  },
+  goToChange(target: "next" | "previous"): void {
+    if (editor !== null && "goToDiff" in editor) editor.goToDiff(target);
+  },
+});
 
 const current = computed(
   () => props.store.files().find((f) => f.path === props.store.selectedPath) ?? null,

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { mount, type VueWrapper } from "@vue/test-utils";
 import { nextTick, reactive } from "vue";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { PrFile, PrView } from "@gander/shared";
 import type { Store } from "../store.js";
 import FileTree from "./FileTree.vue";
+import { collapsedDirs } from "../tree-nav.js";
 
 const file = (path: string, checked = false): PrFile =>
   ({ path, status: "M", baseContent: "", headContent: "", baseHash: "b", headHash: "h", checked, changedSince: false });
@@ -94,6 +95,9 @@ function fileRow(wrapper: VueWrapper, path: string) {
 }
 
 describe("FileTree", () => {
+  // Collapse state is shared across the tree's recursive levels, so it outlives a mount.
+  beforeEach(() => collapsedDirs.clear());
+
   const treeFiles = [
     file("app/models/member.rb", false),
     file("app/services/dues/late_fee_calculator.rb", true),

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, reactive, watch } from "vue";
+import { computed, watch } from "vue";
 import type { Store } from "../store.js";
 import { buildTree, dirState, filesUnder, type TreeNode } from "../tree.js";
+import { collapsedDirs, toggleCollapsed } from "../tree-nav.js";
 import {
   fileIconFor,
   folderIconFor,
@@ -23,8 +24,6 @@ const props = withDefaults(defineProps<{
   files?: ChangedFile[];
   showStatus?: boolean;
 }>(), { showStatus: true });
-
-const collapsed = reactive(new Set<string>());
 
 const depth = computed(() => props.depth ?? 0);
 const nodes = computed(() => props.nodes ?? buildTree(props.files ?? props.store.files()));
@@ -67,12 +66,7 @@ function dirStateFor(node: TreeNode & { type: "dir" }): "all" | "some" | "none" 
 // (never through a null in between), so switching PRs within the same repo never unmounts
 // this component. Clear stale collapse state whenever the reviewed PR changes.
 const prIdentity = computed(() => `${props.store.currentRepoId ?? ""}#${props.store.view?.pr.number ?? props.store.localView?.worktree.path ?? ""}`);
-watch(prIdentity, () => collapsed.clear());
-
-function toggleCollapsed(path: string) {
-  if (collapsed.has(path)) collapsed.delete(path);
-  else collapsed.add(path);
-}
+watch(prIdentity, () => { if (depth.value === 0) collapsedDirs.clear(); });
 
 function checkDir(node: TreeNode & { type: "dir" }) {
   const files = filesUnder(node).filter((file): file is PrFile => "checked" in file);
@@ -101,7 +95,7 @@ function fileIcon(path: string) {
 }
 
 function folderIcon(node: TreeNode & { type: "dir" }) {
-  return folderIconFor(props.iconTheme, { name: node.name, expanded: !collapsed.has(node.path) });
+  return folderIconFor(props.iconTheme, { name: node.name, expanded: !collapsedDirs.has(node.path) });
 }
 </script>
 
@@ -118,7 +112,7 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
         @keydown.enter.space.prevent="toggleCollapsed(node.path)"
       >
         <component
-          :is="collapsed.has(node.path) ? ChevronRight : ChevronDown"
+          :is="collapsedDirs.has(node.path) ? ChevronRight : ChevronDown"
           v-if="iconThemeShowsExplorerArrows(iconTheme)"
           class="hierarchy-slot chev"
           :size="14"
@@ -142,7 +136,7 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
         <span class="fname">{{ node.name }}</span>
       </div>
       <FileTree
-        v-if="node.type === 'dir' && !collapsed.has(node.path)"
+        v-if="node.type === 'dir' && !collapsedDirs.has(node.path)"
         :store="store"
         :icon-theme="iconTheme"
         :nodes="node.children"

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -194,8 +194,7 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
 .cb.on { border-color: var(--success); color: var(--success); }
 .cb.part { border-color: var(--success); color: var(--success); }
 .tnode.checked .fname { color: var(--faint-foreground); }
-/* The cursor is where the keyboard is, which is not always the file on screen. */
-.tnode.cur { box-shadow: inset 2px 0 0 var(--accent); }
+
 .note-mark { display: inline-flex; align-items: center; gap: 2px; color: var(--accent); flex: none; }
 .note-count { font-size: 10px; line-height: 1; font-variant-numeric: tabular-nums; }
 .delta-mark { width: 7px; height: 7px; border-radius: 50%; background: var(--warning); flex: none; }

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -2,7 +2,7 @@
 import { computed, watch } from "vue";
 import type { Store } from "../store.js";
 import { buildTree, dirState, filesUnder, type TreeNode } from "../tree.js";
-import { collapsedDirs, toggleCollapsed } from "../tree-nav.js";
+import { collapsedDirs, cursor, toggleCollapsed } from "../tree-nav.js";
 import {
   fileIconFor,
   folderIconFor,
@@ -105,10 +105,11 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
       <div
         v-if="node.type === 'dir'"
         class="tnode isdir"
+        :class="{ cur: node.path === cursor }"
         :style="{ paddingLeft: `${10 + depth * 16}px` }"
         role="button"
         tabindex="0"
-        @click="toggleCollapsed(node.path)"
+        @click="cursor = node.path; toggleCollapsed(node.path)"
         @keydown.enter.space.prevent="toggleCollapsed(node.path)"
       >
         <component
@@ -146,11 +147,11 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
       <div
         v-if="node.type === 'file'"
         class="tnode"
-        :class="{ sel: node.file.path === store.selectedPath, checked: reviewFile(node)?.checked }"
+        :class="{ sel: node.file.path === store.selectedPath, cur: node.file.path === cursor, checked: reviewFile(node)?.checked }"
         :style="{ paddingLeft: `${10 + depth * 16}px` }"
         role="button"
         tabindex="0"
-        @click="store.select(node.file.path)"
+        @click="cursor = node.file.path; store.select(node.file.path)"
         @keydown.enter.space.prevent="store.select(node.file.path)"
       >
         <span class="hierarchy-slot" aria-hidden="true" />
@@ -193,6 +194,8 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
 .cb.on { border-color: var(--success); color: var(--success); }
 .cb.part { border-color: var(--success); color: var(--success); }
 .tnode.checked .fname { color: var(--faint-foreground); }
+/* The cursor is where the keyboard is, which is not always the file on screen. */
+.tnode.cur { box-shadow: inset 2px 0 0 var(--accent); }
 .note-mark { display: inline-flex; align-items: center; gap: 2px; color: var(--accent); flex: none; }
 .note-count { font-size: 10px; line-height: 1; font-variant-numeric: tabular-nums; }
 .delta-mark { width: 7px; height: 7px; border-radius: 50%; background: var(--warning); flex: none; }

--- a/packages/app/src/renderer/src/components/KeymapHelp.vue
+++ b/packages/app/src/renderer/src/components/KeymapHelp.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { BINDINGS, GROUPS } from "../keymap.js";
+
+defineEmits<{ close: [] }>();
+
+// Rendered from the same table the handler dispatches on, so the sheet cannot drift
+// from what the keys actually do.
+const inGroup = (group: string) => BINDINGS.filter((binding) => binding.group === group);
+</script>
+
+<template>
+  <div class="scrim" @click="$emit('close')">
+    <section class="sheet" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" @click.stop>
+      <header>
+        <h2>Keyboard</h2>
+        <p>Esc or ? closes this.</p>
+      </header>
+      <div class="groups">
+        <section v-for="group in GROUPS" :key="group">
+          <h3>{{ group }}</h3>
+          <dl>
+            <template v-for="binding in inGroup(group)" :key="binding.command">
+              <dt><kbd>{{ binding.label }}</kbd></dt>
+              <dd>
+                {{ binding.description }}
+                <span v-if="binding.treeOnly" class="scope">in the tree</span>
+              </dd>
+            </template>
+          </dl>
+        </section>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.scrim { position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; background: rgb(0 0 0 / 45%); z-index: 40; }
+.sheet { width: min(680px, 90vw); max-height: 80vh; overflow-y: auto; padding: 20px 24px 24px; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--panel-background); box-shadow: var(--shadow-lg); }
+header h2 { margin: 0; font-size: 15px; }
+header p { margin: 2px 0 16px; color: var(--faint-foreground); font-size: 12px; }
+.groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 20px 28px; }
+h3 { margin: 0 0 6px; color: var(--faint-foreground); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+dl { display: grid; grid-template-columns: auto 1fr; gap: 6px 12px; margin: 0; align-items: baseline; }
+dt { justify-self: start; }
+dd { margin: 0; font-size: 13px; }
+kbd { display: inline-block; padding: 2px 6px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--background); font: 11px var(--mono); white-space: nowrap; }
+.scope { color: var(--faint-foreground); font-size: 11px; }
+</style>

--- a/packages/app/src/renderer/src/components/KeymapHelp.vue
+++ b/packages/app/src/renderer/src/components/KeymapHelp.vue
@@ -21,10 +21,7 @@ const inGroup = (group: string) => BINDINGS.filter((binding) => binding.group ==
           <dl>
             <template v-for="binding in inGroup(group)" :key="binding.command">
               <dt><kbd>{{ binding.label }}</kbd></dt>
-              <dd>
-                {{ binding.description }}
-                <span v-if="binding.treeOnly" class="scope">in the tree</span>
-              </dd>
+              <dd>{{ binding.description }}</dd>
             </template>
           </dl>
         </section>
@@ -44,5 +41,4 @@ dl { display: grid; grid-template-columns: auto 1fr; gap: 6px 12px; margin: 0; a
 dt { justify-self: start; }
 dd { margin: 0; font-size: 13px; }
 kbd { display: inline-block; padding: 2px 6px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--background); font: 11px var(--mono); white-space: nowrap; }
-.scope { color: var(--faint-foreground); font-size: 11px; }
 </style>

--- a/packages/app/src/renderer/src/keymap.test.ts
+++ b/packages/app/src/renderer/src/keymap.test.ts
@@ -27,10 +27,10 @@ describe("keymap", () => {
     expect(bindingFor(press("j", { altKey: true }))).toBeNull();
   });
 
-  it("binds the arrow keys alongside hjkl, and o alongside expand", () => {
+  it("binds the arrows alongside j and k, and o to the directory toggle", () => {
     expect(bindingFor(press("ArrowDown"))?.command).toBe("next-file");
-    expect(bindingFor(press("ArrowLeft"))?.command).toBe("collapse");
-    expect(bindingFor(press("o"))?.command).toBe("expand");
+    expect(bindingFor(press("ArrowUp"))?.command).toBe("previous-file");
+    expect(bindingFor(press("o"))?.command).toBe("toggle-directory");
   });
 
   // The `?` sheet renders from this table, so a binding outside the printed groups would

--- a/packages/app/src/renderer/src/keymap.test.ts
+++ b/packages/app/src/renderer/src/keymap.test.ts
@@ -10,8 +10,10 @@ describe("keymap", () => {
   });
 
   it("tells a shifted letter from its lower case", () => {
-    expect(bindingFor(press("x"))?.command).toBe("toggle-checked");
-    expect(bindingFor(press("X"))?.command).toBe("check-and-advance");
+    expect(bindingFor(press("m"))?.command).toBe("toggle-checked");
+    expect(bindingFor(press("j"))?.command).toBe("next-file");
+    expect(bindingFor(press("J"))?.command).toBe("mark-and-advance");
+    expect(bindingFor(press("K"))?.command).toBe("mark-and-retreat");
   });
 
   // ⌘B toggles the tree; a bare b would otherwise claim the same key.

--- a/packages/app/src/renderer/src/keymap.test.ts
+++ b/packages/app/src/renderer/src/keymap.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { BINDINGS, GROUPS, bindingFor } from "./keymap.js";
+
+const press = (key: string, modifiers: Partial<KeyboardEvent> = {}): KeyboardEvent =>
+  ({ key, metaKey: false, ctrlKey: false, altKey: false, ...modifiers }) as KeyboardEvent;
+
+describe("keymap", () => {
+  it("matches a plain letter", () => {
+    expect(bindingFor(press("j"))?.command).toBe("next-file");
+  });
+
+  it("tells a shifted letter from its lower case", () => {
+    expect(bindingFor(press("x"))?.command).toBe("toggle-checked");
+    expect(bindingFor(press("X"))?.command).toBe("check-and-advance");
+  });
+
+  // ⌘B toggles the tree; a bare b would otherwise claim the same key.
+  it("requires the modifier where one is specified, and refuses it where none is", () => {
+    expect(bindingFor(press("b"))).toBeNull();
+    expect(bindingFor(press("b", { metaKey: true }))?.command).toBe("toggle-tree");
+    expect(bindingFor(press("j", { metaKey: true }))).toBeNull();
+  });
+
+  it("leaves Option combinations to the system", () => {
+    expect(bindingFor(press("j", { altKey: true }))).toBeNull();
+  });
+
+  it("binds the arrow keys alongside hjkl", () => {
+    expect(bindingFor(press("ArrowDown"))?.command).toBe("next-file");
+    expect(bindingFor(press("ArrowLeft"))?.command).toBe("collapse");
+  });
+
+  // The `?` sheet renders from this table, so a binding outside the printed groups would
+  // work while going undocumented.
+  it("puts every binding in a group the help sheet prints", () => {
+    for (const binding of BINDINGS) expect(GROUPS).toContain(binding.group);
+  });
+
+  it("claims each key once", () => {
+    const seen = BINDINGS.flatMap((b) => b.keys.map((k) => `${b.meta === true ? "meta+" : ""}${k}`));
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+});

--- a/packages/app/src/renderer/src/keymap.test.ts
+++ b/packages/app/src/renderer/src/keymap.test.ts
@@ -27,9 +27,10 @@ describe("keymap", () => {
     expect(bindingFor(press("j", { altKey: true }))).toBeNull();
   });
 
-  it("binds the arrow keys alongside hjkl", () => {
+  it("binds the arrow keys alongside hjkl, and o alongside expand", () => {
     expect(bindingFor(press("ArrowDown"))?.command).toBe("next-file");
     expect(bindingFor(press("ArrowLeft"))?.command).toBe("collapse");
+    expect(bindingFor(press("o"))?.command).toBe("expand");
   });
 
   // The `?` sheet renders from this table, so a binding outside the printed groups would

--- a/packages/app/src/renderer/src/keymap.test.ts
+++ b/packages/app/src/renderer/src/keymap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BINDINGS, GROUPS, bindingFor } from "./keymap.js";
+import { BINDINGS, GROUPS, bindingFor, isPrefix } from "./keymap.js";
 
 const press = (key: string, modifiers: Partial<KeyboardEvent> = {}): KeyboardEvent =>
   ({ key, metaKey: false, ctrlKey: false, altKey: false, ...modifiers }) as KeyboardEvent;
@@ -39,8 +39,26 @@ describe("keymap", () => {
     for (const binding of BINDINGS) expect(GROUPS).toContain(binding.group);
   });
 
+  // gg is vim's, and g does nothing on its own, so it can begin a chord without any other
+  // binding having to know about it.
+  it("reaches a chord only while its prefix is pending", () => {
+    expect(bindingFor(press("g"))).toBeNull();
+    expect(isPrefix(press("g"), null)).toBe("g");
+    expect(bindingFor(press("g"), "g")?.command).toBe("first-file");
+  });
+
+  it("hides plain bindings while a prefix is pending", () => {
+    expect(bindingFor(press("j"), "g")).toBeNull();
+    expect(bindingFor(press("G"))?.command).toBe("last-file");
+  });
+
+  it("does not start a chord on a modified key, or while one is already pending", () => {
+    expect(isPrefix(press("g", { metaKey: true }), null)).toBeNull();
+    expect(isPrefix(press("g"), "g")).toBeNull();
+  });
+
   it("claims each key once", () => {
-    const seen = BINDINGS.flatMap((b) => b.keys.map((k) => `${b.meta === true ? "meta+" : ""}${k}`));
+    const seen = BINDINGS.flatMap((b) => b.keys.map((k) => `${b.prefix ?? ""}${b.meta === true ? "meta+" : ""}${k}`));
     expect(new Set(seen).size).toBe(seen.length);
   });
 });

--- a/packages/app/src/renderer/src/keymap.ts
+++ b/packages/app/src/renderer/src/keymap.ts
@@ -15,7 +15,8 @@ export type Command =
   | "focus-tree"
   | "focus-diff"
   | "toggle-checked"
-  | "check-and-advance"
+  | "mark-and-advance"
+  | "mark-and-retreat"
   | "next-change"
   | "previous-change"
   | "delta-view"
@@ -48,8 +49,9 @@ export const BINDINGS: Binding[] = [
   { command: "focus-tree", keys: ["Tab"], label: "Tab", description: "Focus the file tree", group: "Move" },
   { command: "focus-diff", keys: ["Escape"], label: "Esc", description: "Return to the diff", group: "Move" },
 
-  { command: "toggle-checked", keys: ["x", " "], label: "x / Space", description: "Check or un-check this file", group: "Review" },
-  { command: "check-and-advance", keys: ["X"], label: "⇧X", description: "Check it and go to the next unchecked file", group: "Review" },
+  { command: "toggle-checked", keys: ["m", " "], label: "m / Space", description: "Mark or unmark this file", group: "Review" },
+  { command: "mark-and-advance", keys: ["J"], label: "⇧J", description: "Mark it and go to the next unmarked file", group: "Review" },
+  { command: "mark-and-retreat", keys: ["K"], label: "⇧K", description: "Mark it and go to the previous unmarked file", group: "Review" },
   { command: "capture-note", keys: ["n"], label: "n", description: "Capture a note", group: "Review" },
   { command: "toggle-notes", keys: ["N"], label: "⇧N", description: "Show or hide the notes", group: "Review" },
 

--- a/packages/app/src/renderer/src/keymap.ts
+++ b/packages/app/src/renderer/src/keymap.ts
@@ -5,6 +5,10 @@
  * help learning about it, and the help cannot claim a key that does nothing.
  */
 
+/** Keys that begin a two-key binding rather than doing anything themselves. */
+export type Prefix = "g";
+export const PREFIXES: Prefix[] = ["g"];
+
 export type Command =
   | "next-file"
   | "previous-file"
@@ -33,13 +37,15 @@ export interface Binding {
   group: "Move" | "Review" | "Read" | "Panels";
   /** Held with Command on macOS, Control elsewhere. */
   meta?: true;
+  /** Reached by pressing this key first, vim's two-key form. */
+  prefix?: Prefix;
 }
 
 export const BINDINGS: Binding[] = [
   { command: "next-file", keys: ["j", "ArrowDown"], label: "j / ↓", description: "Next row", group: "Move" },
   { command: "previous-file", keys: ["k", "ArrowUp"], label: "k / ↑", description: "Previous row", group: "Move" },
-  { command: "first-file", keys: ["Home"], label: "Home", description: "First row", group: "Move" },
-  { command: "last-file", keys: ["End"], label: "End", description: "Last row", group: "Move" },
+  { command: "first-file", keys: ["g"], prefix: "g", label: "gg", description: "First row", group: "Move" },
+  { command: "last-file", keys: ["G"], label: "⇧G", description: "Last row", group: "Move" },
   { command: "toggle-directory", keys: ["o"], label: "o", description: "Open the directory and step in, or close the one you are in", group: "Move" },
   { command: "dismiss", keys: ["Escape"], label: "Esc", description: "Close what is open on top", group: "Move" },
 
@@ -59,11 +65,23 @@ export const BINDINGS: Binding[] = [
 
 export const GROUPS: Binding["group"][] = ["Move", "Review", "Read", "Panels"];
 
-export function bindingFor(event: KeyboardEvent): Binding | null {
+/**
+ * `pending` is the prefix key already pressed, if any. A binding with a prefix is reachable
+ * only while that prefix is pending, and a plain binding only while none is — so `g` can
+ * begin `gg` without `G` or any other key having to know about it.
+ */
+export function bindingFor(event: KeyboardEvent, pending: Prefix | null = null): Binding | null {
   const held = event.metaKey || event.ctrlKey;
   return BINDINGS.find((binding) => {
     if ((binding.meta === true) !== held) return false;
     if (event.altKey) return false;
+    if ((binding.prefix ?? null) !== pending) return false;
     return binding.keys.includes(event.key);
   }) ?? null;
+}
+
+/** True when this key only makes sense as the start of a two-key binding. */
+export function isPrefix(event: KeyboardEvent, pending: Prefix | null): Prefix | null {
+  if (pending !== null || event.metaKey || event.ctrlKey || event.altKey) return null;
+  return PREFIXES.find((prefix) => prefix === event.key) ?? null;
 }

--- a/packages/app/src/renderer/src/keymap.ts
+++ b/packages/app/src/renderer/src/keymap.ts
@@ -40,7 +40,7 @@ export const BINDINGS: Binding[] = [
   { command: "previous-file", keys: ["k", "ArrowUp"], label: "k / ↑", description: "Previous row", group: "Move" },
   { command: "first-file", keys: ["Home"], label: "Home", description: "First row", group: "Move" },
   { command: "last-file", keys: ["End"], label: "End", description: "Last row", group: "Move" },
-  { command: "toggle-directory", keys: ["o"], label: "o", description: "Open or close the directory", group: "Move" },
+  { command: "toggle-directory", keys: ["o"], label: "o", description: "Open the directory and step in, or close the one you are in", group: "Move" },
   { command: "dismiss", keys: ["Escape"], label: "Esc", description: "Close what is open on top", group: "Move" },
 
   { command: "toggle-checked", keys: ["m", " "], label: "m / Space", description: "Mark or unmark this file, or the whole directory", group: "Review" },

--- a/packages/app/src/renderer/src/keymap.ts
+++ b/packages/app/src/renderer/src/keymap.ts
@@ -1,0 +1,73 @@
+/**
+ * Every key the review surface answers to, in one table.
+ *
+ * The handler and the `?` sheet both read this, so a binding cannot be added without the
+ * help learning about it, and the help cannot claim a key that does nothing.
+ */
+
+export type Command =
+  | "next-file"
+  | "previous-file"
+  | "first-file"
+  | "last-file"
+  | "collapse"
+  | "expand"
+  | "focus-tree"
+  | "focus-diff"
+  | "toggle-checked"
+  | "check-and-advance"
+  | "next-change"
+  | "previous-change"
+  | "delta-view"
+  | "capture-note"
+  | "toggle-notes"
+  | "toggle-tree"
+  | "help";
+
+export interface Binding {
+  command: Command;
+  /** `event.key` values that run the command. */
+  keys: string[];
+  /** What the sheet prints, which is not always what `event.key` reports. */
+  label: string;
+  description: string;
+  group: "Move" | "Review" | "Read" | "Panels";
+  /** Held with Command on macOS, Control elsewhere. */
+  meta?: true;
+  /** Acts only while the file tree holds focus, because it changes the tree's shape. */
+  treeOnly?: true;
+}
+
+export const BINDINGS: Binding[] = [
+  { command: "next-file", keys: ["j", "ArrowDown"], label: "j / ↓", description: "Next file", group: "Move" },
+  { command: "previous-file", keys: ["k", "ArrowUp"], label: "k / ↑", description: "Previous file", group: "Move" },
+  { command: "first-file", keys: ["Home"], label: "Home", description: "First file", group: "Move" },
+  { command: "last-file", keys: ["End"], label: "End", description: "Last file", group: "Move" },
+  { command: "collapse", keys: ["h", "ArrowLeft"], label: "h / ←", description: "Collapse the directory", group: "Move", treeOnly: true },
+  { command: "expand", keys: ["l", "ArrowRight"], label: "l / →", description: "Expand the directory", group: "Move", treeOnly: true },
+  { command: "focus-tree", keys: ["Tab"], label: "Tab", description: "Focus the file tree", group: "Move" },
+  { command: "focus-diff", keys: ["Escape"], label: "Esc", description: "Return to the diff", group: "Move" },
+
+  { command: "toggle-checked", keys: ["x", " "], label: "x / Space", description: "Check or un-check this file", group: "Review" },
+  { command: "check-and-advance", keys: ["X"], label: "⇧X", description: "Check it and go to the next unchecked file", group: "Review" },
+  { command: "capture-note", keys: ["n"], label: "n", description: "Capture a note", group: "Review" },
+  { command: "toggle-notes", keys: ["N"], label: "⇧N", description: "Show or hide the notes", group: "Review" },
+
+  { command: "next-change", keys: ["]"], label: "]", description: "Next change in this file", group: "Read" },
+  { command: "previous-change", keys: ["["], label: "[", description: "Previous change in this file", group: "Read" },
+  { command: "delta-view", keys: ["d"], label: "d", description: "Changes since your review", group: "Read" },
+
+  { command: "toggle-tree", keys: ["b"], label: "⌘B", description: "Show or hide the file tree", group: "Panels", meta: true },
+  { command: "help", keys: ["?"], label: "?", description: "This list", group: "Panels" },
+];
+
+export const GROUPS: Binding["group"][] = ["Move", "Review", "Read", "Panels"];
+
+export function bindingFor(event: KeyboardEvent): Binding | null {
+  const held = event.metaKey || event.ctrlKey;
+  return BINDINGS.find((binding) => {
+    if ((binding.meta === true) !== held) return false;
+    if (event.altKey) return false;
+    return binding.keys.includes(event.key);
+  }) ?? null;
+}

--- a/packages/app/src/renderer/src/keymap.ts
+++ b/packages/app/src/renderer/src/keymap.ts
@@ -10,8 +10,7 @@ export type Command =
   | "previous-file"
   | "first-file"
   | "last-file"
-  | "collapse"
-  | "expand"
+  | "toggle-directory"
   | "dismiss"
   | "toggle-checked"
   | "mark-and-advance"
@@ -41,8 +40,7 @@ export const BINDINGS: Binding[] = [
   { command: "previous-file", keys: ["k", "ArrowUp"], label: "k / ↑", description: "Previous row", group: "Move" },
   { command: "first-file", keys: ["Home"], label: "Home", description: "First row", group: "Move" },
   { command: "last-file", keys: ["End"], label: "End", description: "Last row", group: "Move" },
-  { command: "collapse", keys: ["h", "ArrowLeft"], label: "h / ←", description: "Close the directory, or step out to it", group: "Move" },
-  { command: "expand", keys: ["l", "ArrowRight", "o"], label: "l / → / o", description: "Open the directory", group: "Move" },
+  { command: "toggle-directory", keys: ["o"], label: "o", description: "Open or close the directory", group: "Move" },
   { command: "dismiss", keys: ["Escape"], label: "Esc", description: "Close what is open on top", group: "Move" },
 
   { command: "toggle-checked", keys: ["m", " "], label: "m / Space", description: "Mark or unmark this file, or the whole directory", group: "Review" },

--- a/packages/app/src/renderer/src/keymap.ts
+++ b/packages/app/src/renderer/src/keymap.ts
@@ -12,8 +12,7 @@ export type Command =
   | "last-file"
   | "collapse"
   | "expand"
-  | "focus-tree"
-  | "focus-diff"
+  | "dismiss"
   | "toggle-checked"
   | "mark-and-advance"
   | "mark-and-retreat"
@@ -35,23 +34,20 @@ export interface Binding {
   group: "Move" | "Review" | "Read" | "Panels";
   /** Held with Command on macOS, Control elsewhere. */
   meta?: true;
-  /** Acts only while the file tree holds focus, because it changes the tree's shape. */
-  treeOnly?: true;
 }
 
 export const BINDINGS: Binding[] = [
-  { command: "next-file", keys: ["j", "ArrowDown"], label: "j / ↓", description: "Next file", group: "Move" },
-  { command: "previous-file", keys: ["k", "ArrowUp"], label: "k / ↑", description: "Previous file", group: "Move" },
-  { command: "first-file", keys: ["Home"], label: "Home", description: "First file", group: "Move" },
-  { command: "last-file", keys: ["End"], label: "End", description: "Last file", group: "Move" },
-  { command: "collapse", keys: ["h", "ArrowLeft"], label: "h / ←", description: "Collapse the directory", group: "Move", treeOnly: true },
-  { command: "expand", keys: ["l", "ArrowRight"], label: "l / →", description: "Expand the directory", group: "Move", treeOnly: true },
-  { command: "focus-tree", keys: ["Tab"], label: "Tab", description: "Focus the file tree", group: "Move" },
-  { command: "focus-diff", keys: ["Escape"], label: "Esc", description: "Return to the diff", group: "Move" },
+  { command: "next-file", keys: ["j", "ArrowDown"], label: "j / ↓", description: "Next row", group: "Move" },
+  { command: "previous-file", keys: ["k", "ArrowUp"], label: "k / ↑", description: "Previous row", group: "Move" },
+  { command: "first-file", keys: ["Home"], label: "Home", description: "First row", group: "Move" },
+  { command: "last-file", keys: ["End"], label: "End", description: "Last row", group: "Move" },
+  { command: "collapse", keys: ["h", "ArrowLeft"], label: "h / ←", description: "Close the directory, or step out to it", group: "Move" },
+  { command: "expand", keys: ["l", "ArrowRight", "o"], label: "l / → / o", description: "Open the directory", group: "Move" },
+  { command: "dismiss", keys: ["Escape"], label: "Esc", description: "Close what is open on top", group: "Move" },
 
-  { command: "toggle-checked", keys: ["m", " "], label: "m / Space", description: "Mark or unmark this file", group: "Review" },
-  { command: "mark-and-advance", keys: ["J"], label: "⇧J", description: "Mark it and go to the next unmarked file", group: "Review" },
-  { command: "mark-and-retreat", keys: ["K"], label: "⇧K", description: "Mark it and go to the previous unmarked file", group: "Review" },
+  { command: "toggle-checked", keys: ["m", " "], label: "m / Space", description: "Mark or unmark this file, or the whole directory", group: "Review" },
+  { command: "mark-and-advance", keys: ["J"], label: "⇧J", description: "Mark it and go to the next unmarked row", group: "Review" },
+  { command: "mark-and-retreat", keys: ["K"], label: "⇧K", description: "Mark it and go to the previous unmarked row", group: "Review" },
   { command: "capture-note", keys: ["n"], label: "n", description: "Capture a note", group: "Review" },
   { command: "toggle-notes", keys: ["N"], label: "⇧N", description: "Show or hide the notes", group: "Review" },
 

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -83,6 +83,58 @@ describe("store", () => {
     expect(store.selectedPath).toBe("a.rb");
   });
 
+  // Switching repositories clears the loaded view, which bumps the generation counter.
+  // A generation read before that ran looked superseded by this call's own work, so the
+  // repository opened and the pull request silently did not.
+  it("opens the pull request even when another repository was already loaded", async () => {
+    const store = createStore(fakeApi({
+      listRepos: async () => [
+        { repoId: "acme/atlas", url: "u", localPath: "/tmp/atlas" },
+        { repoId: "acme/beacon", url: "u2", localPath: "/tmp/beacon" },
+      ],
+    }));
+    await store.loadRepos();
+    await store.openTarget({ repoId: "acme/beacon", prNumber: 1 });
+    expect(store.currentRepoId).toBe("acme/beacon");
+
+    await store.openTarget({ repoId: "acme/atlas", prNumber: 1 });
+
+    expect(store.currentRepoId).toBe("acme/atlas");
+    expect(store.view).not.toBeNull();
+  });
+
+  // The 30-second poll can be mid-flight when the reviewer opens a pull request, which
+  // closes the worktree in the main process. Its refusal reached the reviewer as an error
+  // naming a worktree they had already left.
+  it("discards a local refresh the reviewer has already moved on from", async () => {
+    let release: (() => void) | null = null;
+    const store = createStore(fakeApi({
+      listRepos: async () => [
+        { repoId: "acme/atlas", url: "u", localPath: "/tmp/atlas" },
+        { repoId: "acme/beacon", url: "u2", localPath: "/tmp/beacon" },
+      ],
+      listWorktrees: async () => [{ path: "/tmp/beacon", branch: "main", head: "b", isPrimary: true, prNumber: null }],
+      openLocal: async () => ({
+        worktree: { path: "/tmp/beacon", branch: "main", head: "b", isPrimary: true, prNumber: null },
+        files: [], baseRef: "main",
+      }),
+      refreshLocal: async () => new Promise((_resolve, reject) => {
+        release = () => reject(new Error("/tmp/beacon is not the open local worktree"));
+      }),
+    }));
+    await store.loadRepos();
+    await store.selectRepo("acme/beacon");
+    await store.openLocal("/tmp/beacon");
+
+    const refreshing = store.refresh();
+    await store.openTarget({ repoId: "acme/atlas", prNumber: 1 });
+    release?.();
+    await refreshing;
+
+    expect(store.error).toBeNull();
+    expect(store.currentRepoId).toBe("acme/atlas");
+  });
+
   it("opens a target naming only a repository", async () => {
     const store = createStore(fakeApi());
     await store.loadRepos();

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -107,18 +107,17 @@ describe("store", () => {
   // closes the worktree in the main process. Its refusal reached the reviewer as an error
   // naming a worktree they had already left.
   it("discards a local refresh the reviewer has already moved on from", async () => {
-    let release: (() => void) | null = null;
+    let release: () => void = () => {};
+    const worktree = { path: "/tmp/beacon", headSha: "b", branch: "main", locked: false };
+    const localView: LocalView = { worktree, defaultBranch: "main", mergeBaseSha: "a", files: [] };
     const store = createStore(fakeApi({
       listRepos: async () => [
         { repoId: "acme/atlas", url: "u", localPath: "/tmp/atlas" },
         { repoId: "acme/beacon", url: "u2", localPath: "/tmp/beacon" },
       ],
-      listWorktrees: async () => [{ path: "/tmp/beacon", branch: "main", head: "b", isPrimary: true, prNumber: null }],
-      openLocal: async () => ({
-        worktree: { path: "/tmp/beacon", branch: "main", head: "b", isPrimary: true, prNumber: null },
-        files: [], baseRef: "main",
-      }),
-      refreshLocal: async () => new Promise((_resolve, reject) => {
+      listWorktrees: async () => [worktree],
+      openLocal: async () => localView,
+      refreshLocal: async () => new Promise<LocalView>((_resolve, reject) => {
         release = () => reject(new Error("/tmp/beacon is not the open local worktree"));
       }),
     }));
@@ -128,7 +127,7 @@ describe("store", () => {
 
     const refreshing = store.refresh();
     await store.openTarget({ repoId: "acme/atlas", prNumber: 1 });
-    release?.();
+    release();
     await refreshing;
 
     expect(store.error).toBeNull();

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -101,6 +101,23 @@ describe("store", () => {
     expect(store.error).toBe("acme/new is not registered. Open one of its checkout folders first.");
   });
 
+  // bin/gander registers a repository in the main process as it opens one, which happens
+  // after the renderer last read the list. Without the re-read, the first open of a
+  // checkout the app has not seen always failed.
+  it("re-reads the repository list before refusing a target", async () => {
+    let registered = false;
+    const store = createStore(fakeApi({
+      listRepos: async () => (registered ? [{ repoId: "acme/atlas", url: "u", localPath: "/p" }] : []),
+    }));
+    await store.loadRepos();
+    registered = true;
+
+    await store.openTarget({ repoId: "acme/atlas", prNumber: null });
+
+    expect(store.error).toBeNull();
+    expect(store.targetRepoId).toBe("acme/atlas");
+  });
+
   it("loads repos, selects one, opens a PR, tracks progress", async () => {
     const store = createStore(fakeApi());
     await store.loadRepos();

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -173,7 +173,6 @@ export function createStore(api: GanderApi): Store {
     },
     async openTarget(target: OpenTarget) {
       await userAction(() => withBusy(() => guard(async () => {
-        const generation = target.prNumber === null ? null : ++localContextGeneration;
         // bin/gander can register a repository as it opens one, which happens in the main
         // process after this list was last read. Re-read before refusing, or the first
         // open of a checkout the app has not seen always fails.
@@ -185,8 +184,11 @@ export function createStore(api: GanderApi): Store {
         // those would clear the busy flag halfway through this one.
         await activateRepo(target.repoId);
         if (target.prNumber === null) return;
-        if (generation !== localContextGeneration) return;
-        await applyOpenedPr(target.repoId, target.prNumber, generation);
+        // Taken after activateRepo, not before: switching repositories clears the loaded
+        // view, which bumps the counter, and a generation read earlier would then look
+        // superseded by this call's own work — leaving the repository open and the pull
+        // request never opened.
+        await applyOpenedPr(target.repoId, target.prNumber, ++localContextGeneration);
       })));
     },
     async selectRepo(repoId: string) {
@@ -252,7 +254,21 @@ export function createStore(api: GanderApi): Store {
     async refresh() {
       await withBusy(() => guard(async () => {
         if (store.localView) {
-          applyLocalView(await api.refreshLocal(store.localView.worktree.path));
+          const worktreePath = store.localView.worktree.path;
+          const generation = localContextGeneration;
+          // The poll can still be in flight when the reviewer opens something else, which
+          // closes this worktree in the main process. Its refusal then means this request
+          // was superseded, not that anything failed, so it must not reach the reviewer as
+          // an error about a worktree they have already left.
+          let refreshed;
+          try {
+            refreshed = await api.refreshLocal(worktreePath);
+          } catch (err) {
+            if (superseded(generation, worktreePath)) return;
+            throw err;
+          }
+          if (superseded(generation, worktreePath)) return;
+          applyLocalView(refreshed);
           await refreshExplorer();
         } else if (store.currentRepoId && store.view) {
           store.view = await api.refreshPr(store.currentRepoId, store.view.pr.number);
@@ -355,6 +371,11 @@ export function createStore(api: GanderApi): Store {
       store.error = (err as Error).message;
       store.localFile = null;
     }
+  }
+
+  /** True once the reviewer has moved on from the worktree a request was made for. */
+  function superseded(generation: number, worktreePath: string): boolean {
+    return generation !== localContextGeneration || store.localView?.worktree.path !== worktreePath;
   }
 
   async function refreshExplorer(): Promise<void> {

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -174,6 +174,10 @@ export function createStore(api: GanderApi): Store {
     async openTarget(target: OpenTarget) {
       await userAction(() => withBusy(() => guard(async () => {
         const generation = target.prNumber === null ? null : ++localContextGeneration;
+        // bin/gander can register a repository as it opens one, which happens in the main
+        // process after this list was last read. Re-read before refusing, or the first
+        // open of a checkout the app has not seen always fails.
+        if (!store.repos.some((r) => r.repoId === target.repoId)) store.repos = await api.listRepos();
         if (!store.repos.some((r) => r.repoId === target.repoId)) {
           throw new Error(`${target.repoId} is not registered. Open one of its checkout folders first.`);
         }

--- a/packages/app/src/renderer/src/styles/tree.css
+++ b/packages/app/src/renderer/src/styles/tree.css
@@ -11,7 +11,11 @@
 
 .tnode:hover { background: var(--hover-background); }
 .tnode:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.tnode.sel { background: var(--selection-background); box-shadow: inset 2px 0 0 var(--accent); }
+/* Two different things: `cur` is where the keyboard is, `sel` is the file in the diff.
+   They part company only while the cursor rests on a directory, so the bar marks the
+   cursor alone and the open file keeps the background — one row, one bar. */
+.tnode.sel { background: var(--selection-background); }
+.tnode.cur { box-shadow: inset 2px 0 0 var(--accent); }
 .tnode .hierarchy-slot { width: 14px; flex: none; }
 .tnode .chev { color: var(--faint-foreground); }
 .tnode .fname { overflow: hidden; text-overflow: ellipsis; }

--- a/packages/app/src/renderer/src/tree-nav.test.ts
+++ b/packages/app/src/renderer/src/tree-nav.test.ts
@@ -65,6 +65,11 @@ describe("tree navigation", () => {
     expect(nextUnchecked(files, "README.md")).toBe("src/deep/inner.ts");
   });
 
+  it("searches backwards too, so marking can walk a review in reverse", () => {
+    expect(nextUnchecked(files, "README.md", -1)).toBe("vendor/bundle.js");
+    expect(nextUnchecked(files, "src/deep/inner.ts", -1)).toBe("README.md");
+  });
+
   it("has no next unchecked file once everything is checked", () => {
     expect(nextUnchecked(files.map((f) => file(f.path, true)), "src/app.ts")).toBeNull();
   });

--- a/packages/app/src/renderer/src/tree-nav.test.ts
+++ b/packages/app/src/renderer/src/tree-nav.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ChangedFile, PrFile } from "@gander/shared";
 import {
-  collapsedDirectoryAfter,
   collapsedDirs,
-  directoryOf,
   edge,
-  nextUnchecked,
+  filesAt,
+  nextUnmarked,
+  parentOf,
+  pathOf,
+  rows,
   step,
   visibleFiles,
 } from "./tree-nav.js";
@@ -25,52 +27,55 @@ const paths = (list: ChangedFile[]): string[] => list.map((f) => f.path);
 beforeEach(() => collapsedDirs.clear());
 
 describe("tree navigation", () => {
-  it("walks files in the order the tree draws them", () => {
-    // Directories are drawn before the files beside them, so src/deep precedes src/app.ts.
-    expect(paths(visibleFiles(files))).toEqual([
-      "src/deep/inner.ts", "src/app.ts", "vendor/bundle.js", "README.md",
+  // The cursor stops on directories as well as files, the way an explorer list does —
+  // otherwise there is no way to reach a directory to open or close it.
+  it("walks every row the tree draws, directories included", () => {
+    expect(rows(files).map(pathOf)).toEqual([
+      "src", "src/deep", "src/deep/inner.ts", "src/app.ts", "vendor", "vendor/bundle.js", "README.md",
     ]);
   });
 
-  // Collapsing is how a reviewer sets noise aside. If the cursor stepped into a collapsed
-  // directory anyway, collapsing would be decoration rather than a review gesture.
-  it("steps past a collapsed directory instead of into it", () => {
+  it("leaves the contents of a collapsed directory out, but keeps its row", () => {
     collapsedDirs.add("vendor");
-    expect(step(files, "src/app.ts", 1)).toBe("README.md");
+    expect(rows(files).map(pathOf)).toEqual([
+      "src", "src/deep", "src/deep/inner.ts", "src/app.ts", "vendor", "README.md",
+    ]);
+    expect(paths(visibleFiles(files))).toEqual(["src/deep/inner.ts", "src/app.ts", "README.md"]);
   });
 
   it("stops at the ends rather than wrapping", () => {
     expect(step(files, "README.md", 1)).toBeNull();
-    expect(step(files, "src/deep/inner.ts", -1)).toBeNull();
+    expect(step(files, "src", -1)).toBeNull();
   });
 
-  it("finds the first and last visible file", () => {
-    expect(edge(files, "first")).toBe("src/deep/inner.ts");
+  it("finds the first and last row", () => {
+    expect(edge(files, "first")).toBe("src");
     expect(edge(files, "last")).toBe("README.md");
   });
 
-  it("names the directory a file sits in, and null at the root", () => {
-    expect(directoryOf(files, "src/deep/inner.ts")).toBe("src/deep");
-    expect(directoryOf(files, "README.md")).toBeNull();
+  it("names the directory a row sits in, and null at the top level", () => {
+    expect(parentOf(files, "src/deep/inner.ts")).toBe("src/deep");
+    expect(parentOf(files, "src")).toBeNull();
   });
 
-  // `l` has to undo the `h` that just collapsed a directory and stepped the cursor above it.
-  it("offers the first collapsed directory at or after the cursor to expand", () => {
-    collapsedDirs.add("vendor");
-    expect(collapsedDirectoryAfter(files, "src/app.ts")).toBe("vendor");
+  // Marking a directory has to cover what it holds even when it is folded away: folding is
+  // about reading, not about scope.
+  it("collects every file under a directory, collapsed or not", () => {
+    collapsedDirs.add("src");
+    expect(paths(filesAt(files, "src"))).toEqual(["src/deep/inner.ts", "src/app.ts"]);
+    expect(paths(filesAt(files, "README.md"))).toEqual(["README.md"]);
   });
 
-  it("skips checked files when advancing, and wraps once", () => {
-    expect(nextUnchecked(files, "src/app.ts")).toBe("vendor/bundle.js");
-    expect(nextUnchecked(files, "README.md")).toBe("src/deep/inner.ts");
+  it("advances to a row holding unmarked work, and wraps once", () => {
+    expect(nextUnmarked(files, "src/app.ts")).toBe("vendor");
+    expect(nextUnmarked(files, "README.md")).toBe("src");
   });
 
-  it("searches backwards too, so marking can walk a review in reverse", () => {
-    expect(nextUnchecked(files, "README.md", -1)).toBe("vendor/bundle.js");
-    expect(nextUnchecked(files, "src/deep/inner.ts", -1)).toBe("README.md");
+  it("searches backwards too", () => {
+    expect(nextUnmarked(files, "README.md", -1)).toBe("vendor/bundle.js");
   });
 
-  it("has no next unchecked file once everything is checked", () => {
-    expect(nextUnchecked(files.map((f) => file(f.path, true)), "src/app.ts")).toBeNull();
+  it("has nothing left to advance to once everything is marked", () => {
+    expect(nextUnmarked(files.map((f) => file(f.path, true)), "src/app.ts")).toBeNull();
   });
 });

--- a/packages/app/src/renderer/src/tree-nav.test.ts
+++ b/packages/app/src/renderer/src/tree-nav.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ChangedFile, PrFile } from "@gander/shared";
+import {
+  collapsedDirectoryAfter,
+  collapsedDirs,
+  directoryOf,
+  edge,
+  nextUnchecked,
+  step,
+  visibleFiles,
+} from "./tree-nav.js";
+
+const file = (path: string, checked = false): PrFile =>
+  ({ path, status: "M", baseContent: "", headContent: "", baseHash: "b", headHash: "h", checked, changedSince: false });
+
+const files = [
+  file("README.md"),
+  file("src/app.ts", true),
+  file("src/deep/inner.ts"),
+  file("vendor/bundle.js"),
+];
+
+const paths = (list: ChangedFile[]): string[] => list.map((f) => f.path);
+
+beforeEach(() => collapsedDirs.clear());
+
+describe("tree navigation", () => {
+  it("walks files in the order the tree draws them", () => {
+    // Directories are drawn before the files beside them, so src/deep precedes src/app.ts.
+    expect(paths(visibleFiles(files))).toEqual([
+      "src/deep/inner.ts", "src/app.ts", "vendor/bundle.js", "README.md",
+    ]);
+  });
+
+  // Collapsing is how a reviewer sets noise aside. If the cursor stepped into a collapsed
+  // directory anyway, collapsing would be decoration rather than a review gesture.
+  it("steps past a collapsed directory instead of into it", () => {
+    collapsedDirs.add("vendor");
+    expect(step(files, "src/app.ts", 1)).toBe("README.md");
+  });
+
+  it("stops at the ends rather than wrapping", () => {
+    expect(step(files, "README.md", 1)).toBeNull();
+    expect(step(files, "src/deep/inner.ts", -1)).toBeNull();
+  });
+
+  it("finds the first and last visible file", () => {
+    expect(edge(files, "first")).toBe("src/deep/inner.ts");
+    expect(edge(files, "last")).toBe("README.md");
+  });
+
+  it("names the directory a file sits in, and null at the root", () => {
+    expect(directoryOf(files, "src/deep/inner.ts")).toBe("src/deep");
+    expect(directoryOf(files, "README.md")).toBeNull();
+  });
+
+  // `l` has to undo the `h` that just collapsed a directory and stepped the cursor above it.
+  it("offers the first collapsed directory at or after the cursor to expand", () => {
+    collapsedDirs.add("vendor");
+    expect(collapsedDirectoryAfter(files, "src/app.ts")).toBe("vendor");
+  });
+
+  it("skips checked files when advancing, and wraps once", () => {
+    expect(nextUnchecked(files, "src/app.ts")).toBe("vendor/bundle.js");
+    expect(nextUnchecked(files, "README.md")).toBe("src/deep/inner.ts");
+  });
+
+  it("has no next unchecked file once everything is checked", () => {
+    expect(nextUnchecked(files.map((f) => file(f.path, true)), "src/app.ts")).toBeNull();
+  });
+});

--- a/packages/app/src/renderer/src/tree-nav.ts
+++ b/packages/app/src/renderer/src/tree-nav.ts
@@ -86,12 +86,13 @@ export function edge(files: ChangedFile[], which: "first" | "last"): string | nu
 }
 
 /**
- * The next unchecked file after `from`. Collapsed directories stay out of it for the same
- * reason the cursor skips them — they are the noise the reviewer set aside. Wraps once, so
- * a pass that started in the middle still reaches the files above where it began.
+ * The nearest unmarked file in `delta`'s direction. Collapsed directories stay out of it
+ * for the same reason the cursor skips them — they are the noise the reviewer set aside.
+ * Wraps once, so a pass that started in the middle still reaches the files it skipped past;
+ * that backward jump is the point, since it shows the hole the reviewer left.
  */
-export function nextUnchecked(files: ChangedFile[], from: string | null): string | null {
-  const ordered = visibleFiles(files);
+export function nextUnchecked(files: ChangedFile[], from: string | null, delta: 1 | -1 = 1): string | null {
+  const ordered = delta === 1 ? visibleFiles(files) : [...visibleFiles(files)].reverse();
   const start = ordered.findIndex((file) => file.path === from);
   const rotated = start === -1 ? ordered : [...ordered.slice(start + 1), ...ordered.slice(0, start + 1)];
   return rotated.find((file) => "checked" in file && !file.checked)?.path ?? null;

--- a/packages/app/src/renderer/src/tree-nav.ts
+++ b/packages/app/src/renderer/src/tree-nav.ts
@@ -1,31 +1,31 @@
-import { reactive } from "vue";
+import { reactive, ref } from "vue";
 import type { ChangedFile } from "@gander/shared";
 import { buildTree, type TreeNode } from "./tree.js";
 
 /**
- * Which directories are collapsed, and whether the keyboard is in the tree.
+ * Where the keyboard is in the file tree, and which directories are collapsed.
  *
- * FileTree renders itself recursively, so collapse state held inside the component
- * would live in as many Sets as there are levels. Keyboard navigation needs one answer
- * to "what is visible", so the set lives here and every level reads it. Directory paths
- * are full paths, so one flat set is unambiguous.
+ * FileTree renders itself recursively, so collapse state held inside the component would
+ * live in as many Sets as there are levels. Keyboard movement needs one answer to what is
+ * visible, so the set lives here and every level reads it. Directory paths are full paths,
+ * so one flat set is unambiguous.
  */
 export const collapsedDirs = reactive(new Set<string>());
 
 /**
- * True while the file tree holds focus. Collapsing is a structural change, so it stays
- * deliberate: it acts only when the reviewer is in the tree, never while they are reading
- * a diff, where a directory folding away would hide the row they are on.
+ * The row the keyboard is on, which is a directory as often as a file. It is separate from
+ * the reviewer's selected file because a directory has nothing to show in the diff: passing
+ * over one leaves the reader looking at the file they were already reading.
  */
-export const treeFocus = reactive({ active: false });
+export const cursor = ref<string | null>(null);
 
 export function toggleCollapsed(path: string): void {
   if (collapsedDirs.has(path)) collapsedDirs.delete(path);
   else collapsedDirs.add(path);
 }
 
-/** Every row the tree draws, in order, with directories inside a collapsed one left out. */
-function rows(files: ChangedFile[]): TreeNode[] {
+/** Every row the tree draws, in order, with the contents of a collapsed directory left out. */
+export function rows(files: ChangedFile[]): TreeNode[] {
   const walk = (nodes: TreeNode[]): TreeNode[] =>
     nodes.flatMap((node) => {
       if (node.type === "file") return [node];
@@ -34,66 +34,76 @@ function rows(files: ChangedFile[]): TreeNode[] {
   return walk(buildTree(files));
 }
 
-/**
- * Files in the order the tree draws them, skipping anything inside a collapsed directory.
- * Collapsing is how a reviewer sets noise aside, so the cursor walks past a collapsed
- * directory rather than expanding it — what moves is what can be seen.
- */
+export function pathOf(node: TreeNode): string {
+  return node.type === "dir" ? node.path : node.file.path;
+}
+
+export function rowAt(files: ChangedFile[], path: string | null): TreeNode | null {
+  if (path === null) return null;
+  return rows(files).find((node) => pathOf(node) === path) ?? null;
+}
+
+/** Files in draw order, skipping anything inside a collapsed directory. */
 export function visibleFiles(files: ChangedFile[]): ChangedFile[] {
   return rows(files).flatMap((node) => (node.type === "file" ? [node.file] : []));
 }
 
-/** The directory row that owns `path`, or null when the file sits at the root. */
-export function directoryOf(files: ChangedFile[], path: string): string | null {
+/** The directory row that owns `path`, or null when the row sits at the top level. */
+export function parentOf(files: ChangedFile[], path: string): string | null {
   let found: string | null = null;
   const walk = (nodes: TreeNode[], parent: string | null): void => {
     for (const node of nodes) {
-      if (node.type === "file") {
-        if (node.file.path === path) found = parent;
-      } else if (!collapsedDirs.has(node.path)) {
-        walk(node.children, node.path);
-      }
+      if (pathOf(node) === path) { found = parent; return; }
+      if (node.type === "dir" && !collapsedDirs.has(node.path)) walk(node.children, node.path);
     }
   };
   walk(buildTree(files), null);
   return found;
 }
 
-/**
- * The first collapsed directory drawn at or after `path` — what `l` expands, so that it
- * undoes the `h` that collapsed the directory the cursor just stepped out of.
- */
-export function collapsedDirectoryAfter(files: ChangedFile[], path: string | null): string | null {
-  const drawn = rows(files);
-  const from = path === null ? 0 : drawn.findIndex((n) => n.type === "file" && n.file.path === path);
-  const search = from === -1 ? drawn : drawn.slice(from);
-  const hit = search.find((node) => node.type === "dir" && collapsedDirs.has(node.path));
-  return hit?.type === "dir" ? hit.path : null;
-}
-
-/** Stops at the ends rather than wrapping: the last file should read as "that is all of them". */
+/** Stops at the ends rather than wrapping: the last row should read as "that is all of them". */
 export function step(files: ChangedFile[], from: string | null, delta: 1 | -1): string | null {
-  const visible = visibleFiles(files);
-  if (visible.length === 0) return null;
-  const index = visible.findIndex((file) => file.path === from);
-  if (index === -1) return (delta === 1 ? visible[0] : visible[visible.length - 1])?.path ?? null;
-  return visible[index + delta]?.path ?? null;
+  const drawn = rows(files);
+  if (drawn.length === 0) return null;
+  const index = drawn.findIndex((node) => pathOf(node) === from);
+  if (index === -1) {
+    const fallback = delta === 1 ? drawn[0] : drawn[drawn.length - 1];
+    return fallback === undefined ? null : pathOf(fallback);
+  }
+  const next = drawn[index + delta];
+  return next === undefined ? null : pathOf(next);
 }
 
 export function edge(files: ChangedFile[], which: "first" | "last"): string | null {
-  const visible = visibleFiles(files);
-  return (which === "first" ? visible[0] : visible[visible.length - 1])?.path ?? null;
+  const drawn = rows(files);
+  const node = which === "first" ? drawn[0] : drawn[drawn.length - 1];
+  return node === undefined ? null : pathOf(node);
+}
+
+/** Every file beneath a row: the row itself when it is a file, the whole subtree when not. */
+export function filesAt(files: ChangedFile[], path: string | null): ChangedFile[] {
+  const node = rowAt(files, path);
+  if (node === null) return [];
+  if (node.type === "file") return [node.file];
+  // Reads the built tree rather than the drawn rows, so marking a collapsed directory still
+  // covers what it contains — folding it away is about reading, not about scope.
+  const collect = (n: TreeNode): ChangedFile[] =>
+    n.type === "file" ? [n.file] : n.children.flatMap(collect);
+  return collect(node);
 }
 
 /**
- * The nearest unmarked file in `delta`'s direction. Collapsed directories stay out of it
- * for the same reason the cursor skips them — they are the noise the reviewer set aside.
- * Wraps once, so a pass that started in the middle still reaches the files it skipped past;
- * that backward jump is the point, since it shows the hole the reviewer left.
+ * The nearest row in `delta`'s direction holding unmarked work. Wraps once, so a pass that
+ * started in the middle still reaches what it skipped past; that backward jump is the
+ * point, since it shows the hole the reviewer left.
  */
-export function nextUnchecked(files: ChangedFile[], from: string | null, delta: 1 | -1 = 1): string | null {
-  const ordered = delta === 1 ? visibleFiles(files) : [...visibleFiles(files)].reverse();
-  const start = ordered.findIndex((file) => file.path === from);
-  const rotated = start === -1 ? ordered : [...ordered.slice(start + 1), ...ordered.slice(0, start + 1)];
-  return rotated.find((file) => "checked" in file && !file.checked)?.path ?? null;
+export function nextUnmarked(files: ChangedFile[], from: string | null, delta: 1 | -1 = 1): string | null {
+  const drawn = delta === 1 ? rows(files) : [...rows(files)].reverse();
+  const start = drawn.findIndex((node) => pathOf(node) === from);
+  const rotated = start === -1 ? drawn : [...drawn.slice(start + 1), ...drawn.slice(0, start + 1)];
+  const hit = rotated.find((node) => {
+    const under = filesAt(files, pathOf(node));
+    return under.some((file) => "checked" in file && !file.checked);
+  });
+  return hit === undefined ? null : pathOf(hit);
 }

--- a/packages/app/src/renderer/src/tree-nav.ts
+++ b/packages/app/src/renderer/src/tree-nav.ts
@@ -1,0 +1,98 @@
+import { reactive } from "vue";
+import type { ChangedFile } from "@gander/shared";
+import { buildTree, type TreeNode } from "./tree.js";
+
+/**
+ * Which directories are collapsed, and whether the keyboard is in the tree.
+ *
+ * FileTree renders itself recursively, so collapse state held inside the component
+ * would live in as many Sets as there are levels. Keyboard navigation needs one answer
+ * to "what is visible", so the set lives here and every level reads it. Directory paths
+ * are full paths, so one flat set is unambiguous.
+ */
+export const collapsedDirs = reactive(new Set<string>());
+
+/**
+ * True while the file tree holds focus. Collapsing is a structural change, so it stays
+ * deliberate: it acts only when the reviewer is in the tree, never while they are reading
+ * a diff, where a directory folding away would hide the row they are on.
+ */
+export const treeFocus = reactive({ active: false });
+
+export function toggleCollapsed(path: string): void {
+  if (collapsedDirs.has(path)) collapsedDirs.delete(path);
+  else collapsedDirs.add(path);
+}
+
+/** Every row the tree draws, in order, with directories inside a collapsed one left out. */
+function rows(files: ChangedFile[]): TreeNode[] {
+  const walk = (nodes: TreeNode[]): TreeNode[] =>
+    nodes.flatMap((node) => {
+      if (node.type === "file") return [node];
+      return collapsedDirs.has(node.path) ? [node] : [node, ...walk(node.children)];
+    });
+  return walk(buildTree(files));
+}
+
+/**
+ * Files in the order the tree draws them, skipping anything inside a collapsed directory.
+ * Collapsing is how a reviewer sets noise aside, so the cursor walks past a collapsed
+ * directory rather than expanding it — what moves is what can be seen.
+ */
+export function visibleFiles(files: ChangedFile[]): ChangedFile[] {
+  return rows(files).flatMap((node) => (node.type === "file" ? [node.file] : []));
+}
+
+/** The directory row that owns `path`, or null when the file sits at the root. */
+export function directoryOf(files: ChangedFile[], path: string): string | null {
+  let found: string | null = null;
+  const walk = (nodes: TreeNode[], parent: string | null): void => {
+    for (const node of nodes) {
+      if (node.type === "file") {
+        if (node.file.path === path) found = parent;
+      } else if (!collapsedDirs.has(node.path)) {
+        walk(node.children, node.path);
+      }
+    }
+  };
+  walk(buildTree(files), null);
+  return found;
+}
+
+/**
+ * The first collapsed directory drawn at or after `path` — what `l` expands, so that it
+ * undoes the `h` that collapsed the directory the cursor just stepped out of.
+ */
+export function collapsedDirectoryAfter(files: ChangedFile[], path: string | null): string | null {
+  const drawn = rows(files);
+  const from = path === null ? 0 : drawn.findIndex((n) => n.type === "file" && n.file.path === path);
+  const search = from === -1 ? drawn : drawn.slice(from);
+  const hit = search.find((node) => node.type === "dir" && collapsedDirs.has(node.path));
+  return hit?.type === "dir" ? hit.path : null;
+}
+
+/** Stops at the ends rather than wrapping: the last file should read as "that is all of them". */
+export function step(files: ChangedFile[], from: string | null, delta: 1 | -1): string | null {
+  const visible = visibleFiles(files);
+  if (visible.length === 0) return null;
+  const index = visible.findIndex((file) => file.path === from);
+  if (index === -1) return (delta === 1 ? visible[0] : visible[visible.length - 1])?.path ?? null;
+  return visible[index + delta]?.path ?? null;
+}
+
+export function edge(files: ChangedFile[], which: "first" | "last"): string | null {
+  const visible = visibleFiles(files);
+  return (which === "first" ? visible[0] : visible[visible.length - 1])?.path ?? null;
+}
+
+/**
+ * The next unchecked file after `from`. Collapsed directories stay out of it for the same
+ * reason the cursor skips them — they are the noise the reviewer set aside. Wraps once, so
+ * a pass that started in the middle still reaches the files above where it began.
+ */
+export function nextUnchecked(files: ChangedFile[], from: string | null): string | null {
+  const ordered = visibleFiles(files);
+  const start = ordered.findIndex((file) => file.path === from);
+  const rotated = start === -1 ? ordered : [...ordered.slice(start + 1), ...ordered.slice(0, start + 1)];
+  return rotated.find((file) => "checked" in file && !file.checked)?.path ?? null;
+}


### PR DESCRIPTION
Fills in the keyboard review pass: `j`/`k` and the arrows walk files, `x` or Space checks one, `Shift+X` checks it and jumps to the next unchecked file, `[`/`]` step through changes within a diff, `d` opens the delta tab, `Shift+N` toggles the notes, and `?` prints the sheet.

## Decisions

**Selection is the app's cursor.** Nothing in the app is editable, so there is no text cursor competing for the keys and no reason a keypress should mean different things depending on where the last click landed. Movement works from anywhere, including mid-scroll in a diff.

**Collapse is a review gesture.** A collapsed directory is the noise the reviewer set aside, so the cursor walks past it rather than expanding it — otherwise collapsing would be decoration. The trade is that files inside a collapsed directory are not reached by `j`/`k` or by `Shift+X`; the progress count still includes them.

**`h`/`l` need tree focus.** They change the tree's shape. Folding a directory while the reviewer reads a file inside it would hide the row they are on, so the tree has to be focused first — `Tab` in, `Esc` back.

**Movement stops at the ends** rather than wrapping, matching VS Code's explorer.

## Shape

`keymap.ts` is the single table. The handler dispatches on it and the `?` sheet renders from it, so a binding cannot be added without the help learning about it, and the help cannot claim a key that does nothing.

`tree-nav.ts` takes collapse state and the visible-file order out of `FileTree.vue`. That component renders itself recursively, so collapse state inside it lived in as many Sets as there were levels; keyboard movement needs one answer to what is visible.

`DiffPane` exposes the two things only it can do — the delta tab and Monaco's change-to-change navigation.

## Tests

`tree-nav.test.ts` covers draw order, stepping past a collapsed directory, stopping at the ends, and the next-unchecked search. `keymap.test.ts` covers modifier matching, shifted keys, and that every binding lands in a printed group and claims its key once.

`pnpm typecheck` and `pnpm test` pass — 346 tests.