### PR TITLE
Remove note replies

### DIFF
--- a/.agents/skills/review-with-gander/SKILL.md
+++ b/.agents/skills/review-with-gander/SKILL.md
@@ -57,9 +57,10 @@ Treat a note as work, not as a checkbox:
 bin/mcp call mark_note_addressed id=NOTE_ID commitRef=COMMIT_SHA summary="WHAT CHANGED"
 ```
 
-Only the reviewer resolves a note after re-reviewing the file. The current
-MCP contract has no threaded agent reply; the `note` on
-`mark_note_addressed` is the temporary response channel.
+Discuss the note with the reviewer in the active agent session. Only mark it
+addressed after the work is complete, and use `summary` for a concise durable
+record of what changed. Only the reviewer resolves a note after re-reviewing the
+file; the MCP contract has no reply tool.
 
 ## Diagnose the bridge
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,8 @@ credential reference, a release step, the binding design.
 | `releasing.md` | The release procedure and what the signing machine provides |
 | `plans/`, `briefs/`, `mockups/` | Implementation plans, briefs, and the reference mockup |
 
-`docs/STATE.md` says where the project stands. Interface work and the agent reply
-channel are GitHub issues.
+`docs/STATE.md` says where the project stands. Interface work is tracked in GitHub
+issues.
 
 Settings are validated strictly, so a config written by an earlier version stops
 the app from starting. While the shape is still settling there are no migrations:
@@ -120,10 +120,10 @@ reviewed", not "unchanged".
 **Note lifecycle:** `open` (reviewer captures with `n`) → `addressed` (agent,
 over MCP, with optional commit ref and summary) → `resolved` (reviewer re-checks
 the file). Resolution is always the reviewer's act; no MCP tool may resolve
-anything. Replies form a thread without changing that lifecycle. The MCP
-contract is deliberately three tools — `get_review_notes`,
-`reply_to_note`, and `mark_note_addressed`. Agents have `git` and `gh`
-for code; this contract carries only the review conversation. Keep it small.
+anything. The MCP contract is deliberately two tools — `get_review_notes` and
+`mark_note_addressed`. Agents discuss notes with the reviewer in their active
+session; MCP carries the reviewer's notes and the durable completion state. Agents
+have `git` and `gh` for code. Keep the contract small.
 
 `GANDER_SERVICE_URL` and `GANDER_TOKEN` override the config file at *connection*
 time, not load time (`resolveServiceConnection` in `main/config.ts`) — otherwise

--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -203,16 +203,16 @@ claude mcp add --transport http gander "$GANDER_SERVICE_URL/mcp" \
   --header "Authorization: Bearer $GANDER_TOKEN"
 ```
 
-Run it in the repository being reviewed, not in this one. Three tools appear:
+Run it in the repository being reviewed, not in this one. Two tools appear:
 
 | Tool | Purpose |
 |------|---------|
-| `get_review_notes` | Notes for a repo + branch (or pull request number), with reply threads and counts for every state; addressed and resolved notes can be included explicitly |
-| `reply_to_note` | Adds an agent reply to a note without changing its lifecycle state |
+| `get_review_notes` | Notes for a repo + branch (or pull request number), with counts for every state; addressed and resolved notes can be included explicitly |
 | `mark_note_addressed` | Flags one as acted on, with an optional commit ref and summary |
 
-Nothing over MCP resolves a note. That stays the reviewer's act, made by
-re-reviewing the file in the app.
+Discuss notes in the active agent session. Nothing over MCP replies to or resolves
+a note. Resolution stays the reviewer's act, made by re-reviewing the file in the
+app.
 
 ## Config precedence
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -32,7 +32,7 @@ Gander starts from a local Git repository and turns it into a review hub: Git su
 - A known repository exposes its full file tree, all linked worktrees, and its open pull requests.
 - The file explorer shows the selected worktree's complete read-only filesystem tree, including ignored files but excluding Git administrative metadata.
 - The current-diff view shows the selected worktree's live change from the default-branch merge base through its working directory, including non-ignored untracked files.
-- Pull-request review retains checkoffs, snapshots, changed-since state, notes, and agent replies.
+- Pull-request review retains checkoffs, snapshots, changed-since state, and notes.
 - Local files and current diffs have no persisted review state, notes, or editing.
 - Repository and worktree selection is persistent context above the workspace views; Explorer, Current Diff, and Pull Requests are peer lenses over that target.
 - GitHub is the only forge in v1. Git and filesystem failures remain visible.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -53,9 +53,9 @@ an agent has acted on one, and `resolved` when the reviewer re-checks the file.
 Agents reach them over MCP at `/mcp` on the review service — see `DEVSTACK.md`
 for registration.
 
-Notes also carry reply threads. Reviewer and agent replies remain attached
-to the note and do not change its lifecycle state; agents add replies with
-the dedicated MCP reply tool.
+Agents discuss notes with the reviewer in their active session. Once the work is
+complete, they record the durable completion state through MCP with an optional
+commit ref and summary.
 
 Each opened pull request records its own branch, which is how the service maps an
 agent's working branch to a pull request without holding GitHub credentials.
@@ -95,7 +95,7 @@ those release manifests for updates and ask before restarting to install. The
 repository also generates a checksummed Homebrew cask handoff; publishing and
 verifying the separate personal tap remains a manual release task.
 
-Interface work and the agent reply channel are tracked as GitHub issues.
+Interface work is tracked as GitHub issues.
 
 ## Testing
 

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -60,7 +60,6 @@ export interface GanderApi {
   closeLocal(): Promise<void>;
   onLocalViewChanged(listener: (update: LocalViewUpdate) => void): () => void;
   addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha">): Promise<PrView>;
-  addReviewerReply(repoId: string, prNumber: number, id: number, text: string): Promise<PrView>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<PrView>;
   getSettings(): Promise<AppSettings>;
   updateSettings(settings: AppSettings): Promise<AppSettings>;

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -170,7 +170,6 @@ async function bootstrap(): Promise<GanderConfig> {
   ipcMain.handle("gander:reviewedSnapshot", async (_e, repoId: string, n: number, path: string) => reviewer.reviewedSnapshot(repoId, n, path));
   ipcMain.handle("gander:imagePreview", async (_e, repoId: string, n: number, path: string) => reviewer.imagePreview(repoId, n, path));
   ipcMain.handle("gander:addNote", async (_e, repoId: string, n: number, input: { path: string | null; line: number | null; text: string }) => reviewer.addNote(repoId, n, input));
-  ipcMain.handle("gander:addReviewerReply", async (_e, repoId: string, n: number, id: number, text: string) => reviewer.addReviewerReply(repoId, n, id, text));
   ipcMain.handle("gander:deleteNote", async (_e, repoId: string, n: number, id: number) => reviewer.deleteNote(repoId, n, id));
   ipcMain.handle("gander:setCheckedMany", async (_e, repoId: string, n: number, paths: string[], checked: boolean) => reviewer.setCheckedMany(repoId, n, paths, checked));
   // Connection is deliberately not part of the settings document: that document is

--- a/packages/app/src/main/review.test.ts
+++ b/packages/app/src/main/review.test.ts
@@ -111,18 +111,6 @@ describe("review pipeline", () => {
     expect(reopened.files.find((f) => f.path === "a.rb")!.checked).toBe(true);
   });
 
-  it("adds a reviewer reply through the real service and keeps it on reopen", async () => {
-    await reviewer.openPr("acme/atlas", 1);
-    const withNote = await reviewer.addNote("acme/atlas", 1, { path: "a.rb", line: 2, text: "Why?" });
-    const id = withNote.notes[0]!.id;
-
-    const replied = await reviewer.addReviewerReply("acme/atlas", 1, id, "Because the caller retries.");
-    expect(replied.notes[0]).toMatchObject({
-      state: "open", replies: [{ author: "reviewer", text: "Because the caller retries." }],
-    });
-    expect((await reviewer.openPr("acme/atlas", 1)).notes[0]?.replies).toHaveLength(1);
-  });
-
   it("setCheckedMany checks a batch from the cached view and persists it", async () => {
     await reviewer.openPr("acme/atlas", 1);
     const view = await reviewer.setCheckedMany("acme/atlas", 1, ["a.rb", "b.rb"], true);

--- a/packages/app/src/main/review.ts
+++ b/packages/app/src/main/review.ts
@@ -17,7 +17,6 @@ export interface Reviewer {
   setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<PrView>;
   setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView>;
   addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha">): Promise<PrView>;
-  addReviewerReply(repoId: string, prNumber: number, id: number, text: string): Promise<PrView>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<PrView>;
   /** The file as it stood when the reviewer last checked it — the base for the delta view. */
   reviewedSnapshot(repoId: string, prNumber: number, path: string): Promise<string | null>;
@@ -279,15 +278,6 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
         side(file.headHash, entry.headSha),
       ]);
       return { base, head };
-    },
-    async addReviewerReply(repoId, prNumber, id, text) {
-      const entry = requireWritable(repoId, prNumber);
-      const { view } = entry;
-      const note = view.notes.find((q) => q.id === id);
-      if (!note) throw new Error(`Note ${id} is not part of PR #${prNumber}`);
-      const reply = await writeServiceState(entry, () => deps.service.addReviewerReply(repoId, prNumber, id, text));
-      note.replies = [...note.replies, reply];
-      return view;
     },
     async deleteNote(repoId, prNumber, id) {
       const entry = requireWritable(repoId, prNumber);

--- a/packages/app/src/main/service-client.test.ts
+++ b/packages/app/src/main/service-client.test.ts
@@ -83,7 +83,7 @@ describe("a request with no body", () => {
       app.post("/api/reviews/:repoId/:prNumber/notes", async (req, reply) => {
         seen.push(req.headers["content-type"]);
         return reply.code(201).send({
-          id: 1, path: "a.rb", line: null, text: "why?", state: "open", replies: [],
+          id: 1, path: "a.rb", line: null, text: "why?", state: "open",
           headSha: null, commitRef: null, summary: null, createdAt: new Date().toISOString(),
         });
       });

--- a/packages/app/src/main/service-client.ts
+++ b/packages/app/src/main/service-client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { describeNetworkError } from "./network-error.js";
-import { FileCheckoffSchema, NoteReplySchema, NoteSchema, ReviewStateSchema, type FileCheckoff, type NewNote, type PrContext, type PutFileState, type Note, type NoteReply, type ReviewState } from "@gander/shared";
+import { FileCheckoffSchema, NoteSchema, ReviewStateSchema, type FileCheckoff, type NewNote, type PrContext, type PutFileState, type Note, type ReviewState } from "@gander/shared";
 import { checkServiceStatus, type ServiceStatus } from "./connection.js";
 
 export class ServiceConnectionError extends Error {}
@@ -12,7 +12,6 @@ export interface ServiceClient {
   putFileState(repoId: string, prNumber: number, input: PutFileState): Promise<FileCheckoff>;
   listNotes(repoId: string, prNumber: number): Promise<Note[]>;
   addNote(repoId: string, prNumber: number, input: NewNote): Promise<Note>;
-  addReviewerReply(repoId: string, prNumber: number, id: number, text: string): Promise<NoteReply>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<void>;
   setPrContext(repoId: string, prNumber: number, context: PrContext): Promise<void>;
   getSnapshot(repoId: string, prNumber: number, path: string): Promise<{ baseContent: string | null; headContent: string | null }>;
@@ -175,10 +174,6 @@ export function createServiceClient(connection: Connection): ServiceClient {
     addNote: async (repoId, prNumber, input) => {
       const path = `${reviewPath(repoId, prNumber)}/notes`;
       return validate(NoteSchema, path, await req("POST", path, input, { reviewKey: reviewKey(repoId, prNumber) }));
-    },
-    addReviewerReply: async (repoId, prNumber, id, text) => {
-      const path = `${reviewPath(repoId, prNumber)}/notes/${id}/replies`;
-      return validate(NoteReplySchema, path, await req("POST", path, { text }, { reviewKey: reviewKey(repoId, prNumber) }));
     },
     deleteNote: async (repoId, prNumber, id) => {
       await req("DELETE", `${reviewPath(repoId, prNumber)}/notes/${id}`, undefined, { reviewKey: reviewKey(repoId, prNumber) });

--- a/packages/app/src/preload/api.test.ts
+++ b/packages/app/src/preload/api.test.ts
@@ -47,14 +47,6 @@ describe("preload API", () => {
     expect(invoke).toHaveBeenLastCalledWith("gander:updateSettings", settings);
   });
 
-  it("routes reviewer replies through the reply IPC channel", async () => {
-    const invoke = vi.fn(async () => ({}));
-    const api = createGanderApi(invoke, vi.fn());
-
-    await api.addReviewerReply("acme/atlas", 7, 12, "A reviewer reply");
-    expect(invoke).toHaveBeenLastCalledWith("gander:addReviewerReply", "acme/atlas", 7, 12, "A reviewer reply");
-  });
-
   it("requests an image preview only through its explicit IPC channel", async () => {
     const invoke = vi.fn(async () => ({}));
     const api = createGanderApi(invoke, vi.fn());

--- a/packages/app/src/preload/api.ts
+++ b/packages/app/src/preload/api.ts
@@ -84,7 +84,6 @@ export function createGanderApi(
     closeLocal: () => call("closeLocal"),
     onLocalViewChanged: (listener) => subscribe("gander:localViewChanged", (update: LocalViewUpdate) => listener(update)),
     addNote: (repoId, prNumber, input) => call("addNote", repoId, prNumber, input),
-    addReviewerReply: (repoId, prNumber, id, text) => call("addReviewerReply", repoId, prNumber, id, text),
     deleteNote: (repoId, prNumber, id) => call("deleteNote", repoId, prNumber, id),
     getConnection: () => call("getConnection"),
     testConnection: (url, token) => call("testConnection", url, token),

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -60,7 +60,6 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
     async reviewedSnapshot() { return null; },
     async imagePreview() { return null; },
     async addNote() {},
-    async addReviewerReply() {},
     async deleteNote() {},
     async setChecked(path: string, checked: boolean) {
       calls.setChecked.push([path, checked]);
@@ -175,7 +174,6 @@ describe("FileTree", () => {
       commitRef: null,
       summary: null,
       createdAt: "2026-08-18T00:00:00.000Z",
-      replies: [],
     }]));
     const wrapper = mount(FileTree, { props: { store, iconTheme: "catppuccin-mocha" } });
 
@@ -216,7 +214,6 @@ describe("FileTree", () => {
       commitRef: null,
       summary: null,
       createdAt: "2026-08-18T00:00:00.000Z",
-      replies: [],
     });
     const { store } = fakeStore(prView(1, [target, other], [
       note(1, target.path, "open"),
@@ -245,7 +242,6 @@ describe("FileTree", () => {
       commitRef: null,
       summary: null,
       createdAt: "2026-08-18T00:00:00.000Z",
-      replies: [],
     }]));
     const wrapper = mount(FileTree, { props: { store, iconTheme: "catppuccin-mocha" } });
 

--- a/packages/app/src/renderer/src/components/NoteItem.vue
+++ b/packages/app/src/renderer/src/components/NoteItem.vue
@@ -8,43 +8,30 @@ import {
   ChevronDown,
   CircleHelp,
   Copy,
-  MessageSquare,
   Trash2,
 } from "lucide-vue-next";
 
 const props = defineProps<{
   note: Note;
   current: boolean;
-  submitting: boolean;
   copied: boolean;
 }>();
 const emit = defineEmits<{
   navigate: [note: Note];
-  reply: [noteId: number];
   copy: [note: Note];
   delete: [noteId: number];
 }>();
-const draft = defineModel<string>({ default: "" });
-
-// Deleting a note is the only thing here that cannot be taken back: the text, the
-// line it was captured against, and any reasoning an agent replied with all go together.
+// Deleting a note is the only thing here that cannot be taken back: its text and
+// the line it was captured against go together.
 const confirmingDelete = shallowRef(false);
 
-const deleteDetail = computed(() => {
-  const replies = props.note.replies.length;
-  const thread = replies === 0
-    ? "The note"
-    : `The note and ${replies === 1 ? "its reply" : `its ${replies} replies`}`;
-  return `${thread} will be removed from the review. This cannot be undone.`;
-});
+const deleteDetail = "The note will be removed from the review. This cannot be undone.";
 
-// A keyed thread instance survives service refreshes, so a reviewer's disclosure
-// choice remains stable even when a reply replaces the Note object.
+// A keyed note instance survives service refreshes, so a reviewer's disclosure
+// choice remains stable when the Note object is replaced.
 const expanded = shallowRef(props.note.state === "open");
 const bodyId = computed(() => `note-body-${props.note.id}`);
 const titleId = computed(() => `note-title-${props.note.id}`);
-const replyCount = computed(() => props.note.replies.length);
-const replyCountLabel = computed(() => `${replyCount.value} ${replyCount.value === 1 ? "reply" : "replies"}`);
 const location = computed(() => {
   if (props.note.path === null) return "This pull request";
   const name = props.note.path.split("/").pop() ?? props.note.path;
@@ -61,12 +48,12 @@ function formatTimestamp(value: string): string {
 
 <template>
   <li
-    class="thread"
+    class="note-item"
     :class="[{ current }, `state-${note.state}`]"
     :data-note-id="note.id"
     :aria-labelledby="titleId"
   >
-    <div class="thread-header">
+    <div class="note-header">
       <div class="identity">
         <button
           class="location"
@@ -93,15 +80,11 @@ function formatTimestamp(value: string): string {
         @click="expanded = !expanded"
       >
         <span :id="titleId" class="preview">{{ note.text }}</span>
-        <span class="reply-count">
-          <MessageSquare :size="12" aria-hidden="true" />
-          {{ replyCountLabel }}
-        </span>
         <ChevronDown class="chevron" :class="{ expanded }" :size="15" aria-hidden="true" />
       </button>
     </div>
 
-    <section v-show="expanded" :id="bodyId" class="thread-body" data-note-body>
+    <section v-show="expanded" :id="bodyId" class="note-body" data-note-body>
       <div class="note-message">
         <div class="message-heading">
           <h3>Note</h3>
@@ -118,41 +101,14 @@ function formatTimestamp(value: string): string {
         <p v-if="note.summary" class="message-text">{{ note.summary }}</p>
       </section>
 
-      <section v-if="note.replies.length > 0" class="replies" aria-label="Replies">
-        <h3>Replies</h3>
-        <ol>
-          <li v-for="reply in note.replies" :key="reply.id" class="reply">
-            <div class="message-heading">
-              <span class="author" :class="reply.author">
-                {{ reply.author === "reviewer" ? "Reviewer" : "Agent" }}
-              </span>
-              <time :datetime="reply.createdAt">{{ formatTimestamp(reply.createdAt) }}</time>
-            </div>
-            <p class="message-text">{{ reply.text }}</p>
-          </li>
-        </ol>
-      </section>
-
-      <form class="reply-form" @submit.prevent="emit('reply', note.id)">
-        <label :for="`note-reply-${note.id}`">Reply</label>
-        <input
-          :id="`note-reply-${note.id}`"
-          v-model="draft"
-          data-app-typing="true"
-          :aria-label="`Reply to note ${note.id}`"
-          placeholder="Reply…"
-          :disabled="submitting"
-        />
-      </form>
-
-      <div class="thread-actions">
+      <div class="note-actions">
         <button
           type="button"
-          :aria-label="`Copy note ${note.id} thread`"
+          :aria-label="`Copy note ${note.id}`"
           @click="emit('copy', note)"
         >
           <Copy :size="13" aria-hidden="true" />
-          {{ copied ? "Copied" : "Copy thread" }}
+          {{ copied ? "Copied" : "Copy note" }}
         </button>
         <button
           class="delete"
@@ -178,14 +134,14 @@ function formatTimestamp(value: string): string {
 </template>
 
 <style scoped>
-.thread {
+.note-item {
   border-bottom: 1px solid var(--workbench-border);
   border-left: 1px solid transparent;
   min-width: 0;
 }
-.thread.state-open { border-left-color: var(--accent); }
-.thread.current { background: var(--selection-background); }
-.thread-header { display: flex; flex-direction: column; gap: 5px; padding: 9px 10px 8px; min-width: 0; }
+.note-item.state-open { border-left-color: var(--accent); }
+.note-item.current { background: var(--selection-background); }
+.note-header { display: flex; flex-direction: column; gap: 5px; padding: 9px 10px 8px; min-width: 0; }
 .identity { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .location {
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -201,37 +157,27 @@ function formatTimestamp(value: string): string {
 .state.addressed { color: var(--warning); }
 .state.resolved { color: var(--success); }
 .disclosure {
-  display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 8px;
+  display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 8px;
   width: 100%; min-width: 0; padding: 2px 0; border: 0; background: none; color: inherit; cursor: pointer; text-align: left;
 }
 .preview { min-width: 0; overflow: hidden; color: var(--workbench-foreground); font-size: 12.5px; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
-.reply-count { display: inline-flex; align-items: center; gap: 4px; color: var(--faint-foreground); font: 10px var(--mono); white-space: nowrap; }
 .chevron { color: var(--faint-foreground); transition: transform 120ms ease; }
 .chevron.expanded { transform: rotate(180deg); }
-.thread-body { padding: 1px 10px 11px; }
-.note-message, .agent-update, .replies { min-width: 0; border-radius: var(--radius-md); }
+.note-body { padding: 1px 10px 11px; }
+.note-message, .agent-update { min-width: 0; border-radius: var(--radius-md); }
 .note-message { padding: 9px 10px; background: var(--input-background); border: 1px solid var(--workbench-border); }
-.agent-update, .replies { margin: 8px 0 0 12px; padding: 9px 10px; border-left: 1px solid var(--accent); background: color-mix(in srgb, var(--accent) 6%, transparent); }
-.replies { border-left-color: var(--workbench-border); background: transparent; }
+.agent-update { margin: 8px 0 0 12px; padding: 9px 10px; border-left: 1px solid var(--accent); background: color-mix(in srgb, var(--accent) 6%, transparent); }
 .message-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; min-width: 0; }
-.message-heading h3, .replies > h3, .author { margin: 0; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
-.agent-update .message-heading h3, .author.agent { color: var(--accent); }
+.message-heading h3 { margin: 0; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
+.agent-update .message-heading h3 { color: var(--accent); }
 .message-heading time { min-width: 0; color: var(--faint-foreground); font-size: 9.5px; text-align: right; }
 .message-heading code { overflow: hidden; max-width: 45%; padding: 1px 5px; border-radius: var(--radius-sm); background: var(--badge-background); color: var(--muted-foreground); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
 .message-text { margin: 4px 0 0; min-width: 0; color: var(--workbench-foreground); font-size: 12.5px; line-height: 1.5; overflow-wrap: anywhere; white-space: pre-wrap; }
-.replies ol { list-style: none; margin: 7px 0 0; padding: 0; }
-.reply { padding: 8px 0; border-top: 1px solid var(--workbench-border); }
-.reply:last-child { padding-bottom: 0; }
-.reply-form { margin-top: 9px; }
-.reply-form label { display: block; margin-bottom: 4px; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }
-.reply-form input { width: 100%; background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-md); color: var(--workbench-foreground); font: inherit; font-size: 12px; padding: 6px 8px; }
-.reply-form input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
-.reply-form input:disabled { color: var(--faint-foreground); }
-.thread-actions { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
-.thread-actions button { display: inline-flex; align-items: center; gap: 5px; border: 0; padding: 2px 0; background: none; color: var(--muted-foreground); font: inherit; font-size: 10.5px; cursor: pointer; }
-.thread-actions .delete { margin-left: auto; color: var(--faint-foreground); }
-.thread-actions .delete:hover { color: var(--danger); }
-.location:focus-visible, .disclosure:focus-visible, .thread-actions button:focus-visible {
+.note-actions { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
+.note-actions button { display: inline-flex; align-items: center; gap: 5px; border: 0; padding: 2px 0; background: none; color: var(--muted-foreground); font: inherit; font-size: 10.5px; cursor: pointer; }
+.note-actions .delete { margin-left: auto; color: var(--faint-foreground); }
+.note-actions .delete:hover { color: var(--danger); }
+.location:focus-visible, .disclosure:focus-visible, .note-actions button:focus-visible {
   outline: 2px solid var(--accent); outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) { .chevron { transition: none; } }

--- a/packages/app/src/renderer/src/components/NotesDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/NotesDrawer.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
-import { flushPromises, mount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { reactive } from "vue";
 import type { PrView } from "@gander/shared";
 import type { Store } from "../store.js";
 import { pendingReveal } from "../selection.js";
@@ -30,7 +29,6 @@ function store(notes: PrView["notes"], overrides: Partial<Store> = {}): Store {
   return {
     view: view(notes),
     selectedPath: null,
-    async addReviewerReply() {},
     async deleteNote() {},
     select() {},
     ...overrides,
@@ -48,7 +46,6 @@ const notes: PrView["notes"] = [
     commitRef: null,
     summary: null,
     createdAt: "2026-08-18T00:00:00.000Z",
-    replies: [],
   },
   {
     id: 2,
@@ -60,10 +57,6 @@ const notes: PrView["notes"] = [
     commitRef: "abc1234",
     summary: "Kept the contract and added coverage.",
     createdAt: "2026-08-18T01:00:00.000Z",
-    replies: [
-      { id: 3, author: "agent", text: "The regression test now covers both callers.", createdAt: "2026-08-18T02:00:00.000Z" },
-      { id: 4, author: "reviewer", text: "That covers my concern.", createdAt: "2026-08-18T03:00:00.000Z" },
-    ],
   },
 ];
 
@@ -95,7 +88,6 @@ describe("NotesDrawer", () => {
           commitRef: null,
           summary: null,
           createdAt: "2026-08-18T00:00:00.000Z",
-          replies: [],
         }]),
         dock: "right",
       },
@@ -107,7 +99,7 @@ describe("NotesDrawer", () => {
     expect(wrapper.emitted("addNote")).toHaveLength(1);
   });
 
-  it("opens new notes and collapses addressed threads without losing their identity", () => {
+  it("opens new notes and collapses addressed notes without losing their identity", () => {
     const wrapper = mount(NotesDrawer, { props: { store: store(notes), dock: "right" } });
 
     const toggles = wrapper.findAll("button[aria-expanded]");
@@ -119,11 +111,10 @@ describe("NotesDrawer", () => {
     expect(addressed.text()).toContain("addressed.ts:9");
     expect(addressed.get(".state").text()).toBe("addressed");
     expect(addressed.text()).toContain("Could this preserve the existing caller contract?");
-    expect(addressed.text()).toContain("2 replies");
     expect(addressed.find("[data-note-body]").isVisible()).toBe(false);
   });
 
-  it("exposes a keyboard-operable disclosure and a labeled reply hierarchy", async () => {
+  it("exposes a keyboard-operable disclosure and labeled agent update", async () => {
     const wrapper = mount(NotesDrawer, { props: { store: store(notes), dock: "bottom" } });
     const addressed = wrapper.get("[data-note-id='2']");
     const toggle = addressed.get("button[aria-expanded='false']");
@@ -136,25 +127,18 @@ describe("NotesDrawer", () => {
     expect(addressed.get("[data-note-body]").isVisible()).toBe(true);
     expect(addressed.get("[aria-label='Agent update']").text()).toContain("Kept the contract and added coverage.");
     expect(addressed.get("[aria-label='Agent update'] code").text()).toBe("abc1234");
-    expect(addressed.get("[aria-label='Replies']").text()).toContain("Agent");
-    expect(addressed.get("[aria-label='Replies']").text()).toContain("Reviewer");
   });
 
-  it("preserves navigation, delete, and reply actions inside an expanded thread", async () => {
+  it("preserves navigation and delete actions inside an expanded note", async () => {
     const select = vi.fn();
     const deleteNote = vi.fn(async () => {});
-    const addReviewerReply = vi.fn(async () => {});
-    const drawerStore = store(notes, { select, deleteNote, addReviewerReply });
+    const drawerStore = store(notes, { select, deleteNote });
     const wrapper = mount(NotesDrawer, { props: { store: drawerStore, dock: "right" } });
     const open = wrapper.get("[data-note-id='1']");
 
     await open.get("button[data-note-location]").trigger("click");
     expect(select).toHaveBeenCalledWith("src/a-very-long-file-name.ts");
     expect(pendingReveal.value).toBe(37);
-
-    await open.get("input[aria-label='Reply to note 1']").setValue("A reviewer follow-up");
-    await open.get("form").trigger("submit");
-    expect(addReviewerReply).toHaveBeenCalledWith(1, "A reviewer follow-up");
 
     await open.get("button[aria-label='Delete note 1']").trigger("click");
     // The click opens the confirmation; nothing is deleted until it is answered.
@@ -187,36 +171,17 @@ describe("NotesDrawer", () => {
     expect(open.get("dialog.confirm .detail").text()).toMatch(/cannot be undone/);
   });
 
-  it("preserves an explicit disclosure choice when a reply refreshes the note", async () => {
-    const drawerStore = reactive(store(notes)) as Store;
-    drawerStore.addReviewerReply = async (id, text) => {
-      drawerStore.view = view(notes.map((note) => note.id === id
-        ? { ...note, replies: [...note.replies, { id: 5, author: "reviewer", text, createdAt: "2026-08-18T04:00:00.000Z" }] }
-        : note));
-    };
-    const wrapper = mount(NotesDrawer, { props: { store: drawerStore, dock: "right" } });
-    const addressed = wrapper.get("[data-note-id='2']");
-    await addressed.get("button[aria-expanded='false']").trigger("click");
-    await addressed.get("input").setValue("One more thought");
-    await addressed.get("form").trigger("submit");
-    await flushPromises();
-
-    expect(addressed.get("button[aria-expanded]").attributes("aria-expanded")).toBe("true");
-    expect(addressed.get("[aria-label='Replies']").text()).toContain("One more thought");
-  });
-
-  it("copies a complete note thread and all threads as markdown", async () => {
+  it("copies a complete note and all notes as markdown", async () => {
     const writeText = vi.fn(async () => {});
     Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
     const wrapper = mount(NotesDrawer, { props: { store: store(notes), dock: "right" } });
     const addressed = wrapper.get("[data-note-id='2']");
     await addressed.get("button[aria-expanded='false']").trigger("click");
 
-    await addressed.get("button[aria-label='Copy note 2 thread']").trigger("click");
+    await addressed.get("button[aria-label='Copy note 2']").trigger("click");
     expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("Agent update (abc1234): Kept the contract"));
-    expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("Agent: The regression test now covers both callers."));
 
-    await wrapper.get("button[aria-label='Copy all note threads']").trigger("click");
+    await wrapper.get("button[aria-label='Copy all notes']").trigger("click");
     expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("### src/a-very-long-file-name.ts:37 — open"));
     expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("### src/addressed.ts:9 — addressed"));
   });

--- a/packages/app/src/renderer/src/components/NotesDrawer.vue
+++ b/packages/app/src/renderer/src/components/NotesDrawer.vue
@@ -1,17 +1,15 @@
 <script setup lang="ts">
-import { computed, reactive, shallowRef } from "vue";
+import { computed, shallowRef } from "vue";
 import type { Note } from "@gander/shared";
 import { Copy, MessageSquare, PanelBottom, PanelRight, Plus, X } from "lucide-vue-next";
 import type { Store } from "../store.js";
 import { revealLine } from "../selection.js";
-import NoteThread from "./NoteThread.vue";
+import NoteItem from "./NoteItem.vue";
 
 const props = defineProps<{ store: Store; dock: "right" | "bottom" }>();
 const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addNote: [] }>();
 
 const notes = computed(() => props.store.view?.notes ?? []);
-const drafts = reactive<Record<number, string>>({});
-const submitting = reactive(new Set<number>());
 const copiedNoteId = shallowRef<number | null>(null);
 const copiedAll = shallowRef(false);
 
@@ -19,20 +17,6 @@ function goTo(q: { path: string | null; line: number | null }): void {
   if (q.path === null) return;
   props.store.select(q.path);
   if (q.line !== null) revealLine(q.line);
-}
-
-async function reply(noteId: number): Promise<void> {
-  const text = drafts[noteId]?.trim() ?? "";
-  if (!text || submitting.has(noteId)) return;
-  const before = notes.value.find((q) => q.id === noteId)?.replies.length ?? 0;
-  submitting.add(noteId);
-  try {
-    await props.store.addReviewerReply(noteId, text);
-    const after = notes.value.find((q) => q.id === noteId)?.replies.length ?? 0;
-    if (after > before) drafts[noteId] = "";
-  } finally {
-    submitting.delete(noteId);
-  }
 }
 
 function noteMarkdown(note: Note): string {
@@ -47,9 +31,6 @@ function noteMarkdown(note: Note): string {
   if (note.summary || note.commitRef) {
     const commit = note.commitRef ? ` (${note.commitRef})` : "";
     parts.push("", `Agent update${commit}: ${note.summary ?? "Addressed"}`);
-  }
-  for (const threadReply of note.replies) {
-    parts.push("", `${threadReply.author === "reviewer" ? "Reviewer" : "Agent"}: ${threadReply.text}`);
   }
   return parts.join("\n");
 }
@@ -83,8 +64,8 @@ async function copyAll(): Promise<void> {
       <button
         v-if="notes.length > 0"
         class="copy-all"
-        aria-label="Copy all note threads"
-        title="Copy all note threads"
+        aria-label="Copy all notes"
+        title="Copy all notes"
         @click="copyAll"
       >
         <Copy :size="13" aria-hidden="true" />
@@ -121,16 +102,13 @@ async function copyAll(): Promise<void> {
     </div>
 
     <ul v-else aria-label="Review notes">
-      <NoteThread
+      <NoteItem
         v-for="note in notes"
         :key="note.id"
-        v-model="drafts[note.id]"
         :note="note"
         :current="note.path === store.selectedPath"
-        :submitting="submitting.has(note.id)"
         :copied="copiedNoteId === note.id"
         @navigate="goTo"
-        @reply="reply"
         @copy="copyNote"
         @delete="store.deleteNote"
       />

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -57,7 +57,6 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     closeLocal: async () => {},
     onLocalViewChanged: () => () => {},
     addNote: async () => prView(),
-    addReviewerReply: async () => prView(),
     deleteNote: async () => prView(),
     getSettings: async () => ({
       editor: { fontFamily: "monospace", fontSize: 16 },
@@ -349,21 +348,6 @@ describe("store", () => {
     await store.refresh();
     expect(store.selectedPath).toBe("b.rb");
     expect(store.view).not.toBeNull();
-  });
-
-  it("sends a reviewer reply for the open review", async () => {
-    let call: [string, number, number, string] | null = null;
-    const store = createStore(fakeApi({
-      addReviewerReply: async (repo, pr, id, text) => {
-        call = [repo, pr, id, text];
-        return prView();
-      },
-    }));
-    await store.loadRepos();
-    await store.selectRepo("acme/atlas");
-    await store.openPr(1);
-    await store.addReviewerReply(12, "A reviewer reply");
-    expect(call).toEqual(["acme/atlas", 1, 12, "A reviewer reply"]);
   });
 
   it("busy is true only while a long-running action is in flight, and clears even on failure", async () => {

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -52,7 +52,6 @@ export interface Store {
   reviewedSnapshot(path: string): Promise<string | null>;
   imagePreview(path: string): Promise<ImagePreview | null>;
   addNote(text: string, path: string | null, line: number | null): Promise<void>;
-  addReviewerReply(id: number, text: string): Promise<void>;
   deleteNote(id: number): Promise<void>;
   select(path: string): void;
   files(): ChangedFile[];
@@ -294,12 +293,6 @@ export function createStore(api: GanderApi): Store {
       await guard(async () => {
         const { repoId, prNumber } = requireOpenPr();
         store.view = await api.deleteNote(repoId, prNumber, id);
-      });
-    },
-    async addReviewerReply(id: number, text: string) {
-      await guard(async () => {
-        const { repoId, prNumber } = requireOpenPr();
-        store.view = await api.addReviewerReply(repoId, prNumber, id, text);
       });
     },
     select(path: string) {

--- a/packages/service/contract.json
+++ b/packages/service/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.4.0",
   "routes": [
     "DELETE /api/reviews/:repoId/:prNumber/notes/:id",
     "DELETE /mcp",
@@ -12,7 +12,6 @@
     "OPTIONS /mcp",
     "PATCH /mcp",
     "POST /api/reviews/:repoId/:prNumber/notes",
-    "POST /api/reviews/:repoId/:prNumber/notes/:id/replies",
     "POST /mcp",
     "PUT /api/reviews/:repoId/:prNumber/context",
     "PUT /api/reviews/:repoId/:prNumber/files",
@@ -124,19 +123,6 @@
         "summary"
       ]
     },
-    "NewNoteReplySchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "text": {
-          "type": "string",
-          "minLength": 1
-        }
-      },
-      "required": [
-        "text"
-      ]
-    },
     "NewNoteSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -185,45 +171,6 @@
         "line",
         "text",
         "headSha"
-      ]
-    },
-    "NoteReplyAuthorSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "string",
-      "enum": [
-        "reviewer",
-        "agent"
-      ]
-    },
-    "NoteReplySchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer",
-          "exclusiveMinimum": 0,
-          "maximum": 9007199254740991
-        },
-        "author": {
-          "type": "string",
-          "enum": [
-            "reviewer",
-            "agent"
-          ]
-        },
-        "text": {
-          "type": "string",
-          "minLength": 1
-        },
-        "createdAt": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "author",
-        "text",
-        "createdAt"
       ]
     },
     "NoteSchema": {
@@ -301,39 +248,6 @@
         },
         "createdAt": {
           "type": "string"
-        },
-        "replies": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "integer",
-                "exclusiveMinimum": 0,
-                "maximum": 9007199254740991
-              },
-              "author": {
-                "type": "string",
-                "enum": [
-                  "reviewer",
-                  "agent"
-                ]
-              },
-              "text": {
-                "type": "string",
-                "minLength": 1
-              },
-              "createdAt": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "author",
-              "text",
-              "createdAt"
-            ]
-          }
         }
       },
       "required": [
@@ -345,8 +259,7 @@
         "headSha",
         "commitRef",
         "summary",
-        "createdAt",
-        "replies"
+        "createdAt"
       ]
     },
     "NoteStateSchema": {
@@ -676,31 +589,6 @@
         },
         "required": [
           "id"
-        ],
-        "$schema": "http://json-schema.org/draft-07/schema#"
-      }
-    },
-    {
-      "name": "reply_to_note",
-      "description": "Add an agent reply to a review note. Use this for clarification, reasoning, or a response that should remain with the review. Replying does not address or resolve the note and does not change its lifecycle state.",
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991,
-            "description": "Note id from get_review_notes."
-          },
-          "text": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The reply to add to the note thread."
-          }
-        },
-        "required": [
-          "id",
-          "text"
         ],
         "$schema": "http://json-schema.org/draft-07/schema#"
       }

--- a/packages/service/src/mcp.test.ts
+++ b/packages/service/src/mcp.test.ts
@@ -49,10 +49,10 @@ afterEach(async () => {
 });
 
 describe("MCP endpoint", () => {
-  it("offers the three note conversation tools", async () => {
+  it("offers only the note pickup and completion tools", async () => {
     const client = await connect();
     const names = (await client.listTools()).tools.map((t) => t.name).sort();
-    expect(names).toEqual(["get_review_notes", "mark_note_addressed", "reply_to_note"]);
+    expect(names).toEqual(["get_review_notes", "mark_note_addressed"]);
     await client.close();
   });
 
@@ -72,39 +72,8 @@ describe("MCP endpoint", () => {
     expect(payload.title).toBe("Feature");
     expect(payload.notes).toEqual([{
       id: expect.any(Number), file: "a.rb", line: 12, text: "Why the retry here?", state: "open",
-      replies: [], capturedAtSha: null, lineMayHaveMoved: false,
+      capturedAtSha: null, lineMayHaveMoved: false,
     }]);
-    await client.close();
-  });
-
-  it("lets an agent reply and returns the thread without changing note state", async () => {
-    storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
-    const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Why?", headSha: "sha-1" });
-
-    const client = await connect();
-    const replied = await client.callTool({
-      name: "reply_to_note",
-      arguments: { id: q.id, text: "This belongs in the model because both callers need it." },
-    });
-    expect(textOf(replied as { content?: unknown })).toContain("state was not changed");
-
-    const payload = JSON.parse(textOf((await client.callTool({
-      name: "get_review_notes",
-      arguments: { repo: "acme/atlas", branch: "feat/thing" },
-    })) as { content?: unknown })) as { notes: Array<{ state: string; replies: Array<{ author: string; text: string }> }> };
-    expect(payload.notes[0]).toMatchObject({
-      state: "open",
-      replies: [{ author: "agent", text: "This belongs in the model because both callers need it." }],
-    });
-    expect(storage.listNotes("acme/atlas", 7)[0]?.state).toBe("open");
-    await client.close();
-  });
-
-  it("reports an unknown note when an agent tries to reply", async () => {
-    const client = await connect();
-    const result = await client.callTool({ name: "reply_to_note", arguments: { id: 999, text: "Anyone there?" } });
-    expect(result.isError).toBe(true);
-    expect(textOf(result as { content?: unknown })).toContain("does not exist");
     await client.close();
   });
 
@@ -161,7 +130,7 @@ describe("MCP endpoint", () => {
     })) as { content?: unknown })) as { notes: Array<Record<string, unknown>> };
     expect(withResolved.notes).toEqual([{
       id: resolved.id, file: "a.rb", line: null, text: "handled", state: "resolved",
-      replies: [], commitRef: "abc1234", summary: "Dropped the retry", capturedAtSha: null, lineMayHaveMoved: false,
+      commitRef: "abc1234", summary: "Dropped the retry", capturedAtSha: null, lineMayHaveMoved: false,
     }]);
     await client.close();
   });

--- a/packages/service/src/mcp.ts
+++ b/packages/service/src/mcp.ts
@@ -4,11 +4,11 @@ import { z } from "zod";
 import type { Storage } from "./storage.js";
 
 /**
- * The MCP contract is deliberately tiny: agents read the reviewer's notes, reply,
- * and say when they have acted on one. Nothing here reads diffs, lists files, touches
+ * The MCP contract is deliberately tiny: agents read the reviewer's notes and say when
+ * they have acted on one. Nothing here reads diffs, lists files, touches
  * checkoffs, or resolves a note — resolution is the reviewer's act alone, made in
  * the app by re-checking the file. Agents already have git and gh for code; this carries
- * only the conversation.
+ * only the reviewer's notes and their durable completion state.
  */
 export function buildMcpServer(storage: Storage, version: string): McpServer {
   const server = new McpServer({ name: "gander", version });
@@ -62,12 +62,6 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
           line: q.line,
           text: q.text,
           state: q.state,
-          replies: q.replies.map((reply) => ({
-            id: reply.id,
-            author: reply.author,
-            text: reply.text,
-            createdAt: reply.createdAt,
-          })),
           ...(q.state === "open" ? {} : { commitRef: q.commitRef, summary: q.summary }),
           capturedAtSha: q.headSha,
           // The branch may have moved since the reviewer read it, in which case the line
@@ -127,30 +121,6 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
         : "";
 
       return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) + hint }] };
-    },
-  );
-
-  server.registerTool(
-    "reply_to_note",
-    {
-      title: "Reply to a review note",
-      description:
-        "Add an agent reply to a review note. Use this for clarification, reasoning, or a response that should remain with the review. " +
-        "Replying does not address or resolve the note and does not change its lifecycle state.",
-      inputSchema: {
-        id: z.number().int().positive().describe("Note id from get_review_notes."),
-        text: z.string().trim().min(1).describe("The reply to add to the note thread."),
-      },
-    },
-    async ({ id, text }) => {
-      const added = storage.addAgentReply(id, { text });
-      if (added === null) {
-        return {
-          content: [{ type: "text", text: `Note ${id} does not exist.` }],
-          isError: true,
-        };
-      }
-      return { content: [{ type: "text", text: `Reply added to note ${id}. Its state was not changed.` }] };
     },
   );
 

--- a/packages/service/src/server.test.ts
+++ b/packages/service/src/server.test.ts
@@ -126,27 +126,6 @@ describe("service API", () => {
       expect(res.statusCode).toBe(400);
     });
 
-    it("adds a reviewer reply to the note thread without changing its state", async () => {
-      const created = await server.inject({ method: "POST", url, headers: AUTH, payload: { path: "a.rb", line: 3, text: "Why?", headSha: "sha-1" } });
-      const id = created.json().id as number;
-      const reply = await server.inject({
-        method: "POST", url: `${url}/${id}/replies`, headers: AUTH, payload: { text: "It is required by the caller." },
-      });
-
-      expect(reply.statusCode).toBe(201);
-      expect(reply.json()).toMatchObject({ author: "reviewer", text: "It is required by the caller." });
-      expect((await server.inject({ method: "GET", url, headers: AUTH })).json()[0]).toMatchObject({
-        state: "open", replies: [{ author: "reviewer", text: "It is required by the caller." }],
-      });
-    });
-
-    it("rejects blank replies and replies scoped to another review", async () => {
-      const created = await server.inject({ method: "POST", url, headers: AUTH, payload: { path: "a.rb", line: null, text: "Why?", headSha: null } });
-      const id = created.json().id as number;
-      expect((await server.inject({ method: "POST", url: `${url}/${id}/replies`, headers: AUTH, payload: { text: "   " } })).statusCode).toBe(400);
-      expect((await server.inject({ method: "POST", url: `/api/reviews/acme%2Fatlas/8/notes/${id}/replies`, headers: AUTH, payload: { text: "Wrong review" } })).statusCode).toBe(404);
-    });
-
     it("404s on deleting a note that is not there", async () => {
       expect((await server.inject({ method: "DELETE", url: `${url}/999`, headers: AUTH })).statusCode).toBe(404);
     });

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -1,6 +1,6 @@
 import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
 import type { ZodError } from "zod";
-import { NewNoteReplySchema, NewNoteSchema, PrContextSchema, PutFileStateSchema } from "@gander/shared";
+import { NewNoteSchema, PrContextSchema, PutFileStateSchema } from "@gander/shared";
 import { handleMcpRequest } from "./mcp.js";
 import type { Storage } from "./storage.js";
 
@@ -131,23 +131,6 @@ export function buildServer(opts: {
         return reply.code(404).send({ error: `no note ${id} on ${req.params.repoId}#${prNumber}` });
       }
       return reply.code(204).send();
-    },
-  );
-
-  app.post<{ Params: { repoId: string; prNumber: string; id: string } }>(
-    "/api/reviews/:repoId/:prNumber/notes/:id/replies",
-    async (req, reply) => {
-      const prNumber = positiveInt("prNumber", req.params.prNumber, reply);
-      if (prNumber === undefined) return;
-      const id = positiveInt("id", req.params.id, reply);
-      if (id === undefined) return;
-      const parsed = NewNoteReplySchema.safeParse(req.body);
-      if (!parsed.success) return badRequest(reply, parsed.error);
-      const added = opts.storage.addReviewerReply(req.params.repoId, prNumber, id, parsed.data);
-      if (added === null) {
-        return reply.code(404).send({ error: `no note ${id} on ${req.params.repoId}#${prNumber}` });
-      }
-      return reply.code(201).send(added);
     },
   );
 

--- a/packages/service/src/storage.test.ts
+++ b/packages/service/src/storage.test.ts
@@ -130,49 +130,6 @@ describe("storage", () => {
       expect(marked).toMatchObject({ state: "addressed", commitRef: "abc1234", summary: "Dropped the retry" });
     });
 
-    it("appends reviewer and agent replies without changing the note state", () => {
-      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 4, text: "Why?", headSha: null });
-
-      expect(storage.addReviewerReply("acme/atlas", 7, q.id, { text: "Because this runs twice." })).toMatchObject({
-        author: "reviewer", text: "Because this runs twice.",
-      });
-      expect(storage.addAgentReply(q.id, { text: "That constraint belongs in the model." })).toMatchObject({
-        author: "agent", text: "That constraint belongs in the model.",
-      });
-
-      expect(storage.listNotes("acme/atlas", 7)[0]).toMatchObject({
-        state: "open",
-        replies: [
-          { author: "reviewer", text: "Because this runs twice." },
-          { author: "agent", text: "That constraint belongs in the model." },
-        ],
-      });
-
-      storage.markNoteAddressed(q.id, { commitRef: null, summary: null });
-      storage.addAgentReply(q.id, { text: "One more detail." });
-      expect(storage.listNotes("acme/atlas", 7)[0]?.state).toBe("addressed");
-
-      storage.putFileState("acme/atlas", 7, {
-        checked: true, path: "a.rb", baseHash: "b", headHash: "h",
-        baseContent: "old", headContent: "new", machine: "studio",
-      });
-      storage.addReviewerReply("acme/atlas", 7, q.id, { text: "Closing note." });
-      expect(storage.listNotes("acme/atlas", 7)[0]?.state).toBe("resolved");
-    });
-
-    it("scopes reviewer replies to the note's review", () => {
-      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
-      expect(storage.addReviewerReply("acme/atlas", 8, q.id, { text: "Wrong review" })).toBeNull();
-      expect(storage.listNotes("acme/atlas", 7)[0]?.replies).toEqual([]);
-    });
-
-    it("deletes a note's reply thread with the note", () => {
-      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
-      storage.addAgentReply(q.id, { text: "Here is why." });
-      expect(storage.deleteNote("acme/atlas", 7, q.id)).toBe(true);
-      expect(storage.addAgentReply(q.id, { text: "Too late" })).toBeNull();
-    });
-
     it("refuses to re-address a note the reviewer already resolved", () => {
       const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
       storage.markNoteAddressed(q.id, { commitRef: "abc1234", summary: "Dropped the retry" });

--- a/packages/service/src/storage.ts
+++ b/packages/service/src/storage.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { gzipSync, gunzipSync } from "node:zlib";
-import type { FileCheckoff, MarkAddressed, NewNote, NewNoteReply, PrContext, PutFileState, Note, NoteReply, ReviewState } from "@gander/shared";
+import type { FileCheckoff, MarkAddressed, NewNote, PrContext, PutFileState, Note, ReviewState } from "@gander/shared";
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS reviews (
@@ -40,14 +40,6 @@ CREATE TABLE IF NOT EXISTS notes (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 CREATE INDEX IF NOT EXISTS notes_by_review ON notes(review_id);
-CREATE TABLE IF NOT EXISTS note_replies (
-  id INTEGER PRIMARY KEY,
-  note_id INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
-  author TEXT NOT NULL CHECK(author IN ('reviewer', 'agent')),
-  text TEXT NOT NULL,
-  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE INDEX IF NOT EXISTS note_replies_by_note ON note_replies(note_id, id);
 `;
 
 export interface Storage {
@@ -65,14 +57,11 @@ export interface Storage {
   markNoteAddressed(id: number, input: MarkAddressed): Note | null;
   listNotes(repoId: string, prNumber: number): Note[];
   addNote(repoId: string, prNumber: number, input: NewNote): Note;
-  addReviewerReply(repoId: string, prNumber: number, id: number, input: NewNoteReply): NoteReply | null;
-  addAgentReply(id: number, input: NewNoteReply): NoteReply | null;
   deleteNote(repoId: string, prNumber: number, id: number): boolean;
   close(): void;
 }
 
 interface NoteRow { id: number; path: string | null; line: number | null; text: string; state: string; head_sha: string | null; commit_ref: string | null; summary: string | null; created_at: string }
-interface NoteReplyRow { id: number; note_id: number; author: string; text: string; created_at: string }
 interface FileStateRow { path: string; checked: number; base_hash: string | null; head_hash: string | null; checked_at: string | null; machine: string | null }
 
 const rowToCheckoff = (r: FileStateRow): FileCheckoff => ({
@@ -81,24 +70,15 @@ const rowToCheckoff = (r: FileStateRow): FileCheckoff => ({
   checkedAt: r.checked_at, machine: r.machine,
 });
 
-const rowToReply = (r: NoteReplyRow): NoteReply => ({
-  id: r.id,
-  author: r.author as NoteReply["author"],
-  text: r.text,
-  createdAt: r.created_at,
-});
-
-const rowToNote = (r: NoteRow, replies: NoteReply[] = []): Note => ({
+const rowToNote = (r: NoteRow): Note => ({
   id: r.id, path: r.path, line: r.line, text: r.text,
   state: r.state as Note["state"],
   headSha: r.head_sha,
   commitRef: r.commit_ref, summary: r.summary,
   createdAt: r.created_at,
-  replies,
 });
 
 const NOTE_COLUMNS = "id, path, line, text, state, head_sha, commit_ref, summary, created_at";
-const REPLY_COLUMNS = "id, note_id, author, text, created_at";
 const FILE_STATE_COLUMNS = "path, checked, base_hash, head_hash, checked_at, machine";
 
 const pack = (s: string | null): Buffer | null => (s === null ? null : gzipSync(Buffer.from(s, "utf8")));
@@ -115,13 +95,6 @@ export function openStorage(dbPath: string): Storage {
     const row = db.prepare("SELECT id FROM reviews WHERE repo_id = ? AND pr_number = ?").get(repoId, prNumber) as { id: number };
     return row.id;
   };
-
-  const repliesForNote = (id: number): NoteReply[] =>
-    (db.prepare(`SELECT ${REPLY_COLUMNS} FROM note_replies WHERE note_id = ? ORDER BY id`).all(id) as NoteReplyRow[])
-      .map(rowToReply);
-
-  const replyById = (id: number | bigint): NoteReply =>
-    rowToReply(db.prepare(`SELECT ${REPLY_COLUMNS} FROM note_replies WHERE id = ?`).get(id) as NoteReplyRow);
 
   return {
     getReview(repoId, prNumber) {
@@ -227,26 +200,13 @@ export function openStorage(dbPath: string): Storage {
         WHERE id = ? AND state = 'open'
       `).run(input.commitRef, input.summary, id).changes;
       if (changed === 0) return null;
-      return rowToNote(db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(id) as NoteRow, repliesForNote(id));
+      return rowToNote(db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(id) as NoteRow);
     },
 
     listNotes(repoId, prNumber) {
       const rid = reviewId(repoId, prNumber);
       const rows = db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE review_id = ? ORDER BY id`).all(rid) as NoteRow[];
-      const replyRows = db.prepare(`
-        SELECT qr.id, qr.note_id, qr.author, qr.text, qr.created_at
-        FROM note_replies qr
-        JOIN notes q ON q.id = qr.note_id
-        WHERE q.review_id = ?
-        ORDER BY qr.id
-      `).all(rid) as NoteReplyRow[];
-      const replies = new Map<number, NoteReply[]>();
-      for (const row of replyRows) {
-        const current = replies.get(row.note_id) ?? [];
-        current.push(rowToReply(row));
-        replies.set(row.note_id, current);
-      }
-      return rows.map((row) => rowToNote(row, replies.get(row.id) ?? []));
+      return rows.map(rowToNote);
     },
 
     addNote(repoId, prNumber, input) {
@@ -256,23 +216,6 @@ export function openStorage(dbPath: string): Storage {
         .run(rid, input.path, input.line, input.text, input.headSha);
       const row = db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(lastInsertRowid) as NoteRow;
       return rowToNote(row);
-    },
-
-    addReviewerReply(repoId, prNumber, id, input) {
-      const rid = reviewId(repoId, prNumber);
-      const result = db.prepare(`
-        INSERT INTO note_replies (note_id, author, text)
-        SELECT q.id, 'reviewer', ? FROM notes q WHERE q.id = ? AND q.review_id = ?
-      `).run(input.text, id, rid);
-      return result.changes === 0 ? null : replyById(result.lastInsertRowid);
-    },
-
-    addAgentReply(id, input) {
-      const result = db.prepare(`
-        INSERT INTO note_replies (note_id, author, text)
-        SELECT id, 'agent', ? FROM notes WHERE id = ?
-      `).run(input.text, id);
-      return result.changes === 0 ? null : replyById(result.lastInsertRowid);
     },
 
     deleteNote(repoId, prNumber, id) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
  *
  * Not the app's release version: releases happen far more often than the contract moves.
  */
-export const SERVICE_VERSION = "0.3.0";
+export const SERVICE_VERSION = "0.4.0";
 
 export const FileStatusSchema = z.enum(["A", "M", "D", "R"]);
 export type FileStatus = z.infer<typeof FileStatusSchema>;
@@ -52,22 +52,6 @@ export type PutFileState = z.infer<typeof PutFileStateSchema>;
 export const NoteStateSchema = z.enum(["open", "addressed", "resolved"]);
 export type NoteState = z.infer<typeof NoteStateSchema>;
 
-export const NoteReplyAuthorSchema = z.enum(["reviewer", "agent"]);
-export type NoteReplyAuthor = z.infer<typeof NoteReplyAuthorSchema>;
-
-export const NoteReplySchema = z.object({
-  id: z.number().int().positive(),
-  author: NoteReplyAuthorSchema,
-  text: z.string().min(1),
-  createdAt: z.string(),
-});
-export type NoteReply = z.infer<typeof NoteReplySchema>;
-
-export const NewNoteReplySchema = z.object({
-  text: z.string().trim().min(1),
-});
-export type NewNoteReply = z.infer<typeof NewNoteReplySchema>;
-
 export const NoteSchema = z.object({
   id: z.number().int().positive(),
   /** null for a note about the pull request as a whole rather than one file. */
@@ -83,7 +67,6 @@ export const NoteSchema = z.object({
   /** One-line summary an agent left when it marked the note addressed. */
   summary: z.string().nullable(),
   createdAt: z.string(),
-  replies: z.array(NoteReplySchema),
 });
 export type Note = z.infer<typeof NoteSchema>;
 


### PR DESCRIPTION
## Summary

- remove reviewer and agent reply threads from shared types, storage, REST, Electron IPC, and the notes UI
- restore the MCP contract to note pickup and durable completion only
- bump the app-to-service contract to 0.4.0 and update agent and operator documentation

## Readiness

- Simplify: clean
- Code review: clean, no unresolved findings
- UI audit: clean detector; existing keyboard, focus, semantic, responsive, and reduced-motion behavior retained
- Adversarial review: skipped; contract and schema change reviewed as the explicit risk area

## Test plan

- pnpm typecheck
- pnpm test (53 files, 322 tests)
- contract snapshot and exact MCP tool assertions
- git diff --check
