### PR TITLE
Add note dialog actions

### DIFF
--- a/packages/app/src/renderer/src/components/NoteCapture.test.ts
+++ b/packages/app/src/renderer/src/components/NoteCapture.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import type { Store } from "../store.js";
 import NoteCapture from "./NoteCapture.vue";
@@ -41,6 +41,36 @@ describe("NoteCapture", () => {
 
     expect(addNote).toHaveBeenCalledWith("Keep this anchor", "reviewed-file.ts", 17);
     expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+
+  it("offers mouse controls for saving and cancelling", async () => {
+    const addNote = vi.fn(async () => {});
+    const store = { addNote } as unknown as Store;
+    const wrapper = mount(NoteCapture, {
+      props: { store, target: { path: "src/review.ts", line: 12 } },
+      attachTo: document.body,
+    });
+
+    const save = wrapper.get("button.save");
+    expect(save.text()).toBe("Save");
+    expect(save.attributes("disabled")).toBeDefined();
+
+    await wrapper.get("textarea").setValue("Review this with a mouse");
+    expect(save.attributes("disabled")).toBeUndefined();
+    (save.element as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(addNote).toHaveBeenCalledWith("Review this with a mouse", "src/review.ts", 12);
+    expect(wrapper.emitted("close")).toHaveLength(1);
+    wrapper.unmount();
+
+    const cancelWrapper = mount(NoteCapture, {
+      props: { store, target: { path: "src/review.ts", line: 12 } },
+    });
+    await cancelWrapper.get("button.cancel").trigger("click");
+
+    expect(cancelWrapper.emitted("close")).toHaveLength(1);
+    expect(addNote).toHaveBeenCalledTimes(1);
   });
 
   it("supports a pull-request-level target", async () => {

--- a/packages/app/src/renderer/src/components/NoteCapture.vue
+++ b/packages/app/src/renderer/src/components/NoteCapture.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, shallowRef, useTemplateRef, watch } from "vue";
+import { computed, nextTick, shallowRef, useTemplateRef, watch } from "vue";
 import type { Store } from "../store.js";
 import type { NoteTarget } from "../selection.js";
 
@@ -7,6 +7,8 @@ const props = defineProps<{ store: Store; target: NoteTarget | null }>();
 const emit = defineEmits<{ close: [] }>();
 
 const text = shallowRef("");
+const saving = shallowRef(false);
+const canSave = computed(() => text.value.trim().length > 0 && !saving.value);
 const box = useTemplateRef<HTMLTextAreaElement>("box");
 
 watch(() => props.target, async (target) => {
@@ -17,12 +19,17 @@ watch(() => props.target, async (target) => {
 });
 
 async function submit(): Promise<void> {
+  if (!canSave.value) return;
   const body = text.value.trim();
-  if (!body) return;
   // The target is fixed before the textarea takes focus. In particular, a gutter click
   // must keep the line it named even if Monaco's cursor or the selected file moves.
-  await props.store.addNote(body, props.target?.path ?? null, props.target?.line ?? null);
-  emit("close");
+  saving.value = true;
+  try {
+    await props.store.addNote(body, props.target?.path ?? null, props.target?.line ?? null);
+    emit("close");
+  } finally {
+    saving.value = false;
+  }
 }
 </script>
 
@@ -46,8 +53,16 @@ async function submit(): Promise<void> {
         @keydown.enter.exact.prevent="submit"
         @keydown.esc.prevent="$emit('close')"
       />
-      <div id="note-capture-hint" class="hint">
-        <kbd>Enter</kbd> to save · <kbd>Shift</kbd>+<kbd>Enter</kbd> for a new line · <kbd>Esc</kbd> to cancel
+      <div class="footer">
+        <div id="note-capture-hint" class="hint">
+          <kbd>Enter</kbd> to save · <kbd>Shift</kbd>+<kbd>Enter</kbd> for a new line · <kbd>Esc</kbd> to cancel
+        </div>
+        <div class="actions">
+          <button type="button" class="cancel" @click="$emit('close')">Cancel</button>
+          <button type="submit" class="save" :disabled="!canSave">
+            {{ saving ? "Saving…" : "Save" }}
+          </button>
+        </div>
       </div>
     </form>
   </div>
@@ -61,6 +76,17 @@ async function submit(): Promise<void> {
 .note { width: 100%; height: clamp(180px, 42vh, 420px); min-height: 120px; max-height: calc(100vh - 160px); background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-md); color: var(--workbench-foreground); caret-color: var(--accent); font: inherit; font-size: 14px; line-height: 1.6; padding: 14px 16px; resize: vertical; }
 .note::selection { background: var(--selection-background); }
 .note:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
+.footer { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
 .hint { font-size: 11px; color: var(--faint-foreground); }
 kbd { font: 10.5px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 1px 5px; }
+.actions { display: flex; flex: none; gap: 8px; }
+button { height: 30px; padding: 0 14px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 12px; cursor: pointer; }
+button:hover:not(:disabled) { border-color: var(--accent); }
+button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+button:disabled { opacity: .55; cursor: default; }
+.save { border-color: var(--accent); background: var(--accent); color: var(--accent-foreground); font-weight: 600; }
+
+@media (max-width: 620px) {
+  .footer { align-items: flex-end; flex-direction: column; }
+}
 </style>


### PR DESCRIPTION
## Summary

- add visible Cancel and Save buttons to the note capture dialog
- disable Save for blank notes and while a save is running
- preserve the existing Enter, Shift+Enter, and Escape shortcuts
- cover mouse save and cancel behavior with a component test

## Readiness

- Simplify: clean
- Code review: clean, no findings
- Adversarial review: skipped; this is a low-risk renderer-only change
- UI audit and polish: clean

## Test plan

- `pnpm test` — 381 tests passed
- `pnpm typecheck`
- focused NoteCapture component test — 4 tests passed
- isolated Electron render check of the dialog
- Impeccable UI detector — clean
