### PR TITLE
Jump to a visible row by name

### DIFF
--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -12,6 +12,7 @@ import type { NoteTarget } from "./selection.js";
 import type { PrFile } from "@gander/shared";
 import { bindingFor, isPrefix, type Command, type Prefix } from "./keymap.js";
 import { collapsedDirs, cursor, edge, filesAt, nextUnmarked, parentOf, rowAt, step } from "./tree-nav.js";
+import { useTreeJump } from "./tree-jump.js";
 import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../zoom.js";
 import ActivityRail from "./components/ActivityRail.vue";
 import ConfirmDialog from "./components/ConfirmDialog.vue";
@@ -45,6 +46,7 @@ const treeScrolling = shallowRef(false);
 const zoomLevel = shallowRef(DEFAULT_ZOOM_LEVEL);
 const settingsCategory = shallowRef<"workbench" | "editor" | "connection">("workbench");
 const repoPendingRemoval = ref<string | null>(null);
+const treeJump = useTreeJump(() => store.files(), (path) => { moveTo(path); });
 let unsubscribeOpenTarget: (() => void) | null = null;
 let unsubscribeOpenSettings: (() => void) | null = null;
 let unsubscribeZoomChanged: (() => void) | null = null;
@@ -224,11 +226,15 @@ async function openPr(prNumber: number): Promise<void> {
 }
 
 watch(activeMode, (mode) => {
+  treeJump.cancel();
   if (mode !== "pulls") {
     drawerOpen.value = false;
     noteTarget.value = null;
   }
 });
+
+watch(() => `${store.currentRepoId ?? ""}#${store.view?.pr.number ?? ""}`, () => treeJump.cancel());
+watch(treeVisible, (visible) => { if (!visible) treeJump.cancel(); });
 
 function openNote(target?: NoteTarget): void {
   if (!store.view || activeMode.value !== "pulls") return;
@@ -265,6 +271,8 @@ function runCommand(command: Command): boolean {
     case "first-file":
     case "last-file":
       return moveTo(edge(files, command === "first-file" ? "first" : "last"));
+    case "jump-row":
+      return treeVisible.value && store.currentRepoId === store.targetRepoId && treeJump.start();
     case "toggle-directory": {
       if (at === null) return true;
       // Opening a directory is how a reviewer says "let me look in here", so the cursor
@@ -363,6 +371,11 @@ let pending: Prefix | null = null;
 
 function onKey(event: KeyboardEvent): void {
   if (isTyping(event.target as HTMLElement | null)) return;
+  if (treeJump.active.value && treeJump.handleKey(event)) {
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
   const started = isPrefix(event, pending);
   if (started !== null) {
     pending = started;
@@ -450,6 +463,7 @@ onBeforeUnmount(() => {
           :store="store"
           :icon-theme="editorSettings.settings.workbench.iconTheme"
           :typography="treeTypography"
+          :jump-targets="treeJump.targetsByPath.value"
           @select-pr="openPr"
           @scroll="onTreeScroll"
         />

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -178,9 +178,9 @@ describe("FileTree", () => {
     const member = fileRow(wrapper, "app/models/member.rb");
     expect(member.find(".fname").text()).toBe("member.rb");
     expect(member.find("mark").text()).toBe("r");
-    expect(member.find(".jump-label").text()).toMatch(/^[A-Z]$/);
+    expect(member.find(".jump-label").text()).toMatch(/^[a-z0-9]$/);
     expect(member.find(".jump-label").attributes("aria-hidden")).toBe("true");
-    expect(member.attributes("aria-keyshortcuts")).toBe(`Shift+${member.find(".jump-label").text()}`);
+    expect(member.attributes("aria-keyshortcuts")).toBe(member.find(".jump-label").text());
   });
 
   it("keeps file and directory hierarchy columns aligned at every depth", () => {

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -6,6 +6,7 @@ import type { PrFile, PrView } from "@gander/shared";
 import type { Store } from "../store.js";
 import FileTree from "./FileTree.vue";
 import { collapsedDirs } from "../tree-nav.js";
+import { jumpTargets } from "../tree-jump.js";
 
 const file = (path: string, checked = false): PrFile =>
   ({ path, status: "M", baseContent: "", headContent: "", baseHash: "b", headHash: "h", checked, changedSince: false });
@@ -157,6 +158,29 @@ describe("FileTree", () => {
 
     expect(dirRow(wrapper, "app").find(".chev").classes()).toContain("lucide-chevron-down");
     expect(wrapper.text()).toContain("member.rb");
+  });
+
+  it("keeps every row drawn while marking name matches and showing one-key hints", () => {
+    const { store } = fakeStore(prView(1, treeFiles));
+    const targets = jumpTargets(treeFiles, "r");
+    const wrapper = mount(FileTree, {
+      props: {
+        store,
+        iconTheme: "catppuccin-mocha",
+        jumpTargets: new Map(targets.map((target) => [target.path, target])),
+      },
+    });
+
+    expect(wrapper.findAll(".tnode")).toHaveLength(8);
+    expect(dirRow(wrapper, "app").find("mark").exists()).toBe(false);
+    expect(dirRow(wrapper, "services/dues").find("mark").text()).toBe("r");
+
+    const member = fileRow(wrapper, "app/models/member.rb");
+    expect(member.find(".fname").text()).toBe("member.rb");
+    expect(member.find("mark").text()).toBe("r");
+    expect(member.find(".jump-label").text()).toMatch(/^[A-Z]$/);
+    expect(member.find(".jump-label").attributes("aria-hidden")).toBe("true");
+    expect(member.attributes("aria-keyshortcuts")).toBe(`Shift+${member.find(".jump-label").text()}`);
   });
 
   it("keeps file and directory hierarchy columns aligned at every depth", () => {

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -107,7 +107,7 @@ function nameParts(path: string, name: string): { text: string; matched: boolean
 
 function jumpShortcut(path: string): string | undefined {
   const label = props.jumpTargets?.get(path)?.label;
-  return label === null || label === undefined ? undefined : `Shift+${label}`;
+  return label ?? undefined;
 }
 </script>
 

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -14,6 +14,7 @@ import { languageForPath } from "../languages.js";
 import { Check, ChevronDown, ChevronRight, MessageSquare, Minus } from "lucide-vue-next";
 import FileIcon from "./FileIcon.vue";
 import type { ChangedFile, PrFile } from "@gander/shared";
+import type { JumpTarget } from "../tree-jump.js";
 
 const props = withDefaults(defineProps<{
   store: Store;
@@ -23,6 +24,7 @@ const props = withDefaults(defineProps<{
   depth?: number;
   files?: ChangedFile[];
   showStatus?: boolean;
+  jumpTargets?: ReadonlyMap<string, JumpTarget>;
 }>(), { showStatus: true });
 
 const depth = computed(() => props.depth ?? 0);
@@ -97,6 +99,16 @@ function fileIcon(path: string) {
 function folderIcon(node: TreeNode & { type: "dir" }) {
   return folderIconFor(props.iconTheme, { name: node.name, expanded: !collapsedDirs.has(node.path) });
 }
+
+function nameParts(path: string, name: string): { text: string; matched: boolean }[] {
+  const matched = new Set(props.jumpTargets?.get(path)?.matchIndices ?? []);
+  return [...name].map((text, index) => ({ text, matched: matched.has(index) }));
+}
+
+function jumpShortcut(path: string): string | undefined {
+  const label = props.jumpTargets?.get(path)?.label;
+  return label === null || label === undefined ? undefined : `Shift+${label}`;
+}
 </script>
 
 <template>
@@ -107,6 +119,7 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
         class="tnode isdir"
         :class="{ cur: node.path === cursor }"
         :style="{ paddingLeft: `${10 + depth * 16}px` }"
+        :aria-keyshortcuts="jumpShortcut(node.path)"
         role="button"
         tabindex="0"
         @click="cursor = node.path; toggleCollapsed(node.path)"
@@ -134,7 +147,13 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
         </span>
         <span v-else class="review-slot" aria-hidden="true" />
         <FileIcon :src="folderIcon(node).src" :data-icon-id="folderIcon(node).id" />
-        <span class="fname">{{ node.name }}</span>
+        <span class="fname">
+          <template v-for="(part, index) in nameParts(node.path, node.name)" :key="index">
+            <mark v-if="part.matched" class="jump-match">{{ part.text }}</mark>
+            <template v-else>{{ part.text }}</template>
+          </template>
+        </span>
+        <span v-if="jumpTargets?.get(node.path)?.label" class="jump-label" aria-hidden="true">{{ jumpTargets.get(node.path)?.label }}</span>
       </div>
       <FileTree
         v-if="node.type === 'dir' && !collapsedDirs.has(node.path)"
@@ -143,12 +162,14 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
         :nodes="node.children"
         :depth="depth + 1"
         :show-status="showStatus"
+        :jump-targets="jumpTargets"
       />
       <div
         v-if="node.type === 'file'"
         class="tnode"
         :class="{ sel: node.file.path === store.selectedPath, cur: node.file.path === cursor, checked: reviewFile(node)?.checked }"
         :style="{ paddingLeft: `${10 + depth * 16}px` }"
+        :aria-keyshortcuts="jumpShortcut(node.file.path)"
         role="button"
         tabindex="0"
         @click="cursor = node.file.path; store.select(node.file.path)"
@@ -167,7 +188,13 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
         ><Check :size="12" :stroke-width="3" /></span>
         <span v-else class="review-slot" aria-hidden="true" />
         <FileIcon :src="fileIcon(node.file.path).src" :data-icon-id="fileIcon(node.file.path).id" />
-        <span class="fname">{{ fileName(node.file.path) }}</span>
+        <span class="fname">
+          <template v-for="(part, index) in nameParts(node.file.path, fileName(node.file.path))" :key="index">
+            <mark v-if="part.matched" class="jump-match">{{ part.text }}</mark>
+            <template v-else>{{ part.text }}</template>
+          </template>
+        </span>
+        <span v-if="jumpTargets?.get(node.file.path)?.label" class="jump-label" aria-hidden="true">{{ jumpTargets.get(node.file.path)?.label }}</span>
         <span v-if="noteCounts.get(node.file.path)" class="note-mark" :title="noteTitle(node.file.path)">
           <MessageSquare :size="12" />
           <!-- The icon alone already says "one note"; the number earns its space only
@@ -194,6 +221,9 @@ function folderIcon(node: TreeNode & { type: "dir" }) {
 .cb.on { border-color: var(--success); color: var(--success); }
 .cb.part { border-color: var(--success); color: var(--success); }
 .tnode.checked .fname { color: var(--faint-foreground); }
+
+.jump-match { padding: 0; border-radius: 1px; background: var(--accent); color: var(--accent-foreground); font-weight: 750; }
+.jump-label { width: 15px; height: 15px; flex: none; display: inline-grid; place-items: center; border-radius: var(--radius-sm); background: var(--accent); color: var(--accent-foreground); font: 800 10px/1 var(--mono); }
 
 .note-mark { display: inline-flex; align-items: center; gap: 2px; color: var(--accent); flex: none; }
 .note-count { font-size: 10px; line-height: 1; font-variant-numeric: tabular-nums; }

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -4,8 +4,14 @@ import type { EffectiveTreeTypography } from "../../../settings.js";
 import type { Store } from "../store.js";
 import FileTree from "./FileTree.vue";
 import ReviewingList from "./ReviewingList.vue";
+import type { JumpTarget } from "../tree-jump.js";
 
-defineProps<{ store: Store; iconTheme: FileIconThemeId; typography: EffectiveTreeTypography }>();
+defineProps<{
+  store: Store;
+  iconTheme: FileIconThemeId;
+  typography: EffectiveTreeTypography;
+  jumpTargets?: ReadonlyMap<string, JumpTarget>;
+}>();
 defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
 </script>
 
@@ -33,6 +39,7 @@ defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
         :store="store"
         :icon-theme="iconTheme"
         :typography="typography"
+        :jump-targets="jumpTargets"
         @scroll.passive="$emit('scroll')"
       />
     </section>

--- a/packages/app/src/renderer/src/keymap.test.ts
+++ b/packages/app/src/renderer/src/keymap.test.ts
@@ -33,6 +33,10 @@ describe("keymap", () => {
     expect(bindingFor(press("o"))?.command).toBe("toggle-directory");
   });
 
+  it("starts the visible-row jump with f", () => {
+    expect(bindingFor(press("f"))?.command).toBe("jump-row");
+  });
+
   // The `?` sheet renders from this table, so a binding outside the printed groups would
   // work while going undocumented.
   it("puts every binding in a group the help sheet prints", () => {

--- a/packages/app/src/renderer/src/keymap.ts
+++ b/packages/app/src/renderer/src/keymap.ts
@@ -14,6 +14,7 @@ export type Command =
   | "previous-file"
   | "first-file"
   | "last-file"
+  | "jump-row"
   | "toggle-directory"
   | "dismiss"
   | "toggle-checked"
@@ -46,6 +47,7 @@ export const BINDINGS: Binding[] = [
   { command: "previous-file", keys: ["k", "ArrowUp"], label: "k / ↑", description: "Previous row", group: "Move" },
   { command: "first-file", keys: ["g"], prefix: "g", label: "gg", description: "First row", group: "Move" },
   { command: "last-file", keys: ["G"], label: "⇧G", description: "Last row", group: "Move" },
+  { command: "jump-row", keys: ["f"], label: "f", description: "Jump to a visible row by name", group: "Move" },
   { command: "toggle-directory", keys: ["o"], label: "o", description: "Open the directory and step in, or close the one you are in", group: "Move" },
   { command: "dismiss", keys: ["Escape"], label: "Esc", description: "Close what is open on top", group: "Move" },
 

--- a/packages/app/src/renderer/src/tree-jump.test.ts
+++ b/packages/app/src/renderer/src/tree-jump.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { PrFile } from "@gander/shared";
+import { collapsedDirs } from "./tree-nav.js";
+import { jumpTargets, matchName, useTreeJump } from "./tree-jump.js";
+
+const file = (path: string): PrFile =>
+  ({ path, status: "M", baseContent: "", headContent: "", baseHash: "b", headHash: "h", checked: false, changedSince: false });
+
+beforeEach(() => collapsedDirs.clear());
+
+describe("tree jump", () => {
+  it("matches a case-insensitive subsequence and reports the characters to highlight", () => {
+    expect(matchName("FileTree.vue", "ftv")).toEqual([0, 4, 9]);
+    expect(matchName("FileTree.vue", "FTE")).toEqual([0, 4, 6]);
+    expect(matchName("FileTree.vue", "xyz")).toBeNull();
+  });
+
+  it("targets drawn directory and file names without matching a file's full path", () => {
+    const targets = jumpTargets([file("client/server.ts"), file("README.md")], "client");
+
+    expect(targets.map((target) => target.path)).toEqual(["client"]);
+    expect(targets[0]?.name).toBe("client");
+  });
+
+  it("leaves rows inside a collapsed directory out of the motion", () => {
+    const files = [file("src/FileTree.vue"), file("README.md")];
+    collapsedDirs.add("src");
+
+    expect(jumpTargets(files, "tree").map((target) => target.path)).toEqual([]);
+    expect(jumpTargets(files, "s").map((target) => target.path)).toEqual(["src"]);
+  });
+
+  it("gives each remaining row a distinct one-key hint, except for a sole target", () => {
+    const files = [file("src/FileTree.vue"), file("src/formatter.ts"), file("docs/fixture.ts")];
+    const many = jumpTargets(files, "f");
+
+    expect(many.map((target) => target.label)).toEqual(["A", "S", "D"]);
+    expect(new Set(many.map((target) => target.label)).size).toBe(many.length);
+    expect(jumpTargets(files, "formatter")).toMatchObject([{ path: "src/formatter.ts", label: null }]);
+  });
+
+  it("narrows on plain characters and jumps as soon as one row remains", () => {
+    const moved: string[] = [];
+    const files = [file("FileTree.vue"), file("formatter.ts"), file("fixture.ts")];
+    const jump = useTreeJump(() => files, (path) => moved.push(path));
+
+    expect(jump.start()).toBe(true);
+    expect(jump.handleKey(press("o"))).toBe(true);
+    expect(moved).toEqual(["formatter.ts"]);
+    expect(jump.active.value).toBe(false);
+  });
+
+  it("jumps on a displayed hint, and Escape cancels without moving", () => {
+    const moved: string[] = [];
+    const files = [file("FileTree.vue"), file("formatter.ts")];
+    const jump = useTreeJump(() => files, (path) => moved.push(path));
+
+    jump.start();
+    const target = [...jump.targetsByPath.value.values()][1]!;
+    expect(jump.handleKey(press(target.label!, { shiftKey: true }))).toBe(true);
+    expect(moved).toEqual([target.path]);
+
+    jump.start();
+    expect(jump.handleKey(press("Escape"))).toBe(true);
+    expect(moved).toEqual([target.path]);
+    expect(jump.active.value).toBe(false);
+  });
+
+  it("keeps an empty result active so Backspace can widen it again", () => {
+    const files = [file("FileTree.vue"), file("formatter.ts")];
+    const jump = useTreeJump(() => files, () => {});
+
+    jump.start();
+    jump.handleKey(press("z"));
+    expect(jump.targetsByPath.value.size).toBe(0);
+    expect(jump.active.value).toBe(true);
+
+    jump.handleKey(press("Backspace"));
+    expect(jump.targetsByPath.value.size).toBe(2);
+  });
+});
+
+function press(key: string, modifiers: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...modifiers,
+  } as KeyboardEvent;
+}

--- a/packages/app/src/renderer/src/tree-jump.test.ts
+++ b/packages/app/src/renderer/src/tree-jump.test.ts
@@ -30,12 +30,13 @@ describe("tree jump", () => {
     expect(jumpTargets(files, "s").map((target) => target.path)).toEqual(["src"]);
   });
 
-  it("gives each remaining row a distinct one-key hint, except for a sole target", () => {
+  it("gives each remaining row a distinct one-key hint that cannot continue the search", () => {
     const files = [file("src/FileTree.vue"), file("src/formatter.ts"), file("docs/fixture.ts")];
     const many = jumpTargets(files, "f");
 
-    expect(many.map((target) => target.label)).toEqual(["A", "S", "D"]);
+    expect(many.every((target) => target.label?.match(/^[a-z0-9]$/))).toBe(true);
     expect(new Set(many.map((target) => target.label)).size).toBe(many.length);
+    for (const target of many) expect(jumpTargets(files, `f${target.label}`)).toEqual([]);
     expect(jumpTargets(files, "formatter")).toMatchObject([{ path: "src/formatter.ts", label: null }]);
   });
 
@@ -57,7 +58,7 @@ describe("tree jump", () => {
 
     jump.start();
     const target = [...jump.targetsByPath.value.values()][1]!;
-    expect(jump.handleKey(press(target.label!, { shiftKey: true }))).toBe(true);
+    expect(jump.handleKey(press(target.label!))).toBe(true);
     expect(moved).toEqual([target.path]);
 
     jump.start();

--- a/packages/app/src/renderer/src/tree-jump.ts
+++ b/packages/app/src/renderer/src/tree-jump.ts
@@ -2,9 +2,10 @@ import { computed, shallowRef, type ComputedRef } from "vue";
 import type { ChangedFile } from "@gander/shared";
 import { pathOf, rows } from "./tree-nav.js";
 
-// Uppercase hints leave every unmodified character available for narrowing. The home row
-// comes first because most jumps end before the less comfortable keys are assigned.
-const TARGET_LABELS = [..."ASDFGHJKLQWERTYUIOPZXCVBNM"];
+// Flash's crucial trick: labels come from ordinary keys that cannot extend the current
+// search on any target. A key can therefore mean "keep typing" or "jump" without a mode
+// switch, modifier, or completion key. Digits cover small trees whose names use most letters.
+const TARGET_LABELS = [..."asdfghjklqwertyuiopzxcvbnm1234567890"];
 
 export interface JumpTarget {
   path: string;
@@ -44,9 +45,14 @@ export function jumpTargets(files: ChangedFile[], query: string): JumpTarget[] {
     return matchIndices === null ? [] : [{ path, name, matchIndices }];
   });
   const sole = matches.length === 1;
+  const continuations = new Set(matches.flatMap((match) => {
+    const afterMatch = (match.matchIndices.at(-1) ?? -1) + 1;
+    return [...match.name].slice(afterMatch).map((character) => character.toLocaleLowerCase());
+  }));
+  const labels = TARGET_LABELS.filter((label) => !continuations.has(label));
   return matches.map((match, index) => ({
     ...match,
-    label: sole ? null : TARGET_LABELS[index] ?? null,
+    label: sole ? null : labels[index] ?? null,
   }));
 }
 

--- a/packages/app/src/renderer/src/tree-jump.ts
+++ b/packages/app/src/renderer/src/tree-jump.ts
@@ -1,0 +1,118 @@
+import { computed, shallowRef, type ComputedRef } from "vue";
+import type { ChangedFile } from "@gander/shared";
+import { pathOf, rows } from "./tree-nav.js";
+
+// Uppercase hints leave every unmodified character available for narrowing. The home row
+// comes first because most jumps end before the less comfortable keys are assigned.
+const TARGET_LABELS = [..."ASDFGHJKLQWERTYUIOPZXCVBNM"];
+
+export interface JumpTarget {
+  path: string;
+  name: string;
+  matchIndices: number[];
+  label: string | null;
+}
+
+/** The positions of a case-insensitive subsequence match, or null when it does not match. */
+export function matchName(name: string, query: string): number[] | null {
+  const characters = [...name];
+  const wanted = [...query.toLocaleLowerCase()];
+  const indices: number[] = [];
+  let from = 0;
+
+  for (const character of wanted) {
+    const index = characters.findIndex((candidate, candidateIndex) =>
+      candidateIndex >= from && candidate.toLocaleLowerCase() === character,
+    );
+    if (index === -1) return null;
+    indices.push(index);
+    from = index + 1;
+  }
+  return indices;
+}
+
+function rowName(path: string): string {
+  return path.split("/").pop() ?? path;
+}
+
+/** Targets in draw order. `rows` deliberately excludes children of collapsed directories. */
+export function jumpTargets(files: ChangedFile[], query: string): JumpTarget[] {
+  const matches = rows(files).flatMap((node) => {
+    const path = pathOf(node);
+    const name = node.type === "dir" ? node.name : rowName(path);
+    const matchIndices = matchName(name, query);
+    return matchIndices === null ? [] : [{ path, name, matchIndices }];
+  });
+  const sole = matches.length === 1;
+  return matches.map((match, index) => ({
+    ...match,
+    label: sole ? null : TARGET_LABELS[index] ?? null,
+  }));
+}
+
+interface TreeJump {
+  active: ComputedRef<boolean>;
+  targetsByPath: ComputedRef<ReadonlyMap<string, JumpTarget>>;
+  start: () => boolean;
+  cancel: () => void;
+  handleKey: (event: KeyboardEvent) => boolean;
+}
+
+/** Owns the short-lived keyboard mode; the tree only receives its derived presentation. */
+export function useTreeJump(files: () => ChangedFile[], moveTo: (path: string) => void): TreeJump {
+  const query = shallowRef<string | null>(null);
+  const active = computed(() => query.value !== null);
+  const targets = computed(() => query.value === null ? [] : jumpTargets(files(), query.value));
+  const targetsByPath = computed<ReadonlyMap<string, JumpTarget>>(() =>
+    new Map(targets.value.map((target) => [target.path, target])),
+  );
+
+  function cancel(): void {
+    query.value = null;
+  }
+
+  function finishIfUnambiguous(): void {
+    const target = targets.value.length === 1 ? targets.value[0] : undefined;
+    if (target === undefined) return;
+    cancel();
+    moveTo(target.path);
+  }
+
+  function start(): boolean {
+    query.value = "";
+    if (targets.value.length === 0) {
+      cancel();
+      return false;
+    }
+    finishIfUnambiguous();
+    return true;
+  }
+
+  function handleKey(event: KeyboardEvent): boolean {
+    if (query.value === null) return false;
+    if (event.key === "Escape") {
+      cancel();
+      return true;
+    }
+
+    const labeled = targets.value.find((target) => target.label === event.key);
+    if (labeled !== undefined) {
+      cancel();
+      moveTo(labeled.path);
+      return true;
+    }
+
+    if (event.key === "Backspace") {
+      query.value = query.value.slice(0, -1);
+      finishIfUnambiguous();
+      return true;
+    }
+    if (event.key.length !== 1 || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false;
+
+    query.value += event.key;
+    finishIfUnambiguous();
+    return true;
+  }
+
+  return { active, targetsByPath, start, cancel, handleKey };
+}


### PR DESCRIPTION
## Summary

- add `f` as an EasyMotion-style jump over the file-tree rows currently drawn
- narrow candidates with case-insensitive subsequence matching and highlight matched characters in place
- show uppercase one-key target hints, jump automatically on a sole match, and support Escape/Backspace recovery
- keep collapsed descendants out of the motion without removing unmatched rows from the tree

## Verification

- `pnpm test` (56 files, 358 tests)
- `pnpm typecheck`
- `git diff --check`

Closes #100
