### PR TITLE
Publish the Homebrew cask from CI

### DIFF
--- a/.github/workflows/publish-cask.yml
+++ b/.github/workflows/publish-cask.yml
@@ -1,0 +1,49 @@
+name: Publish the Homebrew cask
+
+# bin/release renders the cask against the dmg it just signed and attaches it to the
+# release, so the tap only needs the file moved. Publishing here rather than by hand
+# keeps `brew upgrade` from lagging a release nobody remembered to copy across.
+on:
+  release:
+    types: [published]
+  # So a release whose publish failed, or one made before this workflow existed, can be
+  # given another one without re-tagging.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The release tag whose cask to publish
+        required: true
+
+jobs:
+  cask:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Take the cask from the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: gh release download "$TAG" --repo "${{ github.repository }}" --pattern gander.rb --dir cask
+
+      - name: Check out the tap
+        uses: actions/checkout@v5
+        with:
+          repository: steveclarke/homebrew-tap
+          # The default token cannot reach another repository.
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Publish it
+        env:
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        working-directory: tap
+        run: |
+          cp ../cask/gander.rb Casks/gander.rb
+          # A re-run of an already published release is a no-op, not a failed job.
+          if git diff --quiet -- Casks/gander.rb; then
+            echo "Casks/gander.rb already describes $TAG."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "gander $TAG" -- Casks/gander.rb
+          git push

--- a/bin/release
+++ b/bin/release
@@ -64,9 +64,9 @@ rm -rf packages/app/dist
 export APPLE_KEYCHAIN_PROFILE="${APPLE_KEYCHAIN_PROFILE:-outport-notarize}"
 pnpm --filter @gander/app run dist:mac
 
-# The tap is a separate repository and is updated manually after release verification.
-# Generate the exact, checksummed cask it needs as a release asset so that handoff does
-# not require reconstructing artifact names or trusting an unverified checksum.
+# The tap is a separate repository, updated by the publish-cask workflow once this
+# release is published. Render the exact, checksummed cask it needs as a release asset
+# so that handoff neither reconstructs artifact names nor trusts an unverified checksum.
 bin/render-homebrew-cask \
   "$VERSION" \
   "packages/app/dist/Gander-${VERSION}-arm64.dmg" \
@@ -82,4 +82,4 @@ gh release edit "$TAG" --draft=false
 
 echo "==> Published https://github.com/steveclarke/gander/releases/tag/${TAG}"
 echo "    The Linux AppImage follows from CI."
-echo "    After verifying the signed app, publish dist/gander.rb to steveclarke/homebrew-tap/Casks/gander.rb."
+echo "    The Homebrew cask follows from CI."


### PR DESCRIPTION
`bin/release` renders `gander.rb` with the signed dmg's checksum and attaches it to
the release. Copying it into `steveclarke/homebrew-tap` was the one manual step, and
it gets forgotten: the tap describes 0.1.15 while 0.1.17 is out.

A job on `release: published` downloads that asset and commits it to
`Casks/gander.rb`. `workflow_dispatch` with a tag does the same for a release made
before this existed, and re-running against an unchanged cask is a no-op rather
than a failure.

Needs `HOMEBREW_TAP_TOKEN` in this repository's secrets, the same token the other
repositories use for the tap — already added.

Note this drops the "verify the signed app first" gate that the manual step
implied: brew users now see a release as soon as it is published.