### PR TITLE
Split App.vue into surfaces, a sidebar, and four composables

### DIFF
--- a/packages/app/e2e/keyboard-focus.spec.ts
+++ b/packages/app/e2e/keyboard-focus.spec.ts
@@ -29,4 +29,12 @@ test("routes review shortcuts from Monaco without stealing typed note text", asy
   await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "true");
   await app.page.keyboard.press("Shift+N");
   await expect(app.page.getByRole("heading", { name: "Notes", exact: true })).toBeVisible();
+
+  // Change-to-change navigation is Monaco's own, reached through the review surface that
+  // owns the diff. Broken, it moves nothing and says nothing — so read the line back off
+  // the note the next keystroke captures.
+  await editor.click();
+  await app.page.keyboard.press("]");
+  await app.page.keyboard.press("n");
+  await expect(app.page.locator("#note-target")).toContainText("line 2");
 });

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -1,245 +1,70 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
-import type { OpenTarget } from "@gander/shared";
-import { MessageSquare, Plus, X } from "@lucide/vue";
+import { computed, onMounted, ref, shallowRef, watch } from "vue";
+import { X } from "@lucide/vue";
 import { api } from "./api.js";
 import { createStore } from "./store.js";
 import { createEditorSettingsStore } from "./editor-settings-store.js";
-import { notesDock, notesHeight, notesWidth, treeWidth } from "./layout.js";
 import { effectiveTreeTypography } from "../../settings.js";
 import { basename } from "./paths.js";
 import { currentLine } from "./selection.js";
 import type { NoteTarget } from "./selection.js";
-import type { PrFile } from "@gander/shared";
-import { bindingFor, isPrefix, type Command, type Prefix } from "./keymap.js";
-import { collapsedDirs, cursor, edge, filesAt, nextUnmarked, parentOf, rowAt, step } from "./tree-nav.js";
-import { useTreeJump } from "./tree-jump.js";
-import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../zoom.js";
+import { useWorkbench } from "./composables/use-workbench.js";
+import { useReviewKeyboard } from "./composables/use-review-keyboard.js";
+import { useWindowZoom } from "./composables/use-window-zoom.js";
+import { useBackgroundRefresh } from "./composables/use-background-refresh.js";
 import ActivityRail from "./components/ActivityRail.vue";
 import ConfirmDialog from "./components/ConfirmDialog.vue";
-import ContextToolbar from "./components/ContextToolbar.vue";
-import DiffPane from "./components/DiffPane.vue";
-import EmptyState from "./components/EmptyState.vue";
-import FullFilePane from "./components/FullFilePane.vue";
-import LocalSidebar from "./components/LocalSidebar.vue";
-import PullRequestSidebar from "./components/PullRequestSidebar.vue";
-import NoteCapture from "./components/NoteCapture.vue";
-import NotesDrawer from "./components/NotesDrawer.vue";
 import KeymapHelp from "./components/KeymapHelp.vue";
+import LocalSurface from "./components/LocalSurface.vue";
+import NoteCapture from "./components/NoteCapture.vue";
+import ReviewSurface from "./components/ReviewSurface.vue";
 import SettingsPane from "./components/SettingsPane.vue";
-import Splitter from "./components/Splitter.vue";
-import StackPosition from "./components/StackPosition.vue";
 import StatusBar from "./components/StatusBar.vue";
 import TargetBar from "./components/TargetBar.vue";
-
-type WorkbenchMode = "explorer" | "changes" | "pulls" | "settings";
+import WorkbenchSidebar from "./components/WorkbenchSidebar.vue";
 
 const store = createStore(api);
 const editorSettings = createEditorSettingsStore(api, api.initialWindowState.colorTheme);
+const {
+  activeMode, surfaceMode, settingsCategory, unconfigured,
+  openSettings, closeSettings, onConnected,
+  chooseRepo, removeRepo, selectRepo, selectWorktree, selectMode, openPr,
+} = useWorkbench(store, api);
+const { level: zoomLevel, change: changeZoom } = useWindowZoom(api);
 const integratedTitleBar = api.initialWindowState.windowStyle === "integrated-titlebar";
-const activeMode = shallowRef<WorkbenchMode>("explorer");
-const modeBeforeSettings = shallowRef<Exclude<WorkbenchMode, "settings">>("explorer");
-const unconfigured = ref(false);
+
 const noteTarget = shallowRef<NoteTarget | null>(null);
 const drawerOpen = ref(false);
 const treeVisible = ref(true);
 const helpOpen = ref(false);
-const diffPane = ref<InstanceType<typeof DiffPane> | null>(null);
-const treeScrolling = shallowRef(false);
-const zoomLevel = shallowRef(DEFAULT_ZOOM_LEVEL);
-const settingsCategory = shallowRef<"workbench" | "editor" | "connection">("workbench");
 const repoPendingRemoval = ref<string | null>(null);
-const treeJump = useTreeJump(() => store.files(), (path) => { moveTo(path); });
-let unsubscribeOpenTarget: (() => void) | null = null;
-let unsubscribeOpenSettings: (() => void) | null = null;
-let unsubscribeZoomChanged: (() => void) | null = null;
-let treeScrollTimer: ReturnType<typeof setTimeout> | undefined;
+const reviewSurface = ref<InstanceType<typeof ReviewSurface> | null>(null);
 
 const treeTypography = computed(() => effectiveTreeTypography(editorSettings.settings));
-const noteCount = computed(() => store.view?.notes.length ?? 0);
 const repoName = computed(() => store.currentRepoId === null ? "" : basename(store.currentRepoId));
-const hasLoadedView = computed(() => store.view !== null || store.localView !== null);
-const notesSize = computed({
-  get: () => (notesDock.value === "right" ? notesWidth.value : notesHeight.value),
-  set: (value: number) => {
-    if (notesDock.value === "right") notesWidth.value = value;
-    else notesHeight.value = value;
-  },
+
+const treeJump = useReviewKeyboard({
+  store,
+  mode: () => activeMode.value,
+  treeVisible,
+  drawerOpen,
+  helpOpen,
+  diff: () => reviewSurface.value,
+  captureNote: () => openNote(),
 });
 
-onMounted(async () => {
-  unsubscribeOpenTarget = api.onOpenTarget((target) => { void openExternalTarget(target); });
-  unsubscribeOpenSettings = api.onOpenSettings(() => openSettings());
-  unsubscribeZoomChanged = api.onZoomChanged((level) => { zoomLevel.value = level; });
-  zoomLevel.value = await api.getZoomLevel();
-  void editorSettings.load();
-  await refreshConnectionState();
-  await store.loadRepos();
+useBackgroundRefresh(store, () => store.view !== null || store.localView !== null);
 
-  const target = await api.initialTarget();
-  if (target !== null) {
-    await openExternalTarget(target);
-    return;
-  }
+onMounted(() => { void editorSettings.load(); });
 
-  const firstRepo = store.repos[0];
-  if (firstRepo) await selectTargetRepo(firstRepo.repoId, { keepChosenMode: true });
-});
-
-async function openExternalTarget(target: OpenTarget): Promise<void> {
-  await store.openTarget(target);
-  // A named pull request opens in the review even for a repository with no checkout on
-  // this machine: the command named a review, not a folder.
-  if (target.prNumber !== null && store.targetRepoId === target.repoId) {
-    activeMode.value = "pulls";
-    return;
-  }
-  if (store.targetRepoId !== target.repoId || store.targetWorktreePath === null) {
-    activeMode.value = "explorer";
-    return;
-  }
-  if (store.targetWorktreePath) {
-    await openLocalTarget(store.targetWorktreePath, "explorer", store.error);
-  } else activeMode.value = "pulls";
-}
-
-async function onConnected(): Promise<void> {
-  await refreshConnectionState();
-  await store.loadRepos();
-}
-
-async function refreshConnectionState(): Promise<void> {
-  unconfigured.value = (await api.getConnection()).url === "";
-  await store.checkService();
-}
-
-function openSettings(category: "workbench" | "editor" | "connection" = "workbench"): void {
-  if (activeMode.value !== "settings") modeBeforeSettings.value = activeMode.value;
-  settingsCategory.value = category;
-  activeMode.value = "settings";
-}
-
-function closeSettings(): void {
-  activeMode.value = modeBeforeSettings.value;
-  void refreshConnectionState();
-}
-
-async function changeZoom(level: number): Promise<void> {
-  zoomLevel.value = clampZoomLevel(level);
-  zoomLevel.value = await api.setZoomLevel(level);
-}
-
-/** Register a repository from a folder on disk, and open its checkout. `repoId` names the one the reviewer is being asked to locate. */
-async function chooseRepo(repoId?: string): Promise<void> {
-  if (!await store.chooseLocalRepo(repoId)) return;
-  const contextError = store.error;
-  if (!store.targetWorktreePath) {
-    activeMode.value = "explorer";
-    return;
-  }
-  await openLocalTarget(store.targetWorktreePath, "explorer", contextError);
-}
-
-async function removeRepo(): Promise<void> {
-  const repoId = repoPendingRemoval.value;
-  repoPendingRemoval.value = null;
-  if (repoId === null) return;
-  await store.removeRepo(repoId);
-  activeMode.value = "explorer";
-  const next = store.repos[0];
-  if (next) await selectTargetRepo(next.repoId);
-}
-
-/**
- * `keepChosenMode` is for the repository opened at launch: that load finishes long after
- * the window is usable, and it must not drag the reviewer out of a view they opened
- * while it was still working.
- */
-async function selectTargetRepo(repoId: string, { keepChosenMode = false } = {}): Promise<void> {
-  await store.selectRepo(repoId);
-  const contextError = store.error;
-  if (!store.targetWorktreePath) {
-    landIn("explorer", keepChosenMode);
-    return;
-  }
-  await openLocalTarget(store.targetWorktreePath, "explorer", contextError, keepChosenMode);
-}
-
-/**
- * Settings covers the work surface instead of replacing it: rebuilding the editor every
- * time the reviewer checks a setting is the cost this avoids.
- */
-const surfaceMode = computed(() => (activeMode.value === "settings" ? modeBeforeSettings.value : activeMode.value));
-
-function landIn(mode: "explorer" | "changes", keepChosenMode: boolean): void {
-  // The reviewer went somewhere else while the load was in flight: remember where this
-  // target landed, so closing Settings returns to it, and leave them where they are.
-  if (keepChosenMode && activeMode.value !== "explorer") {
-    modeBeforeSettings.value = mode;
-    return;
-  }
-  activeMode.value = mode;
-}
-
-async function selectTargetWorktree(path: string): Promise<void> {
-  const nextMode = activeMode.value === "changes" ? "changes" : "explorer";
-  await store.openLocal(path);
-  if (store.error) return;
-  store.showLocalSurface(nextMode);
-  activeMode.value = nextMode;
-}
-
-async function openLocalTarget(
-  path: string,
-  mode: "explorer" | "changes",
-  contextError: string | null,
-  keepChosenMode = false,
-): Promise<void> {
-  await store.openLocal(path);
-  const localError = store.error;
-  const errors = [...new Set([contextError, localError].filter((error): error is string => error !== null))];
-  store.error = errors.length ? errors.join("\n") : null;
-  if (localError) return;
-  store.showLocalSurface(mode);
-  landIn(mode, keepChosenMode);
-}
-
-async function selectMode(value: WorkbenchMode): Promise<void> {
-  if (value === "settings") {
-    openSettings();
-    return;
-  }
-  if (value === "pulls") {
-    activeMode.value = "pulls";
-    if (store.selectedPrNumber !== null && (store.view?.pr.number !== store.selectedPrNumber || store.currentRepoId !== store.targetRepoId)) {
-      await store.openPr(store.selectedPrNumber);
-    }
-    return;
-  }
-
-  activeMode.value = value;
-  const path = store.targetWorktreePath;
-  if (!path) return;
-  if (store.localView?.worktree.path !== path || store.currentRepoId !== store.targetRepoId) await store.openLocal(path);
-  if (!store.error) store.showLocalSurface(value);
-}
-
-async function openPr(prNumber: number): Promise<void> {
-  activeMode.value = "pulls";
-  await store.openPr(prNumber);
-}
-
+// The notes belong to the pull request being reviewed, so leaving it puts them away.
 watch(activeMode, (mode) => {
-  treeJump.cancel();
-  if (mode !== "pulls") {
-    drawerOpen.value = false;
-    noteTarget.value = null;
-  }
+  if (mode === "pulls") return;
+  drawerOpen.value = false;
+  noteTarget.value = null;
 });
 
-watch(() => `${store.currentRepoId ?? ""}#${store.view?.pr.number ?? ""}`, () => treeJump.cancel());
-watch(treeVisible, (visible) => { if (!visible) treeJump.cancel(); });
-
+/** Opens the note editor. Without a target, the note lands on wherever the reviewer is. */
 function openNote(target?: NoteTarget): void {
   if (!store.view || activeMode.value !== "pulls") return;
   noteTarget.value = target ?? {
@@ -248,184 +73,11 @@ function openNote(target?: NoteTarget): void {
   };
 }
 
-function onTreeScroll(): void {
-  treeScrolling.value = true;
-  clearTimeout(treeScrollTimer);
-  treeScrollTimer = setTimeout(() => { treeScrolling.value = false; }, 500);
+async function confirmRemoveRepo(): Promise<void> {
+  const repoId = repoPendingRemoval.value;
+  repoPendingRemoval.value = null;
+  if (repoId !== null) await removeRepo(repoId);
 }
-
-function isTyping(target: HTMLElement | null): boolean {
-  if (target === null) return false;
-  if (target.closest("[data-app-typing='true']") !== null) return true;
-  if (target.closest(".monaco-editor") !== null) return false;
-  return target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
-}
-
-// Selection is the app's cursor, so the keys that move it work wherever the reviewer is
-// looking. Nothing here is editable, so single letters are safe; isTyping guards the note
-// input and the settings fields, which are the only places a letter means itself.
-function runCommand(command: Command): boolean {
-  const files = store.files();
-  const at = cursor.value ?? store.selectedPath;
-
-  switch (command) {
-    case "next-file":
-    case "previous-file":
-      return moveTo(step(files, at, command === "next-file" ? 1 : -1));
-    case "first-file":
-    case "last-file":
-      return moveTo(edge(files, command === "first-file" ? "first" : "last"));
-    case "jump-row":
-      return treeVisible.value && store.currentRepoId === store.targetRepoId && treeJump.start();
-    case "toggle-directory": {
-      if (at === null) return true;
-      // Opening a directory is how a reviewer says "let me look in here", so the cursor
-      // goes in with it. On anything else the same key closes the directory the cursor is
-      // inside and steps out to it, which is the way back.
-      if (rowAt(files, at)?.type === "dir" && collapsedDirs.has(at)) {
-        collapsedDirs.delete(at);
-        return moveTo(step(files, at, 1));
-      }
-      const dir = rowAt(files, at)?.type === "dir" ? at : parentOf(files, at);
-      if (dir === null) return true;
-      collapsedDirs.add(dir);
-      return moveTo(dir);
-    }
-    case "dismiss": {
-      if (!helpOpen.value) return false;
-      helpOpen.value = false;
-      return true;
-    }
-    case "toggle-checked": {
-      mark(at, null);
-      return true;
-    }
-    case "mark-and-advance":
-    case "mark-and-retreat": {
-      // Read before marking: once this row is marked it is no longer a candidate, and the
-      // search would step over where the reviewer actually is.
-      const next = nextUnmarked(files, at, command === "mark-and-advance" ? 1 : -1);
-      mark(at, true);
-      if (next !== null && next !== at) moveTo(next);
-      return true;
-    }
-    case "next-change":
-      diffPane.value?.goToChange("next");
-      return true;
-    case "previous-change":
-      diffPane.value?.goToChange("previous");
-      return true;
-    case "delta-view":
-      diffPane.value?.showDelta();
-      return true;
-    case "capture-note":
-      openNote();
-      return true;
-    case "toggle-notes":
-      drawerOpen.value = !drawerOpen.value;
-      return true;
-    case "toggle-tree":
-      treeVisible.value = !treeVisible.value;
-      return true;
-    case "help":
-      helpOpen.value = !helpOpen.value;
-      return true;
-  }
-}
-
-/**
- * Moves the cursor, and opens the row when it is a file. A directory has nothing to show,
- * so passing over one leaves the reader looking at the file they were already reading.
- */
-function moveTo(path: string | null): boolean {
-  if (path === null) return true;
-  cursor.value = path;
-  if (rowAt(store.files(), path)?.type === "file") store.select(path);
-  return true;
-}
-
-/** Marks a row: one file, or every file under a directory. `checked` null means toggle. */
-function mark(path: string | null, checked: boolean | null): void {
-  const under = filesAt(store.files(), path).filter((file): file is PrFile => "checked" in file);
-  if (under.length === 0) return;
-  const next = checked ?? under.some((file) => !file.checked);
-  const changing = under.filter((file) => file.checked !== next).map((file) => file.path);
-  if (changing.length === 0) return;
-  if (changing.length === 1) void store.setChecked(changing[0]!, next);
-  else void store.setCheckedMany(changing, next);
-}
-
-
-// Keyboard movement can leave the cursor outside the scrolled area, where the reviewer
-// cannot see what they are on. Follow it; a mouse click is already in view.
-watch(cursor, async () => {
-  await nextTick();
-  document.querySelector(".view-sidebar .tnode.cur")?.scrollIntoView({ block: "nearest" });
-});
-
-// A file opened by any other route — a click, a note, opening the pull request — becomes
-// where the keyboard continues from.
-watch(() => store.selectedPath, (path) => {
-  if (path !== null && rowAt(store.files(), cursor.value)?.type !== "dir") cursor.value = path;
-});
-
-// The half-typed prefix of a two-key binding. Cleared by whatever comes next, so a `g`
-// followed by anything other than the key that completes a chord does nothing at all.
-let pending: Prefix | null = null;
-
-function onKey(event: KeyboardEvent): void {
-  if (isTyping(event.target as HTMLElement | null)) return;
-  if (treeJump.active.value && treeJump.handleKey(event)) {
-    event.preventDefault();
-    event.stopPropagation();
-    return;
-  }
-  const started = isPrefix(event, pending);
-  if (started !== null) {
-    pending = started;
-    event.preventDefault();
-    event.stopPropagation();
-    return;
-  }
-  const binding = bindingFor(event, pending);
-  pending = null;
-  if (binding === null) return;
-  // Everything but the panel toggles is about a pull request under review; in the local
-  // viewer there is no checkoff, no note, and no delta to reach.
-  const reviewing = store.view !== null && activeMode.value === "pulls";
-  if (!reviewing && binding.group !== "Panels") return;
-  if (!runCommand(binding.command)) return;
-  event.preventDefault();
-  event.stopPropagation();
-}
-window.addEventListener("keydown", onKey, true);
-
-const POLL_MS = 30_000;
-let refreshing = false;
-async function refreshOnce(): Promise<void> {
-  if (refreshing || !hasLoadedView.value) return;
-  refreshing = true;
-  try { await store.refresh(); } finally { refreshing = false; }
-}
-const timer = setInterval(() => void refreshOnce(), POLL_MS);
-const HEALTH_MS = 15_000;
-const healthTimer = setInterval(() => void store.checkService(), HEALTH_MS);
-const onFocus = (): void => { void store.checkService(); void refreshOnce();
-  // A pull request opened elsewhere — a browser, an agent, `gh pr create` — is the
-  // usual reason the reviewer comes back to the window at all.
-  void store.refreshPrs();
-};
-window.addEventListener("focus", onFocus);
-onBeforeUnmount(() => {
-  clearInterval(timer);
-  clearInterval(healthTimer);
-  clearTimeout(treeScrollTimer);
-  window.removeEventListener("focus", onFocus);
-  window.removeEventListener("keydown", onKey, true);
-  unsubscribeOpenTarget?.();
-  unsubscribeOpenSettings?.();
-  unsubscribeZoomChanged?.();
-});
 </script>
 
 <template>
@@ -434,8 +86,8 @@ onBeforeUnmount(() => {
       <TargetBar
         :store="store"
         :integrated-title-bar="integratedTitleBar"
-        @select-repo="selectTargetRepo"
-        @select-worktree="selectTargetWorktree"
+        @select-repo="selectRepo($event)"
+        @select-worktree="selectWorktree"
         @select-pr="openPr"
         @open-folder="chooseRepo()"
         @locate-repo="chooseRepo($event)"
@@ -446,6 +98,7 @@ onBeforeUnmount(() => {
         <button aria-label="Dismiss" title="Dismiss" @click="store.dismissError()"><X :size="14" /></button>
       </div>
     </div>
+
     <main class="body">
       <ActivityRail
         :active="activeMode"
@@ -453,31 +106,15 @@ onBeforeUnmount(() => {
         @select="selectMode"
       />
 
-      <div
+      <WorkbenchSidebar
         v-if="treeVisible && activeMode !== 'settings'"
-        class="view-sidebar"
-        :class="{ scrolling: treeScrolling }"
-        :style="{ width: `${treeWidth}px` }"
-      >
-        <LocalSidebar
-          v-if="activeMode === 'explorer' || activeMode === 'changes'"
-          :store="store"
-          :mode="activeMode"
-          :icon-theme="editorSettings.settings.workbench.iconTheme"
-          :typography="treeTypography"
-          @scroll="onTreeScroll"
-        />
-        <PullRequestSidebar
-          v-else
-          :store="store"
-          :icon-theme="editorSettings.settings.workbench.iconTheme"
-          :typography="treeTypography"
-          :jump-targets="treeJump.targetsByPath.value"
-          @select-pr="openPr"
-          @scroll="onTreeScroll"
-        />
-      </div>
-      <Splitter v-if="treeVisible && activeMode !== 'settings'" v-model="treeWidth" orientation="vertical" :min="190" :max="520" />
+        :store="store"
+        :mode="surfaceMode"
+        :icon-theme="editorSettings.settings.workbench.iconTheme"
+        :typography="treeTypography"
+        :jump-targets="treeJump.targetsByPath.value"
+        @select-pr="openPr"
+      />
 
       <div class="content">
         <SettingsPane
@@ -488,89 +125,29 @@ onBeforeUnmount(() => {
           @close="closeSettings"
         />
 
-        <template v-if="surfaceMode === 'explorer' || surfaceMode === 'changes'">
-          <ContextToolbar
-            v-if="store.localView"
-            :title="repoName"
-            refresh-label="Refresh local changes"
-            :busy="store.busy"
-            :progress="`${store.localView.files.length} changed`"
-            progress-class="local-progress"
-            @refresh="store.fetchNow()"
-          >
-            <template #subtitle>{{ store.localView.worktree.branch ?? store.localView.worktree.headSha.slice(0, 8) }}</template>
-          </ContextToolbar>
-          <section class="work-surface">
-            <p v-if="store.busy && !store.localView" class="empty working"><span class="spinner spin" />Opening worktree…</p>
-            <EmptyState
-              v-else-if="!store.targetRepoId"
-              title="Open a repository from disk"
-              detail="Gander will discover its linked worktrees and pull requests from one local checkout."
-            >
-              <button type="button" @click="chooseRepo()">Open repository folder…</button>
-              <button v-if="unconfigured" class="text-action" type="button" @click="openSettings('connection')">Connect a review service for pull requests</button>
-            </EmptyState>
-            <EmptyState
-              v-else-if="!store.targetWorktreePath"
-              title="Checkout unavailable"
-              detail="Gander cannot read the registered checkout for this repository."
-            >
-              <button type="button" @click="store.targetRepoId && chooseRepo(store.targetRepoId)">Locate checkout…</button>
-            </EmptyState>
-            <div v-else-if="!store.localView" class="empty">Select the target again to load this worktree.</div>
-            <FullFilePane v-else-if="surfaceMode === 'explorer'" :file="store.localFile" :editor-settings="editorSettings.settings.editor" class="diff" />
-            <DiffPane v-else :store="store" :editor-settings="editorSettings.settings.editor" class="diff" />
-          </section>
-        </template>
-
-        <template v-else>
-          <ContextToolbar
-            v-if="store.view && store.currentRepoId === store.targetRepoId"
-            :title="repoName"
-            refresh-label="Fetch origin"
-            :busy="store.busy"
-            :progress="`${store.progress().done}/${store.progress().total} reviewed`"
-            @refresh="store.fetchNow()"
-          >
-            <template #subtitle>
-              <StackPosition v-if="store.view.pr.stack" class="header-stack-position" :position="store.view.pr.stack.position" :size="store.view.pr.stack.size" /> #{{ store.view.pr.number }} {{ store.view.pr.title }}
-            </template>
-            <button aria-label="Add note (N)" title="Add note (N)" @click="openNote()"><Plus :size="14" /> Note</button>
-            <button aria-label="Notes" :title="`Notes (${noteCount})`" @click="drawerOpen = !drawerOpen"><MessageSquare :size="15" /><span v-if="noteCount">{{ noteCount }}</span></button>
-          </ContextToolbar>
-          <section class="work-surface">
-            <p v-if="store.busy && !store.view" class="empty working"><span class="spinner spin" />Opening pull request…</p>
-            <EmptyState
-              v-else-if="!store.targetRepoId"
-              title="Open a repository from disk"
-              detail="Pull requests belong to the repository you choose as your target."
-            >
-              <button type="button" @click="chooseRepo()">Open repository folder…</button>
-            </EmptyState>
-            <EmptyState
-              v-else-if="!store.view || store.currentRepoId !== store.targetRepoId"
-              title="Select a pull request"
-              detail="Choose a pull request or stack from the sidebar to begin reviewing."
-            />
-            <div v-else class="workspace" :class="notesDock">
-              <DiffPane ref="diffPane" :store="store" :editor-settings="editorSettings.settings.editor" class="diff" @add-note="openNote" />
-              <template v-if="drawerOpen">
-                <Splitter v-model="notesSize" :orientation="notesDock === 'right' ? 'vertical' : 'horizontal'" :min="notesDock === 'right' ? 220 : 120" :max="700" inverted />
-                <NotesDrawer
-                  :store="store"
-                  class="drawer"
-                  :dock="notesDock"
-                  :style="notesDock === 'right' ? { width: `${notesWidth}px` } : { height: `${notesHeight}px` }"
-                  @dock="notesDock = $event"
-                  @close="drawerOpen = false"
-                  @add-note="openNote()"
-                />
-              </template>
-            </div>
-          </section>
-        </template>
+        <LocalSurface
+          v-if="surfaceMode !== 'pulls'"
+          :store="store"
+          :editor-settings="editorSettings.settings.editor"
+          :mode="surfaceMode"
+          :repo-name="repoName"
+          :unconfigured="unconfigured"
+          @choose-repo="chooseRepo($event)"
+          @connect-service="openSettings('connection')"
+        />
+        <ReviewSurface
+          v-else
+          ref="reviewSurface"
+          v-model:drawer-open="drawerOpen"
+          :store="store"
+          :editor-settings="editorSettings.settings.editor"
+          :repo-name="repoName"
+          @choose-repo="chooseRepo()"
+          @add-note="openNote"
+        />
       </div>
     </main>
+
     <StatusBar
       :store="store"
       :tree-visible="treeVisible"
@@ -588,7 +165,7 @@ onBeforeUnmount(() => {
       title="Remove repository?"
       detail="This removes the repository from Gander. It does not delete any checkout or worktree from disk."
       confirm-label="Remove repository"
-      @confirm="removeRepo"
+      @confirm="confirmRemoveRepo"
       @cancel="repoPendingRemoval = null"
     />
   </div>
@@ -603,19 +180,4 @@ onBeforeUnmount(() => {
 .body { display: flex; min-height: 0; }
 .content { position: relative; flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; }
 .content > .settings-pane { position: absolute; inset: 0; z-index: 5; background: var(--workbench-background); }
-.view-sidebar { --scrollbar-thumb: transparent; --scrollbar-track: transparent; flex: none; min-height: 0; border-right: 1px solid var(--workbench-border); scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track); scrollbar-width: thin; transition: scrollbar-color 120ms cubic-bezier(0.16, 1, 0.3, 1); }
-.view-sidebar:hover, .view-sidebar:focus-within, .view-sidebar.scrolling { --scrollbar-thumb: color-mix(in srgb, var(--faint-foreground) 45%, transparent); }
-.work-surface { flex: 1; min-width: 0; min-height: 0; display: flex; background: var(--workbench-background); }
-.workspace { flex: 1; display: flex; min-width: 0; min-height: 0; }
-.workspace.right { flex-direction: row; }
-.workspace.bottom { flex-direction: column; }
-.drawer { flex: none; }
-.workspace.bottom .drawer { border-left: none; border-top: 1px solid var(--workbench-border); }
-.diff { flex: 1; min-width: 0; min-height: 0; overflow: hidden; }
-.empty { margin: auto; color: var(--faint-foreground); padding: 2rem; }
-.working { display: flex; align-items: center; gap: 10px; }
-.spinner { width: 14px; height: 14px; border: 2px solid var(--workbench-border); border-top-color: var(--faint-foreground); border-radius: 50%; }
-@media (prefers-reduced-motion: reduce) { .view-sidebar { transition: none; } }
-@media (prefers-contrast: more) { .view-sidebar:hover, .view-sidebar:focus-within, .view-sidebar.scrolling { --scrollbar-thumb: var(--workbench-foreground); } }
-@media (forced-colors: active) { .view-sidebar { scrollbar-color: auto; } }
 </style>

--- a/packages/app/src/renderer/src/components/LocalSurface.vue
+++ b/packages/app/src/renderer/src/components/LocalSurface.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type { Store } from "../store.js";
+import type { EditorSettings } from "../../../settings.js";
+import ContextToolbar from "./ContextToolbar.vue";
+import DiffPane from "./DiffPane.vue";
+import EmptyState from "./EmptyState.vue";
+import FullFilePane from "./FullFilePane.vue";
+
+/**
+ * A worktree on this machine: its files in Explorer, or what is uncommitted in it under
+ * Current Diff. Nothing here is reviewable — there is no checkoff, no note, and no
+ * pull request behind it.
+ */
+defineProps<{
+  store: Store;
+  editorSettings: EditorSettings;
+  mode: "explorer" | "changes";
+  repoName: string;
+  /** No review service configured, so the offer to connect one is worth making here. */
+  unconfigured: boolean;
+}>();
+defineEmits<{ chooseRepo: [repoId?: string]; connectService: [] }>();
+</script>
+
+<template>
+  <ContextToolbar
+    v-if="store.localView"
+    :title="repoName"
+    refresh-label="Refresh local changes"
+    :busy="store.busy"
+    :progress="`${store.localView.files.length} changed`"
+    progress-class="local-progress"
+    @refresh="store.fetchNow()"
+  >
+    <template #subtitle>{{ store.localView.worktree.branch ?? store.localView.worktree.headSha.slice(0, 8) }}</template>
+  </ContextToolbar>
+  <section class="work-surface">
+    <p v-if="store.busy && !store.localView" class="empty"><span class="spinner spin" />Opening worktree…</p>
+    <EmptyState
+      v-else-if="!store.targetRepoId"
+      title="Open a repository from disk"
+      detail="Gander will discover its linked worktrees and pull requests from one local checkout."
+    >
+      <button type="button" @click="$emit('chooseRepo')">Open repository folder…</button>
+      <button v-if="unconfigured" class="text-action" type="button" @click="$emit('connectService')">Connect a review service for pull requests</button>
+    </EmptyState>
+    <EmptyState
+      v-else-if="!store.targetWorktreePath"
+      title="Checkout unavailable"
+      detail="Gander cannot read the registered checkout for this repository."
+    >
+      <button type="button" @click="$emit('chooseRepo', store.targetRepoId ?? undefined)">Locate checkout…</button>
+    </EmptyState>
+    <div v-else-if="!store.localView" class="empty">Select the target again to load this worktree.</div>
+    <FullFilePane v-else-if="mode === 'explorer'" :file="store.localFile" :editor-settings="editorSettings" class="diff" />
+    <DiffPane v-else :store="store" :editor-settings="editorSettings" class="diff" />
+  </section>
+</template>
+
+<style scoped src="../styles/work-surface.css"></style>

--- a/packages/app/src/renderer/src/components/ReviewSurface.vue
+++ b/packages/app/src/renderer/src/components/ReviewSurface.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { MessageSquare, Plus } from "@lucide/vue";
+import type { Store } from "../store.js";
+import type { EditorSettings } from "../../../settings.js";
+import type { NoteTarget } from "../selection.js";
+import { notesDock, notesHeight, notesWidth } from "../layout.js";
+import ContextToolbar from "./ContextToolbar.vue";
+import DiffPane from "./DiffPane.vue";
+import EmptyState from "./EmptyState.vue";
+import NotesDrawer from "./NotesDrawer.vue";
+import Splitter from "./Splitter.vue";
+import StackPosition from "./StackPosition.vue";
+
+const props = defineProps<{
+  store: Store;
+  editorSettings: EditorSettings;
+  repoName: string;
+  drawerOpen: boolean;
+}>();
+const emit = defineEmits<{
+  chooseRepo: [];
+  addNote: [target?: NoteTarget];
+  "update:drawerOpen": [open: boolean];
+}>();
+
+const diffPane = ref<InstanceType<typeof DiffPane> | null>(null);
+const noteCount = computed(() => props.store.view?.notes.length ?? 0);
+const notesSize = computed({
+  get: () => (notesDock.value === "right" ? notesWidth.value : notesHeight.value),
+  set: (value: number) => {
+    if (notesDock.value === "right") notesWidth.value = value;
+    else notesHeight.value = value;
+  },
+});
+
+// The keymap reaches the diff through the surface that owns it: which diff is on screen
+// is this component's answer, not the window's.
+defineExpose({
+  goToChange(target: "next" | "previous"): void { diffPane.value?.goToChange(target); },
+  showDelta(): void { diffPane.value?.showDelta(); },
+});
+</script>
+
+<template>
+  <ContextToolbar
+    v-if="store.view && store.currentRepoId === store.targetRepoId"
+    :title="repoName"
+    refresh-label="Fetch origin"
+    :busy="store.busy"
+    :progress="`${store.progress().done}/${store.progress().total} reviewed`"
+    @refresh="store.fetchNow()"
+  >
+    <template #subtitle>
+      <StackPosition v-if="store.view.pr.stack" class="header-stack-position" :position="store.view.pr.stack.position" :size="store.view.pr.stack.size" /> #{{ store.view.pr.number }} {{ store.view.pr.title }}
+    </template>
+    <button aria-label="Add note (N)" title="Add note (N)" @click="emit('addNote')"><Plus :size="14" /> Note</button>
+    <button aria-label="Notes" :title="`Notes (${noteCount})`" @click="emit('update:drawerOpen', !drawerOpen)"><MessageSquare :size="15" /><span v-if="noteCount">{{ noteCount }}</span></button>
+  </ContextToolbar>
+  <section class="work-surface">
+    <p v-if="store.busy && !store.view" class="empty"><span class="spinner spin" />Opening pull request…</p>
+    <EmptyState
+      v-else-if="!store.targetRepoId"
+      title="Open a repository from disk"
+      detail="Pull requests belong to the repository you choose as your target."
+    >
+      <button type="button" @click="emit('chooseRepo')">Open repository folder…</button>
+    </EmptyState>
+    <EmptyState
+      v-else-if="!store.view || store.currentRepoId !== store.targetRepoId"
+      title="Select a pull request"
+      detail="Choose a pull request or stack from the sidebar to begin reviewing."
+    />
+    <div v-else class="workspace" :class="notesDock">
+      <DiffPane ref="diffPane" :store="store" :editor-settings="editorSettings" class="diff" @add-note="emit('addNote', $event)" />
+      <template v-if="drawerOpen">
+        <Splitter v-model="notesSize" :orientation="notesDock === 'right' ? 'vertical' : 'horizontal'" :min="notesDock === 'right' ? 220 : 120" :max="700" inverted />
+        <NotesDrawer
+          :store="store"
+          class="drawer"
+          :dock="notesDock"
+          :style="notesDock === 'right' ? { width: `${notesWidth}px` } : { height: `${notesHeight}px` }"
+          @dock="notesDock = $event"
+          @close="emit('update:drawerOpen', false)"
+          @add-note="emit('addNote')"
+        />
+      </template>
+    </div>
+  </section>
+</template>
+
+<style scoped src="../styles/work-surface.css"></style>
+
+<style scoped>
+.workspace { flex: 1; display: flex; min-width: 0; min-height: 0; }
+.workspace.right { flex-direction: row; }
+.workspace.bottom { flex-direction: column; }
+.drawer { flex: none; }
+.workspace.bottom .drawer { border-left: none; border-top: 1px solid var(--workbench-border); }
+</style>

--- a/packages/app/src/renderer/src/components/WorkbenchSidebar.vue
+++ b/packages/app/src/renderer/src/components/WorkbenchSidebar.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { onBeforeUnmount, shallowRef } from "vue";
+import type { FileIconThemeId } from "../../../file-icon-themes.js";
+import type { EffectiveTreeTypography } from "../../../settings.js";
+import type { Store } from "../store.js";
+import type { JumpTarget } from "../tree-jump.js";
+import { treeWidth } from "../layout.js";
+import LocalSidebar from "./LocalSidebar.vue";
+import PullRequestSidebar from "./PullRequestSidebar.vue";
+import Splitter from "./Splitter.vue";
+
+/** The tree beside the work surface, and the handle that sizes it. */
+defineProps<{
+  store: Store;
+  mode: "explorer" | "changes" | "pulls";
+  iconTheme: FileIconThemeId;
+  typography: EffectiveTreeTypography;
+  jumpTargets: ReadonlyMap<string, JumpTarget>;
+}>();
+defineEmits<{ selectPr: [prNumber: number] }>();
+
+// The scrollbar is invisible until the tree is in use, so that a still sidebar is just
+// filenames. Scrolling counts as use for a moment after it stops.
+const scrolling = shallowRef(false);
+let settle: ReturnType<typeof setTimeout> | undefined;
+
+function onScroll(): void {
+  scrolling.value = true;
+  clearTimeout(settle);
+  settle = setTimeout(() => { scrolling.value = false; }, 500);
+}
+
+onBeforeUnmount(() => { clearTimeout(settle); });
+</script>
+
+<template>
+  <div class="view-sidebar" :class="{ scrolling }" :style="{ width: `${treeWidth}px` }">
+    <LocalSidebar
+      v-if="mode === 'explorer' || mode === 'changes'"
+      :store="store"
+      :mode="mode"
+      :icon-theme="iconTheme"
+      :typography="typography"
+      @scroll="onScroll"
+    />
+    <PullRequestSidebar
+      v-else
+      :store="store"
+      :icon-theme="iconTheme"
+      :typography="typography"
+      :jump-targets="jumpTargets"
+      @select-pr="$emit('selectPr', $event)"
+      @scroll="onScroll"
+    />
+  </div>
+  <Splitter v-model="treeWidth" orientation="vertical" :min="190" :max="520" />
+</template>
+
+<style scoped>
+.view-sidebar { --scrollbar-thumb: transparent; --scrollbar-track: transparent; flex: none; min-height: 0; border-right: 1px solid var(--workbench-border); scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track); scrollbar-width: thin; transition: scrollbar-color 120ms cubic-bezier(0.16, 1, 0.3, 1); }
+.view-sidebar:hover, .view-sidebar:focus-within, .view-sidebar.scrolling { --scrollbar-thumb: color-mix(in srgb, var(--faint-foreground) 45%, transparent); }
+@media (prefers-reduced-motion: reduce) { .view-sidebar { transition: none; } }
+@media (prefers-contrast: more) { .view-sidebar:hover, .view-sidebar:focus-within, .view-sidebar.scrolling { --scrollbar-thumb: var(--workbench-foreground); } }
+@media (forced-colors: active) { .view-sidebar { scrollbar-color: auto; } }
+</style>

--- a/packages/app/src/renderer/src/composables/use-background-refresh.ts
+++ b/packages/app/src/renderer/src/composables/use-background-refresh.ts
@@ -1,0 +1,41 @@
+import { onBeforeUnmount } from "vue";
+import type { Store } from "../store.js";
+
+const POLL_MS = 30_000;
+const HEALTH_MS = 15_000;
+
+/**
+ * Keeps what is on screen honest without the reviewer asking: the open review is re-read
+ * on a slow poll, the service is pinged on a faster one, and coming back to the window
+ * refreshes everything at once.
+ */
+export function useBackgroundRefresh(store: Store, hasLoadedView: () => boolean): void {
+  // One refresh at a time. The poll and the focus handler both fire on a window the
+  // reviewer just came back to, and the second one would read a half-written view.
+  let refreshing = false;
+
+  async function refreshOnce(): Promise<void> {
+    if (refreshing || !hasLoadedView()) return;
+    refreshing = true;
+    try { await store.refresh(); } finally { refreshing = false; }
+  }
+
+  const poll = setInterval(() => void refreshOnce(), POLL_MS);
+  const health = setInterval(() => void store.checkService(), HEALTH_MS);
+
+  function onFocus(): void {
+    void store.checkService();
+    void refreshOnce();
+    // A pull request opened elsewhere — a browser, an agent, `gh pr create` — is the
+    // usual reason the reviewer comes back to the window at all.
+    void store.refreshPrs();
+  }
+
+  window.addEventListener("focus", onFocus);
+
+  onBeforeUnmount(() => {
+    clearInterval(poll);
+    clearInterval(health);
+    window.removeEventListener("focus", onFocus);
+  });
+}

--- a/packages/app/src/renderer/src/composables/use-review-keyboard.ts
+++ b/packages/app/src/renderer/src/composables/use-review-keyboard.ts
@@ -1,0 +1,191 @@
+import { nextTick, onBeforeUnmount, watch, type Ref } from "vue";
+import type { PrFile } from "@gander/shared";
+import { bindingFor, isPrefix, type Command, type Prefix } from "../keymap.js";
+import { collapsedDirs, cursor, edge, filesAt, nextUnmarked, parentOf, rowAt, step } from "../tree-nav.js";
+import { useTreeJump, type TreeJump } from "../tree-jump.js";
+import type { Store } from "../store.js";
+import type { WorkbenchMode } from "./use-workbench.js";
+
+/** The two things only the diff editor can do, reached from the keymap. */
+export interface DiffCommands {
+  goToChange(target: "next" | "previous"): void;
+  showDelta(): void;
+}
+
+export interface KeyboardSurface {
+  store: Store;
+  /** Which surface is on screen. A half-typed jump does not survive leaving it. */
+  mode: () => WorkbenchMode;
+  treeVisible: Ref<boolean>;
+  drawerOpen: Ref<boolean>;
+  helpOpen: Ref<boolean>;
+  /** Null until the review surface has mounted its diff. */
+  diff: () => DiffCommands | null;
+  captureNote: () => void;
+}
+
+/**
+ * Every key the reviewer presses outside a text box, and the cursor it moves.
+ *
+ * Selection is the app's cursor, so these keys work wherever the reviewer is looking —
+ * the tree, the diff, the notes. Nothing in the app is editable, which is what makes bare
+ * letters safe; `isTyping` guards the note input and the settings fields, the only places
+ * a letter means itself.
+ */
+export function useReviewKeyboard(surface: KeyboardSurface): TreeJump {
+  const { store } = surface;
+  const treeJump = useTreeJump(() => store.files(), (path) => { moveTo(path); });
+
+  // The half-typed jump is about what is on screen right now, so changing the surface,
+  // changing which pull request is open, or hiding the tree all retire it.
+  watch(
+    [surface.mode, () => `${store.currentRepoId ?? ""}#${store.view?.pr.number ?? ""}`, surface.treeVisible],
+    () => treeJump.cancel(),
+  );
+
+  function isTyping(target: HTMLElement | null): boolean {
+    if (target === null) return false;
+    if (target.closest("[data-app-typing='true']") !== null) return true;
+    if (target.closest(".monaco-editor") !== null) return false;
+    return target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable;
+  }
+
+  function runCommand(command: Command): boolean {
+    const files = store.files();
+    const at = cursor.value ?? store.selectedPath;
+
+    switch (command) {
+      case "next-file":
+      case "previous-file":
+        return moveTo(step(files, at, command === "next-file" ? 1 : -1));
+      case "first-file":
+      case "last-file":
+        return moveTo(edge(files, command === "first-file" ? "first" : "last"));
+      case "jump-row":
+        return surface.treeVisible.value && store.currentRepoId === store.targetRepoId && treeJump.start();
+      case "toggle-directory": {
+        if (at === null) return true;
+        // Opening a directory is how a reviewer says "let me look in here", so the cursor
+        // goes in with it. On anything else the same key closes the directory the cursor is
+        // inside and steps out to it, which is the way back.
+        if (rowAt(files, at)?.type === "dir" && collapsedDirs.has(at)) {
+          collapsedDirs.delete(at);
+          return moveTo(step(files, at, 1));
+        }
+        const dir = rowAt(files, at)?.type === "dir" ? at : parentOf(files, at);
+        if (dir === null) return true;
+        collapsedDirs.add(dir);
+        return moveTo(dir);
+      }
+      case "dismiss": {
+        if (!surface.helpOpen.value) return false;
+        surface.helpOpen.value = false;
+        return true;
+      }
+      case "toggle-checked": {
+        mark(at, null);
+        return true;
+      }
+      case "mark-and-advance":
+      case "mark-and-retreat": {
+        // Read before marking: once this row is marked it is no longer a candidate, and the
+        // search would step over where the reviewer actually is.
+        const next = nextUnmarked(files, at, command === "mark-and-advance" ? 1 : -1);
+        mark(at, true);
+        if (next !== null && next !== at) moveTo(next);
+        return true;
+      }
+      case "next-change":
+        surface.diff()?.goToChange("next");
+        return true;
+      case "previous-change":
+        surface.diff()?.goToChange("previous");
+        return true;
+      case "delta-view":
+        surface.diff()?.showDelta();
+        return true;
+      case "capture-note":
+        surface.captureNote();
+        return true;
+      case "toggle-notes":
+        surface.drawerOpen.value = !surface.drawerOpen.value;
+        return true;
+      case "toggle-tree":
+        surface.treeVisible.value = !surface.treeVisible.value;
+        return true;
+      case "help":
+        surface.helpOpen.value = !surface.helpOpen.value;
+        return true;
+    }
+  }
+
+  /**
+   * Moves the cursor, and opens the row when it is a file. A directory has nothing to show,
+   * so passing over one leaves the reader looking at the file they were already reading.
+   */
+  function moveTo(path: string | null): boolean {
+    if (path === null) return true;
+    cursor.value = path;
+    if (rowAt(store.files(), path)?.type === "file") store.select(path);
+    return true;
+  }
+
+  /** Marks a row: one file, or every file under a directory. `checked` null means toggle. */
+  function mark(path: string | null, checked: boolean | null): void {
+    const under = filesAt(store.files(), path).filter((file): file is PrFile => "checked" in file);
+    if (under.length === 0) return;
+    const next = checked ?? under.some((file) => !file.checked);
+    const changing = under.filter((file) => file.checked !== next).map((file) => file.path);
+    if (changing.length === 0) return;
+    if (changing.length === 1) void store.setChecked(changing[0]!, next);
+    else void store.setCheckedMany(changing, next);
+  }
+
+  // Keyboard movement can leave the cursor outside the scrolled area, where the reviewer
+  // cannot see what they are on. Follow it; a mouse click is already in view.
+  watch(cursor, async () => {
+    await nextTick();
+    document.querySelector(".view-sidebar .tnode.cur")?.scrollIntoView({ block: "nearest" });
+  });
+
+  // A file opened by any other route — a click, a note, opening the pull request — becomes
+  // where the keyboard continues from.
+  watch(() => store.selectedPath, (path) => {
+    if (path !== null && rowAt(store.files(), cursor.value)?.type !== "dir") cursor.value = path;
+  });
+
+  // The half-typed prefix of a two-key binding. Cleared by whatever comes next, so a `g`
+  // followed by anything other than the key that completes a chord does nothing at all.
+  let pending: Prefix | null = null;
+
+  function onKey(event: KeyboardEvent): void {
+    if (isTyping(event.target as HTMLElement | null)) return;
+    if (treeJump.active.value && treeJump.handleKey(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    const started = isPrefix(event, pending);
+    if (started !== null) {
+      pending = started;
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    const binding = bindingFor(event, pending);
+    pending = null;
+    if (binding === null) return;
+    // Everything but the panel toggles is about a pull request under review; in the local
+    // viewer there is no checkoff, no note, and no delta to reach.
+    const reviewing = store.view !== null && surface.mode() === "pulls";
+    if (!reviewing && binding.group !== "Panels") return;
+    if (!runCommand(binding.command)) return;
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  window.addEventListener("keydown", onKey, true);
+  onBeforeUnmount(() => { window.removeEventListener("keydown", onKey, true); });
+
+  return treeJump;
+}

--- a/packages/app/src/renderer/src/composables/use-window-zoom.ts
+++ b/packages/app/src/renderer/src/composables/use-window-zoom.ts
@@ -1,0 +1,32 @@
+import { onBeforeUnmount, onMounted, shallowRef, type ShallowRef } from "vue";
+import type { GanderApi } from "../api.js";
+import { DEFAULT_ZOOM_LEVEL, clampZoomLevel } from "../../../zoom.js";
+
+/**
+ * The window's zoom, which the menu and the keyboard can change behind the app's back —
+ * hence the subscription rather than a value read once.
+ */
+export function useWindowZoom(api: GanderApi): {
+  level: ShallowRef<number>;
+  change(level: number): Promise<void>;
+} {
+  const level = shallowRef(DEFAULT_ZOOM_LEVEL);
+  let unsubscribe: (() => void) | null = null;
+
+  onMounted(async () => {
+    unsubscribe = api.onZoomChanged((changed) => { level.value = changed; });
+    level.value = await api.getZoomLevel();
+  });
+
+  onBeforeUnmount(() => { unsubscribe?.(); });
+
+  return {
+    level,
+    // Clamp first so the control settles where it will land, rather than overshooting and
+    // snapping back a round trip later.
+    async change(next: number): Promise<void> {
+      level.value = clampZoomLevel(next);
+      level.value = await api.setZoomLevel(next);
+    },
+  };
+}

--- a/packages/app/src/renderer/src/composables/use-workbench.ts
+++ b/packages/app/src/renderer/src/composables/use-workbench.ts
@@ -1,0 +1,226 @@
+import { computed, onBeforeUnmount, onMounted, shallowRef, type ComputedRef, type ShallowRef } from "vue";
+import type { OpenTarget } from "@gander/shared";
+import type { GanderApi } from "../api.js";
+import type { Store } from "../store.js";
+
+/** The four things the activity rail can put on screen. */
+export type WorkbenchMode = "explorer" | "changes" | "pulls" | "settings";
+export type SettingsCategory = "workbench" | "editor" | "connection";
+
+type LocalMode = "explorer" | "changes";
+
+export interface Workbench {
+  activeMode: ShallowRef<WorkbenchMode>;
+  /**
+   * Settings covers the work surface instead of replacing it: rebuilding the editor every
+   * time the reviewer checks a setting is the cost this avoids.
+   */
+  surfaceMode: ComputedRef<Exclude<WorkbenchMode, "settings">>;
+  settingsCategory: ShallowRef<SettingsCategory>;
+  /** No review service is configured, so pull requests are out of reach until one is. */
+  unconfigured: ShallowRef<boolean>;
+  openSettings(category?: SettingsCategory): void;
+  closeSettings(): void;
+  onConnected(): Promise<void>;
+  openExternalTarget(target: OpenTarget): Promise<void>;
+  chooseRepo(repoId?: string): Promise<void>;
+  removeRepo(repoId: string): Promise<void>;
+  selectRepo(repoId: string, options?: { keepChosenMode?: boolean }): Promise<void>;
+  selectWorktree(path: string): Promise<void>;
+  selectMode(mode: WorkbenchMode): Promise<void>;
+  openPr(prNumber: number): Promise<void>;
+}
+
+/**
+ * Which surface the window is showing, and everything that changes it.
+ *
+ * The rule underneath all of it: opening a target decides where the reviewer lands, and
+ * the reviewer's own navigation always wins over a load that is still in flight.
+ */
+export function useWorkbench(store: Store, api: GanderApi): Workbench {
+  const activeMode = shallowRef<WorkbenchMode>("explorer");
+  const modeBeforeSettings = shallowRef<Exclude<WorkbenchMode, "settings">>("explorer");
+  const settingsCategory = shallowRef<SettingsCategory>("workbench");
+  const unconfigured = shallowRef(false);
+
+  const surfaceMode = computed(() => (
+    activeMode.value === "settings" ? modeBeforeSettings.value : activeMode.value
+  ));
+
+  async function refreshConnectionState(): Promise<void> {
+    unconfigured.value = (await api.getConnection()).url === "";
+    await store.checkService();
+  }
+
+  function openSettings(category: SettingsCategory = "workbench"): void {
+    if (activeMode.value !== "settings") modeBeforeSettings.value = activeMode.value;
+    settingsCategory.value = category;
+    activeMode.value = "settings";
+  }
+
+  function closeSettings(): void {
+    activeMode.value = modeBeforeSettings.value;
+    void refreshConnectionState();
+  }
+
+  async function onConnected(): Promise<void> {
+    await refreshConnectionState();
+    await store.loadRepos();
+  }
+
+  function landIn(mode: LocalMode, keepChosenMode: boolean): void {
+    // The reviewer went somewhere else while the load was in flight: remember where this
+    // target landed, so closing Settings returns to it, and leave them where they are.
+    if (keepChosenMode && activeMode.value !== "explorer") {
+      modeBeforeSettings.value = mode;
+      return;
+    }
+    activeMode.value = mode;
+  }
+
+  async function openLocalTarget(
+    path: string,
+    mode: LocalMode,
+    contextError: string | null,
+    keepChosenMode = false,
+  ): Promise<void> {
+    await store.openLocal(path);
+    const localError = store.error;
+    const errors = [...new Set([contextError, localError].filter((error): error is string => error !== null))];
+    store.error = errors.length ? errors.join("\n") : null;
+    if (localError) return;
+    store.showLocalSurface(mode);
+    landIn(mode, keepChosenMode);
+  }
+
+  async function openExternalTarget(target: OpenTarget): Promise<void> {
+    await store.openTarget(target);
+    // A named pull request opens in the review even for a repository with no checkout on
+    // this machine: the command named a review, not a folder.
+    if (target.prNumber !== null && store.targetRepoId === target.repoId) {
+      activeMode.value = "pulls";
+      return;
+    }
+    if (store.targetRepoId !== target.repoId || store.targetWorktreePath === null) {
+      activeMode.value = "explorer";
+      return;
+    }
+    if (store.targetWorktreePath) {
+      await openLocalTarget(store.targetWorktreePath, "explorer", store.error);
+    } else activeMode.value = "pulls";
+  }
+
+  /**
+   * `keepChosenMode` is for the repository opened at launch: that load finishes long after
+   * the window is usable, and it must not drag the reviewer out of a view they opened
+   * while it was still working.
+   */
+  async function selectRepo(repoId: string, { keepChosenMode = false } = {}): Promise<void> {
+    await store.selectRepo(repoId);
+    const contextError = store.error;
+    if (!store.targetWorktreePath) {
+      landIn("explorer", keepChosenMode);
+      return;
+    }
+    await openLocalTarget(store.targetWorktreePath, "explorer", contextError, keepChosenMode);
+  }
+
+  /** Register a repository from a folder on disk, and open its checkout. `repoId` names the one the reviewer is being asked to locate. */
+  async function chooseRepo(repoId?: string): Promise<void> {
+    if (!await store.chooseLocalRepo(repoId)) return;
+    const contextError = store.error;
+    if (!store.targetWorktreePath) {
+      activeMode.value = "explorer";
+      return;
+    }
+    await openLocalTarget(store.targetWorktreePath, "explorer", contextError);
+  }
+
+  async function removeRepo(repoId: string): Promise<void> {
+    await store.removeRepo(repoId);
+    activeMode.value = "explorer";
+    const next = store.repos[0];
+    if (next) await selectRepo(next.repoId);
+  }
+
+  async function selectWorktree(path: string): Promise<void> {
+    const nextMode = activeMode.value === "changes" ? "changes" : "explorer";
+    await store.openLocal(path);
+    if (store.error) return;
+    store.showLocalSurface(nextMode);
+    activeMode.value = nextMode;
+  }
+
+  async function selectMode(mode: WorkbenchMode): Promise<void> {
+    if (mode === "settings") {
+      openSettings();
+      return;
+    }
+    if (mode === "pulls") {
+      activeMode.value = "pulls";
+      if (store.selectedPrNumber !== null && (store.view?.pr.number !== store.selectedPrNumber || store.currentRepoId !== store.targetRepoId)) {
+        await store.openPr(store.selectedPrNumber);
+      }
+      return;
+    }
+
+    activeMode.value = mode;
+    const path = store.targetWorktreePath;
+    if (!path) return;
+    if (store.localView?.worktree.path !== path || store.currentRepoId !== store.targetRepoId) await store.openLocal(path);
+    if (!store.error) store.showLocalSurface(mode);
+  }
+
+  async function openPr(prNumber: number): Promise<void> {
+    activeMode.value = "pulls";
+    await store.openPr(prNumber);
+  }
+
+  /** What the window opens with: the target named on the command line, or the last repository. */
+  async function start(): Promise<void> {
+    await refreshConnectionState();
+    await store.loadRepos();
+
+    const target = await api.initialTarget();
+    if (target !== null) {
+      await openExternalTarget(target);
+      return;
+    }
+
+    const firstRepo = store.repos[0];
+    if (firstRepo) await selectRepo(firstRepo.repoId, { keepChosenMode: true });
+  }
+
+  // The main process can name a target at any time — at launch, and again whenever
+  // `bin/gander` is run against this window.
+  let unsubscribeOpenTarget: (() => void) | null = null;
+  let unsubscribeOpenSettings: (() => void) | null = null;
+
+  onMounted(async () => {
+    unsubscribeOpenTarget = api.onOpenTarget((target) => { void openExternalTarget(target); });
+    unsubscribeOpenSettings = api.onOpenSettings(() => openSettings());
+    await start();
+  });
+
+  onBeforeUnmount(() => {
+    unsubscribeOpenTarget?.();
+    unsubscribeOpenSettings?.();
+  });
+
+  return {
+    activeMode,
+    surfaceMode,
+    settingsCategory,
+    unconfigured,
+    openSettings,
+    closeSettings,
+    onConnected,
+    openExternalTarget,
+    chooseRepo,
+    removeRepo,
+    selectRepo,
+    selectWorktree,
+    selectMode,
+    openPr,
+  };
+}

--- a/packages/app/src/renderer/src/styles/work-surface.css
+++ b/packages/app/src/renderer/src/styles/work-surface.css
@@ -1,0 +1,34 @@
+/* The area under the context toolbar, shared by every surface that fills it: the local
+   viewer, the review, and whatever a surface shows instead when there is nothing yet. */
+.work-surface {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  background: var(--workbench-background);
+}
+
+.diff {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* A line of text where a file would be. Centred, because it is the whole surface. */
+.empty {
+  margin: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 2rem;
+  color: var(--faint-foreground);
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--workbench-border);
+  border-top-color: var(--faint-foreground);
+  border-radius: 50%;
+}

--- a/packages/app/src/renderer/src/tree-jump.ts
+++ b/packages/app/src/renderer/src/tree-jump.ts
@@ -53,7 +53,7 @@ export function jumpTargets(files: ChangedFile[], query: string): JumpTarget[] {
   }));
 }
 
-interface TreeJump {
+export interface TreeJump {
   active: ComputedRef<boolean>;
   targetsByPath: ComputedRef<ReadonlyMap<string, JumpTarget>>;
   start: () => boolean;


### PR DESCRIPTION
App.vue was 621 lines. It held the window's whole navigation model, every keyboard
command, two polling loops, the zoom subscription, and both work surfaces written out
in full. It is now 179 and reads as what it is — the shell that composes the rest.

| Extracted | Lines | Holds |
|---|---|---|
| `use-workbench.ts` | 226 | Which surface is showing and everything that changes it, the target subscriptions, and what the window opens with |
| `use-review-keyboard.ts` | 191 | Every binding, the cursor it moves, and the tree jump |
| `ReviewSurface.vue` | 100 | The pull request under review, its notes drawer, and its splitter |
| `WorkbenchSidebar.vue` | 65 | The tree, its splitter, and the scrollbar's fade |
| `LocalSurface.vue` | 60 | A worktree on this machine, in Explorer or Current Diff |
| `use-background-refresh.ts` | 40 | The review poll, the service poll, and refresh on focus |
| `use-window-zoom.ts` | 32 | The level, its subscription, and the clamp |

`styles/work-surface.css` holds what both surfaces share, included the way `tree.css`
already is.

## The one visible change

`.working` folded into `.empty`, so the plain "Select the target again to load this
worktree." text is now a flex container. It renders the same.

## New indirection, and its test

The keymap used to hold a ref to the diff. It now goes through ReviewSurface, which
forwards the two commands only the diff can answer. A broken forward would move nothing
and say nothing, so `keyboard-focus.spec.ts` reads the cursor back off the note the next
keystroke captures: line 2 with the chain intact, line 1 without. Proved by breaking the
forward and watching it fail.

## Checks

`pnpm typecheck`, 380 unit tests, and all 14 end-to-end specs pass on macOS. Both work
surfaces and the notes drawer were screenshotted in the built app and render as before.