### PR TITLE
Extend Electron end-to-end coverage

### DIFF
--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -22,10 +22,11 @@ while preserving the checkout's process and config isolation.
 | End-to-end tests (build + run) | `pnpm test:e2e` |
 | Re-run end-to-end tests without rebuilding | `pnpm test:e2e:run [file]` |
 
-`pnpm test:e2e` builds the Electron app once, then Playwright runs six independent
-window scenarios: settings persistence, checkoff persistence, changed-image
-decoding, live local changes, the real `bin/gander` command, and the concurrent
-clone regression. Each spec starts with a fresh Electron process, config,
+`pnpm test:e2e` builds the Electron app once, then Playwright runs independent
+window scenarios across persistence, content-based review state, notes and MCP,
+service failure and compatibility, target isolation, keyboard focus, images,
+local changes, the real `bin/gander` command, and clone concurrency. Each spec
+starts with a fresh Electron process, config,
 user-data directory, real service and SQLite database, local GitHub fake, and real
 temporary Git repositories. A spec restarts only its own app when restart is the
 behavior under test.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -100,9 +100,10 @@ Interface work is tracked as GitHub issues.
 ## Testing
 
 `pnpm test` runs the unit suites against real git repositories and real service
-instances. `pnpm test:e2e` builds the Electron app once, then Playwright runs six
-independent, clean-world scenarios covering settings and checkoff persistence,
-changed images, live local worktrees, the real `bin/gander` command, and the clone
-race that reached a person before it reached a test. The suite uses real Git,
+instances. `pnpm test:e2e` builds the Electron app once, then Playwright runs
+independent, clean-world scenarios covering persistence, content-based review
+state, notes and MCP, service recovery and compatibility, target isolation,
+keyboard focus, images, local worktrees, the real `bin/gander` command, and clone
+concurrency. The suite uses real Git,
 Fastify, SQLite, IPC, preload, and renderer boundaries; only GitHub's HTTP endpoint
 is represented by a local fake.

--- a/packages/app/e2e/content-review-state.spec.ts
+++ b/packages/app/e2e/content-review-state.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "./fixtures/test.js";
+import { ReviewDriver } from "./drivers/review.js";
+
+test("keeps identical files reviewed and unchecks content changed by a force-push", async ({ world }) => {
+  const repository = await world.addRepository({ repoId: "acme/content-state" });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+
+  await review.open(repository.title);
+  await review.checkFile("a.rb");
+  await review.checkFile("b.rb");
+  await review.selectFile("a.rb");
+
+  await world.rewritePullRequest(repository, {
+    "a.rb": "class A\n  def go; puts :changed; end\nend\n",
+  });
+  await review.fetchOrigin();
+
+  await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "false");
+  await expect(review.file("b.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "true");
+  await expect(app.page.getByText("Changed since your review — un-checked automatically.", { exact: false })).toBeVisible();
+  await expect(app.page.getByRole("tab", { name: "Changes since your review" })).toBeVisible();
+});

--- a/packages/app/e2e/drivers/mcp.ts
+++ b/packages/app/e2e/drivers/mcp.ts
@@ -1,0 +1,44 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+interface NotePayload {
+  noteCounts: { open: number; addressed: number; resolved: number };
+  notes: Array<{ id: number; file: string | null; line: number | null; text: string; state: string }>;
+}
+
+function textOf(result: { content?: unknown }): string {
+  const [first] = (result.content ?? []) as Array<{ type: string; text?: string }>;
+  return first?.text ?? "";
+}
+
+export class McpDriver {
+  private readonly client = new Client({ name: "gander-e2e-agent", version: "1.0.0" });
+
+  constructor(private readonly serviceUrl: string, private readonly token: string) {}
+
+  async connect(): Promise<this> {
+    await this.client.connect(new StreamableHTTPClientTransport(new URL(`${this.serviceUrl}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${this.token}` } },
+    }));
+    return this;
+  }
+
+  async notes(repo: string, branch: string): Promise<NotePayload> {
+    const result = await this.client.callTool({
+      name: "get_review_notes",
+      arguments: { repo, branch, includeAddressed: true, includeResolved: true },
+    });
+    return JSON.parse(textOf(result as { content?: unknown })) as NotePayload;
+  }
+
+  async markAddressed(id: number, commitRef: string, summary: string): Promise<void> {
+    await this.client.callTool({
+      name: "mark_note_addressed",
+      arguments: { id, commitRef, summary },
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+}

--- a/packages/app/e2e/drivers/review.ts
+++ b/packages/app/e2e/drivers/review.ts
@@ -35,6 +35,23 @@ export class ReviewDriver {
     await expect(checkbox).toHaveAttribute("aria-checked", "true");
   }
 
+  async fetchOrigin(): Promise<void> {
+    await this.page.getByRole("button", { name: "Fetch origin" }).click();
+  }
+
+  async addNote(text: string): Promise<void> {
+    await this.page.getByRole("button", { name: "Add note (N)" }).click();
+    const input = this.page.getByPlaceholder("What needs answering or changing here?");
+    await input.fill(text);
+    await input.press("Enter");
+    await expect(input).toHaveCount(0);
+  }
+
+  async openNotes(): Promise<void> {
+    await this.page.getByRole("button", { name: "Notes", exact: true }).click();
+    await expect(this.page.getByRole("heading", { name: "Notes", exact: true })).toBeVisible();
+  }
+
   async expectProgress(done: number, total: number): Promise<void> {
     await expect(this.page.locator(".context-toolbar .progress")).toHaveText(`${done}/${total} reviewed`);
   }

--- a/packages/app/e2e/drivers/settings.ts
+++ b/packages/app/e2e/drivers/settings.ts
@@ -18,6 +18,11 @@ export class SettingsDriver {
     await expect(this.page.getByRole("heading", { name: "Editor", exact: true })).toBeVisible();
   }
 
+  async openConnectionCategory(): Promise<void> {
+    await this.page.getByRole("button", { name: "Connection", exact: true }).click();
+    await expect(this.page.getByRole("heading", { name: "Connection", exact: true })).toBeVisible();
+  }
+
   async setEditorFont(family: string, size: number): Promise<void> {
     const familyInput = this.page.locator('input[name="editor.fontFamily"]');
     await familyInput.fill(family);

--- a/packages/app/e2e/drivers/workbench.ts
+++ b/packages/app/e2e/drivers/workbench.ts
@@ -20,4 +20,11 @@ export class WorkbenchDriver {
     await expect(trigger).toContainText(branch);
     await expect(this.page.locator(".context-title span")).toHaveText(branch);
   }
+
+  async selectRepository(repoId: string): Promise<void> {
+    const trigger = this.page.locator('button[aria-controls="target-picker"]');
+    await trigger.click();
+    await this.page.locator(".picker-row").filter({ hasText: repoId }).click();
+    await expect(trigger).toContainText(repoId.split("/").at(-1) ?? repoId);
+  }
 }

--- a/packages/app/e2e/fixtures/github-server.ts
+++ b/packages/app/e2e/fixtures/github-server.ts
@@ -60,6 +60,14 @@ export class GithubServer {
     this.repositories.set(repoId, { pullRequests, onList, requestCount: 0 });
   }
 
+  updatePullRequest(repoId: string, pullRequest: PullRequestFixture): void {
+    const repository = this.repositories.get(repoId);
+    if (!repository) throw new Error(`${repoId} is not registered with the GitHub fixture`);
+    const index = repository.pullRequests.findIndex((candidate) => candidate.number === pullRequest.number);
+    if (index < 0) throw new Error(`${repoId}#${pullRequest.number} is not registered with the GitHub fixture`);
+    repository.pullRequests[index] = pullRequest;
+  }
+
   requestsFor(repoId: string): number {
     return this.repositories.get(repoId)?.requestCount ?? 0;
   }

--- a/packages/app/e2e/fixtures/repository.ts
+++ b/packages/app/e2e/fixtures/repository.ts
@@ -1,4 +1,5 @@
-import { rm } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import type { FixtureRepo } from "../../src/main/fixtures.js";
 import { makeFixtureRepo } from "../../src/main/fixtures.js";
 
@@ -38,4 +39,25 @@ export async function removeRepositoryFixture(repository: RepositoryFixture): Pr
     await repository.checkout.git(["worktree", "remove", "--force", repository.worktreePath]);
   }
   await rm(repository.checkout.dir, { recursive: true, force: true });
+}
+
+/** Rewrites the pull-request head while leaving unchanged files byte-identical. */
+export async function amendPullRequest(
+  repository: RepositoryFixture,
+  files: Record<string, FixtureContent>,
+): Promise<void> {
+  await repository.checkout.git(["checkout", "feature"]);
+  try {
+    for (const [path, content] of Object.entries(files)) {
+      const destination = join(repository.checkout.dir, path);
+      await mkdir(dirname(destination), { recursive: true });
+      await writeFile(destination, content);
+    }
+    await repository.checkout.git(["add", "-A"]);
+    await repository.checkout.git(["commit", "--amend", "-m", "rewritten feature"]);
+    repository.headSha = await repository.checkout.git(["rev-parse", "HEAD"]);
+    await repository.checkout.git(["update-ref", `refs/pull/${repository.number}/head`, repository.headSha]);
+  } finally {
+    await repository.checkout.git(["checkout", "main"]);
+  }
 }

--- a/packages/app/e2e/fixtures/world.ts
+++ b/packages/app/e2e/fixtures/world.ts
@@ -14,6 +14,7 @@ import type { FastifyInstance } from "fastify";
 import { GanderApplication } from "./application.js";
 import { GithubServer, type PullRequestFixture } from "./github-server.js";
 import {
+  amendPullRequest,
   createRepositoryFixture,
   removeRepositoryFixture,
   type RepositoryFixture,
@@ -36,10 +37,11 @@ export class GanderWorld {
   readonly socketPath: string;
   readonly clonesPath: string;
   readonly github: GithubServer;
-  readonly service: FastifyInstance;
   readonly serviceUrl: string;
   readonly serviceToken = "e2e-service-token";
 
+  private service: FastifyInstance;
+  private serviceRunning = true;
   private readonly storage: Storage;
   private readonly testInfo: TestInfo;
   private readonly repositories: RepositoryFixture[] = [];
@@ -118,8 +120,49 @@ export class GanderWorld {
     return repository;
   }
 
-  async launch(): Promise<GanderApplication> {
-    const application = new GanderApplication(this.childEnvironment(), this.userDataPath, this.testInfo);
+  async rewritePullRequest(repository: RepositoryFixture, files: Record<string, string | Uint8Array>): Promise<void> {
+    await amendPullRequest(repository, files);
+    this.github.updatePullRequest(repository.repoId, {
+      number: repository.number,
+      title: repository.title,
+      baseSha: repository.baseSha,
+      headSha: repository.headSha,
+    });
+  }
+
+  async stopService(): Promise<void> {
+    if (!this.serviceRunning) return;
+    await this.service.close();
+    this.serviceRunning = false;
+  }
+
+  async startService(options: { version?: string; token?: string } = {}): Promise<void> {
+    if (this.serviceRunning) throw new Error("The E2E service is already running");
+    this.service = buildServer({
+      storage: this.storage,
+      token: options.token ?? this.serviceToken,
+      version: options.version ?? SERVICE_VERSION,
+    });
+    const port = Number(new URL(this.serviceUrl).port);
+    await this.service.listen({ host: "127.0.0.1", port });
+    this.serviceRunning = true;
+  }
+
+  async restartService(options: { version?: string; token?: string } = {}): Promise<void> {
+    await this.stopService();
+    await this.startService(options);
+  }
+
+  uncheckFileInService(repository: RepositoryFixture, path: string): void {
+    this.storage.putFileState(repository.repoId, repository.number, { path, checked: false });
+  }
+
+  async launch(options: { connectionFromEnvironment?: boolean } = {}): Promise<GanderApplication> {
+    const application = new GanderApplication(
+      this.childEnvironment(options.connectionFromEnvironment ?? true),
+      this.userDataPath,
+      this.testInfo,
+    );
     this.applications.push(application);
     return application.launch();
   }
@@ -142,7 +185,7 @@ export class GanderWorld {
     const failed = this.testInfo.status !== this.testInfo.expectedStatus;
     for (const application of [...this.applications].reverse()) await application.close(failed);
     await this.github.close();
-    await this.service.close();
+    if (this.serviceRunning) await this.service.close();
     this.storage.close();
     for (const repository of [...this.repositories].reverse()) {
       await removeRepositoryFixture(repository);
@@ -150,14 +193,12 @@ export class GanderWorld {
     await rm(this.root, { recursive: true, force: true });
   }
 
-  private childEnvironment(): Record<string, string> {
+  private childEnvironment(connectionFromEnvironment = true): Record<string, string> {
     const environment = stringEnvironment(process.env);
     delete environment.ELECTRON_RUN_AS_NODE;
     delete environment.ELECTRON_RENDERER_URL;
     Object.assign(environment, {
       GANDER_CONFIG: this.configPath,
-      GANDER_SERVICE_URL: this.serviceUrl,
-      GANDER_TOKEN: this.serviceToken,
       GANDER_GITHUB_API_URL: this.github.url,
       GANDER_GITHUB_TOKEN: this.github.token,
       GANDER_APP_SOCKET: this.socketPath,
@@ -165,6 +206,13 @@ export class GanderWorld {
       GIT_CONFIG_SYSTEM: join(this.root, "empty-gitconfig"),
       GIT_CONFIG_COUNT: String(this.repositories.length),
     });
+    if (connectionFromEnvironment) {
+      environment.GANDER_SERVICE_URL = this.serviceUrl;
+      environment.GANDER_TOKEN = this.serviceToken;
+    } else {
+      delete environment.GANDER_SERVICE_URL;
+      delete environment.GANDER_TOKEN;
+    }
     // Hidden is the routine mode: the renderer still paints for Playwright, but the suite
     // cannot cover the reviewer's desktop. Opt into a visible window only while debugging.
     if (environment.GANDER_E2E_HEADFUL === "1") delete environment.GANDER_E2E;

--- a/packages/app/e2e/keyboard-focus.spec.ts
+++ b/packages/app/e2e/keyboard-focus.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "./fixtures/test.js";
+import { ReviewDriver } from "./drivers/review.js";
+
+test("routes review shortcuts from Monaco without stealing typed note text", async ({ world }) => {
+  const repository = await world.addRepository({ repoId: "acme/keyboard-focus" });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+  await review.open(repository.title);
+
+  const editor = app.page.locator(".monaco-editor:visible").first();
+  await editor.click();
+  await app.page.keyboard.press("?");
+  await expect(app.page.getByRole("dialog", { name: "Keyboard shortcuts" })).toBeVisible();
+  await app.page.keyboard.press("Escape");
+  await expect(app.page.getByRole("dialog", { name: "Keyboard shortcuts" })).toHaveCount(0);
+
+  await editor.click();
+  await app.page.keyboard.press("n");
+  const note = app.page.getByPlaceholder("What needs answering or changing here?");
+  await expect(note).toBeFocused();
+  await note.fill("Keep this letter: ");
+  await note.press("m");
+  await expect(note).toHaveValue("Keep this letter: m");
+  await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "false");
+  await note.press("Escape");
+
+  await editor.click();
+  await app.page.keyboard.press("m");
+  await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "true");
+  await app.page.keyboard.press("Shift+N");
+  await expect(app.page.getByRole("heading", { name: "Notes", exact: true })).toBeVisible();
+});

--- a/packages/app/e2e/note-lifecycle.spec.ts
+++ b/packages/app/e2e/note-lifecycle.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "./fixtures/test.js";
+import { McpDriver } from "./drivers/mcp.js";
+import { ReviewDriver } from "./drivers/review.js";
+
+test("carries a reviewer note through MCP addressing and reviewer resolution", async ({ world }) => {
+  const repository = await world.addRepository({ repoId: "acme/note-lifecycle" });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+  const agent = await new McpDriver(world.serviceUrl, world.serviceToken).connect();
+
+  try {
+    await review.open(repository.title);
+    await review.selectFile("a.rb");
+    await review.addNote("Explain why this branch is necessary");
+    await review.openNotes();
+
+    const note = app.page.getByRole("listitem").filter({ hasText: "Explain why this branch is necessary" });
+    await expect(note.getByText("open", { exact: true })).toBeVisible();
+
+    const pickedUp = await agent.notes(repository.repoId, "feature");
+    expect(pickedUp.noteCounts).toEqual({ open: 1, addressed: 0, resolved: 0 });
+    expect(pickedUp.notes).toHaveLength(1);
+    await agent.markAddressed(pickedUp.notes[0]!.id, "abc1234", "Removed the unnecessary branch");
+
+    await review.fetchOrigin();
+    await expect(note.getByText("addressed", { exact: true })).toBeVisible();
+    await expect(note.getByRole("region", { name: "Agent update" })).toContainText("Removed the unnecessary branch");
+    await expect(note.getByRole("region", { name: "Agent update" })).toContainText("abc1234");
+
+    await app.page.getByRole("button", { name: "Mark reviewed" }).click();
+    await review.fetchOrigin();
+    await expect(note.getByText("resolved", { exact: true })).toBeVisible();
+
+    const completed = await agent.notes(repository.repoId, "feature");
+    expect(completed.noteCounts).toEqual({ open: 0, addressed: 0, resolved: 1 });
+  } finally {
+    await agent.close();
+  }
+});

--- a/packages/app/e2e/service-compatibility.spec.ts
+++ b/packages/app/e2e/service-compatibility.spec.ts
@@ -1,0 +1,40 @@
+import { SERVICE_VERSION } from "@gander/shared";
+import { test, expect } from "./fixtures/test.js";
+import { ReviewDriver } from "./drivers/review.js";
+import { SettingsDriver } from "./drivers/settings.js";
+
+test("shows an incompatible service version before a review is opened", async ({ world }) => {
+  await world.restartService({ version: "0.0.0" });
+  const app = await world.launch();
+
+  const status = app.page.locator("footer").getByRole("status");
+  await expect(status).toContainText(`Service 0.0.0 is too old · update to ${SERVICE_VERSION}`);
+  await expect(status).toHaveAttribute("title", `Gander service 0.0.0 is too old for this app. Update the service to ${SERVICE_VERSION}.`);
+});
+
+test("warns while keeping a newer patch-level service usable", async ({ world }) => {
+  const [major, minor, patch] = SERVICE_VERSION.split(".").map(Number) as [number, number, number];
+  const newer = `${major}.${minor}.${patch + 1}`;
+  const repository = await world.addRepository({ repoId: "acme/newer-service" });
+  await world.restartService({ version: newer });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+
+  await review.open(repository.title);
+  await expect(app.page.locator("footer").getByRole("status"))
+    .toContainText(`Service ${newer} is newer · app supports ${SERVICE_VERSION}`);
+  await review.checkFile("a.rb");
+  await review.expectProgress(1, 2);
+});
+
+test("reports a bad saved token in connection settings", async ({ world }) => {
+  await world.restartService({ token: "a-different-service-token" });
+  const app = await world.launch({ connectionFromEnvironment: false });
+  const settings = new SettingsDriver(app.page);
+
+  await settings.open();
+  await settings.openConnectionCategory();
+  await app.page.getByRole("button", { name: "Test", exact: true }).click();
+  await expect(app.page.locator(".connection-settings").getByRole("status"))
+    .toHaveText("The service rejected that token.");
+});

--- a/packages/app/e2e/service-recovery.spec.ts
+++ b/packages/app/e2e/service-recovery.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "./fixtures/test.js";
+import { ReviewDriver } from "./drivers/review.js";
+
+test("keeps cached reads, rejects offline writes, and refreshes authoritatively after recovery", async ({ world }) => {
+  const repository = await world.addRepository({ repoId: "acme/service-recovery" });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+  const status = app.page.locator("footer").getByRole("status");
+  const error = app.page.locator(".error-banner");
+
+  await review.open(repository.title);
+  await review.checkFile("a.rb");
+  await world.stopService();
+  world.uncheckFileInService(repository, "a.rb");
+
+  await review.fetchOrigin();
+  await expect(status).toContainText("Service unreachable · showing cached review");
+  await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "true");
+
+  await review.file("b.rb").getByRole("checkbox").click();
+  await expect(error).toContainText("This change was not saved and will not be retried.");
+  await expect(review.file("b.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "false");
+
+  await world.startService();
+  await review.file("b.rb").getByRole("checkbox").click();
+  await expect(error).toContainText("showing cached service data");
+  await expect(review.file("b.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "false");
+
+  await review.fetchOrigin();
+  await expect(status).toContainText("Service connected");
+  await expect(error).toHaveCount(0);
+  await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "false");
+  await expect(review.file("b.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "false");
+
+  await review.file("b.rb").getByRole("checkbox").click();
+  await expect(review.file("b.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "true");
+});

--- a/packages/app/e2e/target-isolation.spec.ts
+++ b/packages/app/e2e/target-isolation.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "./fixtures/test.js";
+import { WorkbenchDriver } from "./drivers/workbench.js";
+
+test("does not let a stale repository load replace the newer target", async ({ world }) => {
+  let releaseFirst!: () => void;
+  const firstMayFinish = new Promise<void>((resolve) => { releaseFirst = resolve; });
+  let firstFinished = false;
+  const first = await world.addRepository({
+    repoId: "acme/slow-repository",
+    onList: async (requestCount) => {
+      if (requestCount !== 1) return;
+      await firstMayFinish;
+      firstFinished = true;
+    },
+  });
+  const second = await world.addRepository({ repoId: "acme/chosen-repository" });
+  const app = await world.launch();
+  const workbench = new WorkbenchDriver(app.page);
+
+  try {
+    await expect.poll(() => world.github.requestsFor(first.repoId)).toBe(1);
+    await workbench.selectRepository(second.repoId);
+    await expect(app.page.locator(".context-title strong")).toHaveText("chosen-repository");
+
+    releaseFirst();
+    await expect.poll(() => firstFinished).toBe(true);
+    await expect(app.page.locator('button[aria-controls="target-picker"]')).toContainText("chosen-repository");
+    await expect(app.page.locator(".context-title strong")).toHaveText("chosen-repository");
+  } finally {
+    releaseFirst();
+  }
+});

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@gander/service": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@playwright/test": "1.62.1",
     "@types/node": "^22.0.0",
     "@vitejs/plugin-vue": "^5.2.0",

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { RefreshCw } from "lucide-vue-next";
+import { RefreshCw } from "@lucide/vue";
 import type { FileIconThemeId } from "../../../file-icon-themes.js";
 import type { EffectiveTreeTypography } from "../../../settings.js";
 import type { Store } from "../store.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@gander/service':
         specifier: workspace:*
         version: link:../service
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1


### PR DESCRIPTION
## What changed

- add independent Electron scenarios for content-addressed checkoffs after a force-push
- drive the reviewer note lifecycle through the UI, real MCP transport, and service
- prove cached reads, fail-closed writes, and authoritative service recovery
- cover older/newer service compatibility and rejected saved tokens
- exercise stale repository-load isolation and real Monaco keyboard focus
- extend the clean-world fixtures with real service restarts, Git rewrites, and MCP clients
- fix the final stale `lucide-vue-next` import exposed by a clean install from current `master`

## Why

PR #103 establishes the modular Playwright harness and six carryover scenarios. This follow-up covers Gander's higher-risk cross-process invariants without turning them back into one dependent session.

Each check still launches a fresh hidden Electron app with isolated config, user data, SQLite, Fastify, GitHub HTTP fixture, and real temporary Git repositories. The suite now has 14 independent tests and remains single-worker with no retries.

## Verification

- `pnpm typecheck`
- `pnpm test` — 57 files, 370 tests
- `pnpm test:e2e` — 14 tests passed in 24.2s
- `git diff --check`
