### PR TITLE
Name the pull request open on a worktree's branch

### DIFF
--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -432,6 +432,7 @@ onBeforeUnmount(() => {
         :integrated-title-bar="integratedTitleBar"
         @select-repo="selectTargetRepo"
         @select-worktree="selectTargetWorktree"
+        @select-pr="openPr"
         @open-folder="chooseRepo()"
         @locate-repo="chooseRepo($event)"
         @remove-repo="repoPendingRemoval = $event"

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { RefreshCw } from "lucide-vue-next";
+import { RefreshCw } from "@lucide/vue";
 import type { FileIconThemeId } from "../../../file-icon-themes.js";
 import type { EffectiveTreeTypography } from "../../../settings.js";
 import type { Store } from "../store.js";

--- a/packages/app/src/renderer/src/components/TargetBar.test.ts
+++ b/packages/app/src/renderer/src/components/TargetBar.test.ts
@@ -4,6 +4,11 @@ import { describe, expect, it } from "vitest";
 import type { Store } from "../store.js";
 import TargetBar from "./TargetBar.vue";
 
+const pr = (number: number, headRef: string, title: string) => ({
+  number, title, body: "", draft: false, baseRef: "main", baseSha: "a", headRef, headSha: "b",
+  stack: null, reviewProgress: null,
+});
+
 const store = {
   repos: [
     { repoId: "acme/atlas", url: "https://github.com/acme/atlas", localPath: "/tmp/atlas" },
@@ -13,10 +18,13 @@ const store = {
     { path: "/tmp/atlas", branch: "main", headSha: "a".repeat(40), locked: false },
     { path: "/tmp/atlas-feature", branch: "feature/search", headSha: "b".repeat(40), locked: false },
   ],
+  prs: [pr(7, "feature/search", "Search across notes")],
   targetRepoId: "acme/atlas",
   targetWorktreePath: "/tmp/atlas-feature",
+  currentRepoId: null,
+  view: null,
   busy: false,
-} as Store;
+} as unknown as Store;
 
 describe("TargetBar", () => {
   it("keeps repository and worktree selection above the workspace modes", async () => {
@@ -30,7 +38,7 @@ describe("TargetBar", () => {
     expect(wrapper.get("#repositories-heading").text()).toBe("Repositories");
     expect(wrapper.get("#worktrees-heading").text()).toBe("Worktrees");
 
-    await wrapper.get(".worktree-row:nth-of-type(1)").trigger("click");
+    await wrapper.findAll(".worktree-row")[0]!.trigger("click");
     expect(wrapper.emitted("selectWorktree")).toEqual([["/tmp/atlas"]]);
   });
 
@@ -54,5 +62,38 @@ describe("TargetBar", () => {
     ]);
     await actions[0]!.trigger("click");
     expect(wrapper.emitted("locateRepo")).toEqual([["acme/atlas"]]);
+  });
+});
+
+describe("TargetBar and its pull requests", () => {
+  it("names the pull request open on a worktree's branch, and opens it", async () => {
+    // The branch and its pull request are the same work. Leaving them unconnected made the
+    // pull request list look wrong to a reviewer who had just selected that branch.
+    const wrapper = mount(TargetBar, { props: { store, integratedTitleBar: false } });
+    await wrapper.get("button[aria-controls='target-picker']").trigger("click");
+
+    const badges = wrapper.findAll(".pr-badge");
+    expect(badges).toHaveLength(1); // only feature/search has one open
+    expect(badges[0]!.text()).toBe("#7");
+
+    await badges[0]!.trigger("click");
+    expect(wrapper.emitted("selectPr")).toEqual([[7]]);
+    expect(wrapper.emitted("selectWorktree")).toBeUndefined(); // the row underneath stays untouched
+  });
+
+  it("names the pull request being reviewed rather than a worktree nobody is looking at", async () => {
+    const reviewing = { ...store, currentRepoId: "acme/atlas", view: { pr: pr(7, "feature/search", "Search across notes"), files: [], notes: [] } } as unknown as Store;
+    const wrapper = mount(TargetBar, { props: { store: reviewing, integratedTitleBar: false } });
+
+    const trigger = wrapper.get("button[aria-controls='target-picker']");
+    expect(trigger.text()).toContain("#7 Search across notes");
+    expect(trigger.text()).not.toContain("feature/search");
+  });
+
+  it("keeps naming the worktree while a pull request from another repository is loaded", async () => {
+    const elsewhere = { ...store, currentRepoId: "acme/beacon", view: { pr: pr(9, "other", "Elsewhere"), files: [], notes: [] } } as unknown as Store;
+    const wrapper = mount(TargetBar, { props: { store: elsewhere, integratedTitleBar: false } });
+
+    expect(wrapper.get("button[aria-controls='target-picker']").text()).toContain("feature/search");
   });
 });

--- a/packages/app/src/renderer/src/components/TargetBar.vue
+++ b/packages/app/src/renderer/src/components/TargetBar.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { ChevronDown, FolderGit2, FolderOpen, FolderPlus, GitBranch, Trash2 } from "@lucide/vue";
+import { ChevronDown, FolderGit2, FolderOpen, FolderPlus, GitBranch, GitPullRequest, Trash2 } from "@lucide/vue";
 import type { Store } from "../store.js";
 
 const props = defineProps<{ store: Store; integratedTitleBar: boolean }>();
 const emit = defineEmits<{
   selectRepo: [repoId: string];
   selectWorktree: [path: string];
+  selectPr: [prNumber: number];
   openFolder: [];
   locateRepo: [repoId: string];
   removeRepo: [repoId: string];
@@ -17,6 +18,20 @@ const root = ref<HTMLElement | null>(null);
 const selectedRepo = computed(() => props.store.repos.find((repo) => repo.repoId === props.store.targetRepoId) ?? null);
 const selectedWorktree = computed(() => props.store.worktrees.find((worktree) => worktree.path === props.store.targetWorktreePath) ?? null);
 const repoName = computed(() => selectedRepo.value?.repoId.split("/").at(-1) ?? "Open repository");
+
+/**
+ * The pull request open on each worktree's branch.
+ *
+ * A worktree and a pull request are the same piece of work seen from two sides, and the
+ * picker is where the reviewer already is when they go looking for one. Without this the
+ * branch and its pull request appear unrelated: selecting the branch a pull request is on
+ * changes nothing about the pull request list, which reads as the list being wrong.
+ */
+const prByBranch = computed(() => new Map(props.store.prs.map((pr) => [pr.headRef, pr])));
+/** The pull request being reviewed, when it belongs to the repository the bar names. */
+const openPr = computed(() => props.store.currentRepoId === props.store.targetRepoId
+  ? props.store.view?.pr ?? null
+  : null);
 const worktreeName = computed(() => selectedWorktree.value?.branch
   ?? selectedWorktree.value?.path.split("/").at(-1)
   ?? null);
@@ -24,6 +39,7 @@ const worktreeName = computed(() => selectedWorktree.value?.branch
 function close(): void { open.value = false; }
 function chooseRepo(repoId: string): void { emit("selectRepo", repoId); close(); }
 function chooseWorktree(path: string): void { emit("selectWorktree", path); close(); }
+function choosePr(prNumber: number): void { emit("selectPr", prNumber); close(); }
 function openFolder(): void { emit("openFolder"); close(); }
 function locateRepo(repoId: string): void { emit("locateRepo", repoId); close(); }
 function removeRepo(repoId: string): void { emit("removeRepo", repoId); close(); }
@@ -55,7 +71,12 @@ onBeforeUnmount(() => {
     >
       <FolderGit2 :size="15" />
       <strong>{{ repoName }}</strong>
-      <template v-if="worktreeName">
+      <template v-if="openPr">
+        <span class="separator">/</span>
+        <GitPullRequest :size="14" />
+        <span class="worktree-name">#{{ openPr.number }} {{ openPr.title }}</span>
+      </template>
+      <template v-else-if="worktreeName">
         <span class="separator">/</span>
         <GitBranch :size="14" />
         <span class="worktree-name">{{ worktreeName }}</span>
@@ -85,19 +106,29 @@ onBeforeUnmount(() => {
 
       <section v-if="store.targetRepoId" aria-labelledby="worktrees-heading">
         <h2 id="worktrees-heading">Worktrees</h2>
-        <button
-          v-for="worktree in store.worktrees"
-          :key="worktree.path"
-          class="picker-row worktree-row"
-          :class="{ selected: worktree.path === store.targetWorktreePath }"
-          type="button"
-          :aria-current="worktree.path === store.targetWorktreePath ? 'true' : undefined"
-          @click="chooseWorktree(worktree.path)"
-        >
-          <GitBranch :size="15" />
-          <span>{{ worktree.branch ?? worktree.headSha.slice(0, 8) }}</span>
-          <small>{{ worktree.path }}</small>
-        </button>
+        <div v-for="worktree in store.worktrees" :key="worktree.path" class="row-pair">
+          <button
+            class="picker-row worktree-row"
+            :class="{ selected: worktree.path === store.targetWorktreePath }"
+            type="button"
+            :aria-current="worktree.path === store.targetWorktreePath ? 'true' : undefined"
+            @click="chooseWorktree(worktree.path)"
+          >
+            <GitBranch :size="15" />
+            <span>{{ worktree.branch ?? worktree.headSha.slice(0, 8) }}</span>
+            <small>{{ worktree.path }}</small>
+          </button>
+          <button
+            v-if="worktree.branch && prByBranch.get(worktree.branch)"
+            class="pr-badge"
+            type="button"
+            :title="`Review #${prByBranch.get(worktree.branch)!.number} ${prByBranch.get(worktree.branch)!.title}`"
+            :aria-label="`Review pull request #${prByBranch.get(worktree.branch)!.number} on ${worktree.branch}`"
+            @click="choosePr(prByBranch.get(worktree.branch)!.number)"
+          >
+            <GitPullRequest :size="13" />#{{ prByBranch.get(worktree.branch)!.number }}
+          </button>
+        </div>
         <p v-if="store.worktrees.length === 0" class="picker-empty">No local worktrees are known for this repository.</p>
       </section>
 
@@ -138,6 +169,11 @@ onBeforeUnmount(() => {
 .target-picker h2 { margin: 0; padding: 5px 12px 4px; color: var(--faint-foreground); font-size: 10px; font-weight: 700; letter-spacing: .55px; text-transform: uppercase; }
 .picker-row, .open-folder, .repository-action { width: 100%; display: grid; grid-template-columns: 17px minmax(90px, auto) minmax(0, 1fr); align-items: center; gap: 8px; min-height: 30px; padding: 5px 12px; border: 0; background: none; color: var(--muted-foreground); text-align: left; font: inherit; cursor: pointer; }
 .picker-row.selected { background: var(--selection-background); color: var(--workbench-foreground); }
+.row-pair { display: flex; align-items: stretch; }
+.row-pair .picker-row { flex: 1; min-width: 0; }
+.pr-badge { flex: none; display: flex; align-items: center; gap: 4px; margin-right: 8px; padding: 0 7px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--elevated-background); color: var(--muted-foreground); font: 11px var(--mono); cursor: pointer; }
+.pr-badge:hover { border-color: var(--accent); color: var(--accent); }
+.pr-badge:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .picker-row:hover, .open-folder:hover, .repository-action:hover { background: var(--hover-background); color: var(--workbench-foreground); }
 .picker-row small { overflow: hidden; color: var(--faint-foreground); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
 .picker-row span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
Selecting `gander / improve` in the target bar and then not finding #104 in the
list reads as the list being broken. It isn't — the list is repository-wide, and
the bar never said that the branch it names has a pull request open on it.

- Worktree rows in the picker carry a `#104` badge when a pull request is open on
  that branch; pressing it opens that review, leaving the worktree selection alone.
- The bar names the pull request under review instead of a worktree nobody is
  looking at, and goes back to the worktree when the review is closed or belongs
  to another repository.

Not the larger change the spec describes (one "Reviewing ▾" listing pull requests
and worktrees together) — that would put the pull request list in two places at
once, which is worth deciding separately.

Also fixes `PullRequestSidebar.vue` still importing `lucide-vue-next`: #104 renamed
the package to `@lucide/vue` and #105 added an import under the old name, so master
currently fails `pnpm typecheck`.

Verified in the running app: the `91-build-a-proper-end-to` worktree shows `#103`,
pressing it opens the review and the bar changes to
`gander / #103 Build a modular Electron end-to-end suite`. `pnpm typecheck` and
`pnpm test` (370) pass.