### PR TITLE
Ask GitHub again for the open pull requests

### DIFF
--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -406,7 +406,11 @@ async function refreshOnce(): Promise<void> {
 const timer = setInterval(() => void refreshOnce(), POLL_MS);
 const HEALTH_MS = 15_000;
 const healthTimer = setInterval(() => void store.checkService(), HEALTH_MS);
-const onFocus = (): void => { void store.checkService(); void refreshOnce(); };
+const onFocus = (): void => { void store.checkService(); void refreshOnce();
+  // A pull request opened elsewhere — a browser, an agent, `gh pr create` — is the
+  // usual reason the reviewer comes back to the window at all.
+  void store.refreshPrs();
+};
 window.addEventListener("focus", onFocus);
 onBeforeUnmount(() => {
   clearInterval(timer);

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -59,6 +59,7 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
     showLocalSurface() {},
     async refresh() {},
     async fetchNow() {},
+    async refreshPrs() {},
     async reviewedSnapshot() { return null; },
     async imagePreview() { return null; },
     async addNote() {},

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ref } from "vue";
+import { RefreshCw } from "lucide-vue-next";
 import type { FileIconThemeId } from "../../../file-icon-themes.js";
 import type { EffectiveTreeTypography } from "../../../settings.js";
 import type { Store } from "../store.js";
@@ -6,13 +8,23 @@ import FileTree from "./FileTree.vue";
 import ReviewingList from "./ReviewingList.vue";
 import type { JumpTarget } from "../tree-jump.js";
 
-defineProps<{
+const props = defineProps<{
   store: Store;
   iconTheme: FileIconThemeId;
   typography: EffectiveTreeTypography;
   jumpTargets?: ReadonlyMap<string, JumpTarget>;
 }>();
 defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
+
+const reloading = ref(false);
+async function reload(): Promise<void> {
+  reloading.value = true;
+  try {
+    await props.store.refreshPrs();
+  } finally {
+    reloading.value = false;
+  }
+}
 </script>
 
 <template>
@@ -21,6 +33,14 @@ defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
       <header>
         <h1>Pull Requests</h1>
         <span>{{ store.prs.length }}</span>
+        <button
+          type="button"
+          class="reload"
+          :disabled="reloading || store.targetRepoId === null"
+          aria-label="Refresh pull requests"
+          title="Refresh pull requests"
+          @click="reload"
+        ><RefreshCw :size="13" :class="{ spin: reloading }" /></button>
       </header>
       <ReviewingList
         v-if="store.prs.length"
@@ -54,6 +74,13 @@ defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
 header { position: sticky; inset-block-start: 0; z-index: 1; height: 35px; box-sizing: border-box; display: flex; align-items: center; gap: 8px; padding-inline: 12px; background: var(--panel-background); border-bottom: 1px solid var(--workbench-border); }
 h1, h2 { margin: 0; color: var(--muted-foreground); font-size: 10px; font-weight: 700; letter-spacing: .55px; text-transform: uppercase; }
 header span { margin-left: auto; color: var(--faint-foreground); font: 10px var(--mono); }
+.reload { display: flex; padding: 2px; border: 0; border-radius: var(--radius-sm); background: none; color: var(--faint-foreground); cursor: pointer; }
+.reload:hover:not(:disabled) { color: var(--workbench-foreground); background: var(--elevated-background); }
+.reload:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.reload:disabled { opacity: .5; cursor: default; }
+.reload .spin { animation: spin .8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .reload .spin { animation: none; } }
 .empty { margin: 0; padding: 12px; color: var(--faint-foreground); font-size: 11px; }
 .files-section :deep(.tree.root) { flex: 1; min-height: 0; overflow: auto; scrollbar-gutter: stable; }
 .pull-sidebar :deep(.reviewing-list) { padding: 5px 0 8px; }

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -418,6 +418,48 @@ describe("store", () => {
     expect(store.view).not.toBeNull();
   });
 
+  it("refreshPrs picks up a pull request opened after the repository was targeted", async () => {
+    // The list arrives once, when the repository becomes the target. Without a way to ask
+    // again, a pull request opened in a browser or by an agent never reaches the reviewer.
+    let open = [{ ...prView().pr, number: 1, title: "First", reviewProgress: null }];
+    const store = createStore(fakeApi({ listPrs: async () => open }));
+    await store.loadRepos();
+    await store.selectRepo("acme/atlas");
+    expect(store.prs.map((pr) => pr.number)).toEqual([1]);
+
+    open = [...open, { ...prView().pr, number: 2, title: "Second", reviewProgress: null }];
+    await store.refreshPrs();
+
+    expect(store.prs.map((pr) => pr.number)).toEqual([1, 2]);
+  });
+
+  it("refreshPrs leaves an error on screen and never flags the workbench busy", async () => {
+    // It also runs on window focus, where clearing the reviewer's error or flashing a
+    // spinner would be an interruption they did not ask for.
+    let fail = true;
+    const store = createStore(fakeApi({
+      listPrs: async () => { if (fail) throw new Error("GitHub API 403: rate limited"); return []; },
+    }));
+    await store.loadRepos();
+    await store.selectRepo("acme/atlas");
+    expect(store.error).toMatch(/403/);
+
+    fail = false;
+    const pending = store.refreshPrs();
+    expect(store.busy).toBe(false);
+    await pending;
+
+    expect(store.error).toMatch(/403/);
+    expect(store.busy).toBe(false);
+  });
+
+  it("refreshPrs does nothing when no repository is targeted", async () => {
+    let calls = 0;
+    const store = createStore(fakeApi({ listPrs: async () => { calls += 1; return []; } }));
+    await store.refreshPrs();
+    expect(calls).toBe(0);
+  });
+
   it("busy is true only while a long-running action is in flight, and clears even on failure", async () => {
     let resolveOpen!: () => void;
     const store = createStore(fakeApi({

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -47,6 +47,15 @@ export interface Store {
   refresh(): Promise<void>;
   /** The reviewer pressing Fetch origin: same work as refresh, but it clears a stale error. */
   fetchNow(): Promise<void>;
+  /**
+   * Re-asks GitHub which pull requests are open on the target repository.
+   *
+   * The list arrives once, when a repository becomes the target. A pull request opened
+   * after that — in a browser, by an agent, by `gh pr create` — never appears, and there is
+   * nothing in the workbench to ask again with, so the reviewer is left with a list that
+   * quietly disagrees with GitHub.
+   */
+  refreshPrs(): Promise<void>;
   setChecked(path: string, checked: boolean): Promise<void>;
   setCheckedMany(paths: string[], checked: boolean): Promise<void>;
   reviewedSnapshot(path: string): Promise<string | null>;
@@ -279,6 +288,13 @@ export function createStore(api: GanderApi): Store {
     },
     async fetchNow() {
       await userAction(() => store.refresh());
+    },
+    async refreshPrs() {
+      const repoId = store.targetRepoId;
+      if (repoId === null) return;
+      // Deliberately quiet: no busy flag and no error reset, because this also runs when the
+      // window regains focus, where a spinner and a cleared error would arrive unasked for.
+      await guard(() => loadContexts(repoId));
     },
     async setChecked(path: string, checked: boolean) {
       await guard(async () => {


### PR DESCRIPTION
Open a pull request while Gander is running and it never shows up. The list is
fetched once, when a repository becomes the target (`store.ts`, the sole caller of
`loadContexts`), and nothing refreshes it. Picking the worktree the branch is on
does not help either — the list is every open pull request on the repository, so
the worktree selector looks related but is not.

- `store.refreshPrs()` re-asks GitHub for the target repository's pull requests.
- A refresh button in the Pull Requests sidebar header, spinning while it runs.
- The same call on window focus — coming back from a browser or an agent is
  exactly when the list is out of date.

`refreshPrs` is deliberately quiet: no busy flag, no cleared error, because
regaining focus is not an action the reviewer took.

Three store tests cover it: a pull request opened after targeting shows up on
refresh, an existing error survives a refresh and the workbench never flags busy,
and nothing is fetched with no repository targeted.