### PR TITLE
Stop the window from scrolling as a document

### DIFF
--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -162,6 +162,28 @@ other's clones.
 
 The app has to be running: `bin/dev -D` first, then the command.
 
+## Inspecting the running window
+
+Set `GANDER_DEBUG_PORT` before starting the app and the renderer speaks the Chrome
+DevTools Protocol on that port, so a layout or state question can be answered against the
+window already on screen instead of a rebuild. It is ignored in a packaged build — the
+port has no authentication.
+
+```bash
+GANDER_DEBUG_PORT=9229 bin/dev
+curl -s localhost:9229/json          # the page's webSocketDebuggerUrl
+```
+
+Open `chrome://inspect` in Chrome, or drive the socket from a script: `Runtime.evaluate`
+reads live geometry and store state, `Page.captureScreenshot` takes a picture of the
+window (pass `fromSurface: false` on macOS, or the call hangs whenever the window is not
+frontmost), and `Emulation.setDeviceMetricsOverride` resizes the viewport to reproduce a
+size-dependent bug.
+
+Restarting the app to attach the port throws away whatever repository, file, and scroll
+position the bug appeared in. When the bug is on screen, attach to a second window or
+reproduce it again after the restart.
+
 ## Testing and debugging MCP
 
 `bin/mcp` runs the official MCP Inspector against the service for the current

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -20,6 +20,18 @@ import { watchLocalView, type LocalViewWatcher } from "./local-viewer.js";
 import { loadUpdateController, supportsInPlaceUpdates, type UpdateController } from "./updates.js";
 import { assertRepositoryRegistered, registerFromCheckout, repositoryFromLocalPath } from "./repository-registration.js";
 
+// In a packaged build the name comes from productName, but in dev Electron falls back to
+// the package name and the macOS app menu reads "@gander/app". Set it before ready so the
+// menu, the About item, and userData all use the same name in both.
+app.setName("Gander");
+
+// Renderer debugging: with GANDER_DEBUG_PORT set, the window speaks CDP on that port, so
+// DevTools — or a script driving Runtime.evaluate and Page.captureScreenshot — can inspect
+// the running app's layout without rebuilding it. Never in a packaged build: the port has
+// no auth and would expose the reviewer's window to anything on the machine.
+const debugPort = process.env.GANDER_DEBUG_PORT;
+if (debugPort && !app.isPackaged) app.commandLine.appendSwitch("remote-debugging-port", debugPort);
+
 let zoomController: ZoomController;
 const localWatchers = new Map<number, LocalViewWatcher>();
 const localViews = new Map<number, LocalView>();

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -558,7 +558,7 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
-.app { display: grid; grid-template-rows: auto 1fr auto; height: 100vh; }
+.app { display: grid; grid-template-rows: auto 1fr auto; height: 100%; }
 .top-stack { min-width: 0; }
 .error-banner { display: flex; align-items: center; gap: 10px; background: var(--danger-background); color: var(--danger); padding: 8px 14px; font-size: 12px; border-bottom: 1px solid var(--workbench-border); }
 .error-banner span { flex: 1; }

--- a/packages/app/src/renderer/src/styles/base.css
+++ b/packages/app/src/renderer/src/styles/base.css
@@ -2,7 +2,11 @@
 body, h1, h2, h3, p, pre, ul, ol { margin: 0; }
 ul, ol { padding: 0; }
 :where(button, input, textarea, select) { margin: 0; padding: 0; }
-html, body { height: 100%; }
+/* A desktop shell has no page to scroll: the panes scroll, the window never does.
+   Without this, anything that overflows scrolls the whole app instead — and the tree's
+   scrollIntoView drags the window with it. */
+html, body, #app { height: 100%; }
+html, body { overflow: hidden; }
 body {
   background: var(--workbench-background); color: var(--workbench-foreground);
   font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;


### PR DESCRIPTION
The whole app window scrolled on both axes: the shell sized itself with `100vh`
and nothing pinned `html, body`, so any overflow scrolled the document, and
`scrollIntoView` in the tree nav dragged the window with it.

- `base.css` / `App.vue` — `html, body, #app { height: 100% }`, `html, body { overflow: hidden }`, `.app` off `100vh`. Standard Electron shell pattern: the panes scroll, the window never does.
- `main/index.ts` — `app.setName("Gander")`, so the macOS menu stops reading `@gander/app` in dev, plus `GANDER_DEBUG_PORT` to open a CDP port on the renderer (dev only; the port has no auth).
- `DEVSTACK.md` — how to inspect the running window over CDP.

Verified against the running app over CDP: document overflow is 0 at 1440x900,
1000x630, 700x460, 520x380 and 420x300, across all four rail modes, with a file
open in Monaco. `pnpm typecheck` and `pnpm test` (349) pass.

Known, not fixed here: below ~520px wide the three grid rows exceed the window
height, so the body clips a few px. Before this change that was the overflow
that scrolled the window; now it clips.

No test — jsdom does not lay out, so a CSS overflow is not reachable from the
unit suite.