### PR TITLE
Add review files toolbar

### DIFF
--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -28,7 +28,7 @@ test("review file toolbar controls folder disclosure and remaining files", async
 
   await toolbar.getByRole("button", { name: "Collapse all folders" }).click();
   await expect(review.file("src/main.ts")).toHaveCount(0);
-  await app.page.locator(".tnode.isdir").filter({ hasText: "src" }).click();
+  await toolbar.getByRole("button", { name: "Expand all folders" }).click();
   await expect(review.file("src/main.ts")).toBeVisible();
 
   // A reviewed top-level file cannot be hidden by folding a parent folder. This is the

--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -22,23 +22,31 @@ test("review file toolbar controls folder disclosure and remaining files", async
 
   await review.open(repository.title);
   const toolbar = app.page.getByRole("toolbar", { name: "Review file display" });
-  await expect(toolbar).toContainText("6 of 6 remaining");
+  await expect(toolbar.getByRole("button")).toHaveText(["Expand", "Collapse", "Remaining"]);
+  await expect(app.page.locator(".files-section header")).toContainText("6/6 left");
 
   await toolbar.getByRole("button", { name: "Collapse all folders" }).click();
   await expect(review.file("src/main.ts")).toHaveCount(0);
   await toolbar.getByRole("button", { name: "Expand all folders" }).click();
   await expect(review.file("src/main.ts")).toBeVisible();
 
-  await review.checkFile("docs/guide.md");
-  await toolbar.getByRole("button", { name: "Collapse reviewed folders" }).click();
-  await expect(review.file("docs/guide.md")).toHaveCount(0);
-  await expect(review.file("src/main.ts")).toBeVisible();
+  // A reviewed top-level file cannot be hidden by folding a parent folder. This is the
+  // important behavior: Remaining filters files, rather than merely collapsing directories.
+  await review.checkFile("a.rb");
 
   const remaining = toolbar.getByRole("button", { name: "Show remaining files only" });
   await remaining.click();
   await expect(remaining).toHaveAttribute("aria-pressed", "true");
-  await expect(toolbar).toContainText("5 of 6 remaining");
-  await expect(app.page.locator(".tnode.isdir").filter({ hasText: "docs" })).toHaveCount(0);
+  await expect(app.page.locator(".files-section header")).toContainText("5/6 left");
+  await expect(review.file("a.rb")).toHaveCount(0);
   await expect(review.file("src/main.ts")).toBeVisible();
 
+  await review.file("src/main.ts").getByRole("checkbox").click();
+  await expect(review.file("src/main.ts")).toHaveCount(0);
+  await expect(app.page.locator(".files-section header")).toContainText("4/6 left");
+
+  await remaining.click();
+  await expect(remaining).toHaveAttribute("aria-pressed", "false");
+  await expect(review.file("a.rb")).toBeVisible();
+  await expect(review.file("src/main.ts")).toBeVisible();
 });

--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -22,12 +22,13 @@ test("review file toolbar controls folder disclosure and remaining files", async
 
   await review.open(repository.title);
   const toolbar = app.page.getByRole("toolbar", { name: "Review file display" });
-  await expect(toolbar.getByRole("button")).toHaveText(["Expand", "Collapse", "Remaining"]);
+  await expect(toolbar.getByRole("button")).toHaveCount(2);
+  await expect(toolbar.getByRole("button", { name: "Show remaining files only" })).toHaveText("Remaining");
   await expect(app.page.locator(".files-section header")).toContainText("6/6 left");
 
   await toolbar.getByRole("button", { name: "Collapse all folders" }).click();
   await expect(review.file("src/main.ts")).toHaveCount(0);
-  await toolbar.getByRole("button", { name: "Expand all folders" }).click();
+  await app.page.locator(".tnode.isdir").filter({ hasText: "src" }).click();
   await expect(review.file("src/main.ts")).toBeVisible();
 
   // A reviewed top-level file cannot be hidden by folding a parent folder. This is the

--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -22,11 +22,11 @@ test("review file toolbar controls folder disclosure and remaining files", async
 
   await review.open(repository.title);
   const toolbar = app.page.getByRole("toolbar", { name: "Review file display" });
-  await expect(toolbar.getByRole("button")).toHaveCount(2);
+  await expect(toolbar.getByRole("button")).toHaveCount(3);
   await expect(app.page.locator(".files-section header").getByRole("toolbar", { name: "Review file display" })).toBeVisible();
   const progress = app.page.locator(".files-section header .review-progress");
-  await expect(progress).toHaveText("6/6 unchecked");
-  await expect(progress).toHaveAttribute("title", "6 of 6 files unchecked");
+  await expect(progress).toHaveText("6/6 unreviewed");
+  await expect(progress).toHaveAttribute("title", "6 of 6 files unreviewed");
 
   await toolbar.getByRole("button", { name: "Collapse all folders" }).click();
   await expect(review.file("src/main.ts")).toHaveCount(0);
@@ -37,19 +37,47 @@ test("review file toolbar controls folder disclosure and remaining files", async
   // important behavior: Remaining filters files, rather than merely collapsing directories.
   await review.checkFile("a.rb");
 
-  const remaining = toolbar.getByRole("button", { name: "Show unchecked files only" });
+  const remaining = toolbar.getByRole("button", { name: "Show unreviewed files only" });
   await remaining.click();
   await expect(remaining).toHaveAttribute("aria-pressed", "true");
-  await expect(progress).toHaveText("5/6 unchecked");
+  await expect(progress).toHaveText("5/6 unreviewed");
   await expect(review.file("a.rb")).toHaveCount(0);
   await expect(review.file("src/main.ts")).toBeVisible();
 
   await review.file("src/main.ts").getByRole("checkbox").click();
   await expect(review.file("src/main.ts")).toHaveCount(0);
-  await expect(progress).toHaveText("4/6 unchecked");
+  await expect(progress).toHaveText("4/6 unreviewed");
 
   await remaining.click();
   await expect(remaining).toHaveAttribute("aria-pressed", "false");
   await expect(review.file("a.rb")).toBeVisible();
+  await expect(review.file("src/main.ts")).toBeVisible();
+});
+
+test("collapses folders whose files are fully reviewed", async ({ world }) => {
+  const repository = await world.addRepository({
+    repoId: "acme/collapse-reviewed-folders",
+    baseFiles: {
+      "docs/guide.md": "old guide\n",
+      "src/main.ts": "old main\n",
+    },
+    featureFiles: {
+      "docs/guide.md": "new guide\n",
+      "src/main.ts": "new main\n",
+    },
+  });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+
+  await review.open(repository.title);
+  const collapseReviewed = app.page.getByRole("button", { name: "Collapse fully reviewed folders" });
+  await expect(collapseReviewed).toBeDisabled();
+
+  await review.file("docs").getByRole("checkbox").click();
+  await expect(collapseReviewed).toBeEnabled();
+  await collapseReviewed.click();
+
+  await expect(review.file("docs")).toBeVisible();
+  await expect(review.file("docs/guide.md")).toHaveCount(0);
   await expect(review.file("src/main.ts")).toBeVisible();
 });

--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -23,7 +23,7 @@ test("review file toolbar controls folder disclosure and remaining files", async
   await review.open(repository.title);
   const toolbar = app.page.getByRole("toolbar", { name: "Review file display" });
   await expect(toolbar.getByRole("button")).toHaveCount(2);
-  await expect(toolbar.getByRole("button", { name: "Show remaining files only" })).toHaveText("Remaining");
+  await expect(app.page.locator(".files-section header").getByRole("toolbar", { name: "Review file display" })).toBeVisible();
   await expect(app.page.locator(".files-section header")).toContainText("6/6 left");
 
   await toolbar.getByRole("button", { name: "Collapse all folders" }).click();

--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "./fixtures/test.js";
+import { ReviewDriver } from "./drivers/review.js";
+
+test("review file toolbar controls folder disclosure and remaining files", async ({ world }) => {
+  const repository = await world.addRepository({
+    repoId: "acme/review-toolbar",
+    baseFiles: {
+      "docs/guide.md": "old guide\n",
+      "src/nested/worker.ts": "old worker\n",
+      "src/main.ts": "old main\n",
+      "README.md": "old readme\n",
+    },
+    featureFiles: {
+      "docs/guide.md": "new guide\n",
+      "src/nested/worker.ts": "new worker\n",
+      "src/main.ts": "new main\n",
+      "README.md": "new readme\n",
+    },
+  });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+
+  await review.open(repository.title);
+  const toolbar = app.page.getByRole("toolbar", { name: "Review file display" });
+  await expect(toolbar).toContainText("6 of 6 remaining");
+
+  await toolbar.getByRole("button", { name: "Collapse all folders" }).click();
+  await expect(review.file("src/main.ts")).toHaveCount(0);
+  await toolbar.getByRole("button", { name: "Expand all folders" }).click();
+  await expect(review.file("src/main.ts")).toBeVisible();
+
+  await review.checkFile("docs/guide.md");
+  await toolbar.getByRole("button", { name: "Collapse reviewed folders" }).click();
+  await expect(review.file("docs/guide.md")).toHaveCount(0);
+  await expect(review.file("src/main.ts")).toBeVisible();
+
+  const remaining = toolbar.getByRole("button", { name: "Show remaining files only" });
+  await remaining.click();
+  await expect(remaining).toHaveAttribute("aria-pressed", "true");
+  await expect(toolbar).toContainText("5 of 6 remaining");
+  await expect(app.page.locator(".tnode.isdir").filter({ hasText: "docs" })).toHaveCount(0);
+  await expect(review.file("src/main.ts")).toBeVisible();
+
+});

--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -22,15 +22,19 @@ test("review file toolbar controls folder disclosure and remaining files", async
 
   await review.open(repository.title);
   const toolbar = app.page.getByRole("toolbar", { name: "Review file display" });
-  await expect(toolbar.getByRole("button")).toHaveCount(3);
+  await expect(toolbar.getByRole("button")).toHaveCount(2);
   await expect(app.page.locator(".files-section header").getByRole("toolbar", { name: "Review file display" })).toBeVisible();
   const progress = app.page.locator(".files-section header .review-progress");
   await expect(progress).toHaveText("6/6 unreviewed");
   await expect(progress).toHaveAttribute("title", "6 of 6 files unreviewed");
 
-  await toolbar.getByRole("button", { name: "Collapse all folders" }).click();
+  const moreActions = toolbar.getByRole("button", { name: "More review file actions" });
+  const actions = app.page.getByRole("group", { name: "More review file actions" });
+  await moreActions.click();
+  await actions.getByRole("button", { name: "Collapse all folders" }).click();
   await expect(review.file("src/main.ts")).toHaveCount(0);
-  await toolbar.getByRole("button", { name: "Expand all folders" }).click();
+  await moreActions.click();
+  await actions.getByRole("button", { name: "Expand all folders" }).click();
   await expect(review.file("src/main.ts")).toBeVisible();
 
   // A reviewed top-level file cannot be hidden by folding a parent folder. This is the
@@ -70,14 +74,83 @@ test("collapses folders whose files are fully reviewed", async ({ world }) => {
   const review = new ReviewDriver(app.page);
 
   await review.open(repository.title);
-  const collapseReviewed = app.page.getByRole("button", { name: "Collapse fully reviewed folders" });
+  const toolbar = app.page.getByRole("toolbar", { name: "Review file display" });
+  const moreActions = toolbar.getByRole("button", { name: "More review file actions" });
+  await moreActions.click();
+  const actions = app.page.getByRole("group", { name: "More review file actions" });
+  const collapseReviewed = actions.getByRole("button", { name: "Collapse fully reviewed folders" });
   await expect(collapseReviewed).toBeDisabled();
+  await app.page.keyboard.press("Escape");
 
   await review.file("docs").getByRole("checkbox").click();
+  await moreActions.click();
   await expect(collapseReviewed).toBeEnabled();
   await collapseReviewed.click();
 
   await expect(review.file("docs")).toBeVisible();
   await expect(review.file("docs/guide.md")).toHaveCount(0);
+  await expect(review.file("src/main.ts")).toBeVisible();
+});
+
+test("keeps review actions inside the minimum-width sidebar", async ({ world }) => {
+  const repository = await world.addRepository({
+    repoId: "acme/narrow-review-toolbar",
+    baseFiles: {
+      "docs/guide.md": "old guide\n",
+      "src/main.ts": "old main\n",
+    },
+    featureFiles: {
+      "docs/guide.md": "new guide\n",
+      "src/main.ts": "new main\n",
+    },
+  });
+  const app = await world.launch();
+  const setTreeWidth = async (treeWidth: number): Promise<void> => {
+    await app.page.evaluate((width) => {
+      localStorage.setItem("gander.layout", JSON.stringify({
+        notesDock: "right",
+        treeWidth: width,
+        notesWidth: 320,
+        notesHeight: 260,
+      }));
+    }, treeWidth);
+    await app.page.reload();
+    await app.page.getByRole("button", { name: "Editor settings" }).waitFor();
+  };
+  const review = new ReviewDriver(app.page);
+
+  await setTreeWidth(226);
+  await review.open(repository.title);
+  let header = app.page.locator(".files-section header");
+  await expect(header.locator(".review-title-prefix")).toBeHidden();
+  await expect(header.locator(".review-progress-label")).toBeVisible();
+  expect(await header.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+
+  await setTreeWidth(190);
+  await review.open(repository.title);
+  header = app.page.locator(".files-section header");
+  const toolbar = header.getByRole("toolbar", { name: "Review file display" });
+  await expect(toolbar.getByRole("button", { name: "Show unreviewed files only" })).toBeVisible();
+  await expect(toolbar.getByRole("button", { name: "More review file actions" })).toBeVisible();
+  await expect(toolbar.getByRole("button", { name: "Collapse all folders" })).toBeHidden();
+  await expect(header.locator(".review-title-prefix")).toBeHidden();
+  await expect(header.locator(".review-progress-label")).toBeHidden();
+  expect(await header.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+
+  const sidebar = app.page.locator(".view-sidebar");
+  for (const width of [190, 205, 206, 226, 250, 251, 264, 280, 281, 520]) {
+    await sidebar.evaluate((element, value) => { element.style.width = `${value}px`; }, width);
+    expect(await header.evaluate((element) => element.scrollWidth <= element.clientWidth), `${width}px`).toBe(true);
+  }
+  await sidebar.evaluate((element) => { element.style.width = "190px"; });
+
+  await toolbar.getByRole("button", { name: "More review file actions" }).click();
+  const menu = app.page.getByRole("group", { name: "More review file actions" });
+  await expect(menu).toBeVisible();
+  await menu.getByRole("button", { name: "Collapse all folders" }).click();
+  await expect(review.file("src/main.ts")).toHaveCount(0);
+
+  await toolbar.getByRole("button", { name: "More review file actions" }).click();
+  await menu.getByRole("button", { name: "Expand all folders" }).click();
   await expect(review.file("src/main.ts")).toBeVisible();
 });

--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -24,7 +24,9 @@ test("review file toolbar controls folder disclosure and remaining files", async
   const toolbar = app.page.getByRole("toolbar", { name: "Review file display" });
   await expect(toolbar.getByRole("button")).toHaveCount(2);
   await expect(app.page.locator(".files-section header").getByRole("toolbar", { name: "Review file display" })).toBeVisible();
-  await expect(app.page.locator(".files-section header")).toContainText("6/6 left");
+  const progress = app.page.locator(".files-section header .review-progress");
+  await expect(progress).toHaveText("6/6 unchecked");
+  await expect(progress).toHaveAttribute("title", "6 of 6 files unchecked");
 
   await toolbar.getByRole("button", { name: "Collapse all folders" }).click();
   await expect(review.file("src/main.ts")).toHaveCount(0);
@@ -35,16 +37,16 @@ test("review file toolbar controls folder disclosure and remaining files", async
   // important behavior: Remaining filters files, rather than merely collapsing directories.
   await review.checkFile("a.rb");
 
-  const remaining = toolbar.getByRole("button", { name: "Show remaining files only" });
+  const remaining = toolbar.getByRole("button", { name: "Show unchecked files only" });
   await remaining.click();
   await expect(remaining).toHaveAttribute("aria-pressed", "true");
-  await expect(app.page.locator(".files-section header")).toContainText("5/6 left");
+  await expect(progress).toHaveText("5/6 unchecked");
   await expect(review.file("a.rb")).toHaveCount(0);
   await expect(review.file("src/main.ts")).toBeVisible();
 
   await review.file("src/main.ts").getByRole("checkbox").click();
   await expect(review.file("src/main.ts")).toHaveCount(0);
-  await expect(app.page.locator(".files-section header")).toContainText("4/6 left");
+  await expect(progress).toHaveText("4/6 unchecked");
 
   await remaining.click();
   await expect(remaining).toHaveAttribute("aria-pressed", "false");

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { PrFile, PrView } from "@gander/shared";
 import type { Store } from "../store.js";
 import FileTree from "./FileTree.vue";
-import { collapsedDirs } from "../tree-nav.js";
+import { collapsedDirs, remainingOnly } from "../tree-nav.js";
 import { jumpTargets } from "../tree-jump.js";
 
 const file = (path: string, checked = false): PrFile =>
@@ -97,7 +97,10 @@ function fileRow(wrapper: VueWrapper, path: string) {
 
 describe("FileTree", () => {
   // Collapse state is shared across the tree's recursive levels, so it outlives a mount.
-  beforeEach(() => collapsedDirs.clear());
+  beforeEach(() => {
+    collapsedDirs.clear();
+    remainingOnly.value = false;
+  });
 
   const treeFiles = [
     file("app/models/member.rb", false),
@@ -138,6 +141,20 @@ describe("FileTree", () => {
 
     expect(calls.setChecked).toEqual([]);
     expect(calls.setCheckedMany).toEqual([]);
+  });
+
+  it("removes reviewed files and empty folders in remaining-only mode", async () => {
+    const { store } = fakeStore(prView(1, treeFiles));
+    const wrapper = mount(FileTree, { props: { store, iconTheme: "catppuccin-mocha" } });
+
+    remainingOnly.value = true;
+    await nextTick();
+
+    expect(wrapper.text()).toContain("member.rb");
+    expect(wrapper.text()).toContain("other.rb");
+    expect(wrapper.text()).not.toContain("late_fee_calculator.rb");
+    expect(wrapper.text()).not.toContain("routes.rb");
+    expect(wrapper.text()).not.toContain("config");
   });
 
   it("resets collapse state when the reviewed PR changes, even though view is reassigned without an intermediate null", async () => {

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -2,7 +2,7 @@
 import { computed, watch } from "vue";
 import type { Store } from "../store.js";
 import { buildTree, dirState, filesUnder, type TreeNode } from "../tree.js";
-import { collapsedDirs, cursor, toggleCollapsed } from "../tree-nav.js";
+import { collapsedDirs, cursor, reviewTreeFiles, toggleCollapsed } from "../tree-nav.js";
 import { iconThemeShowsExplorerArrows } from "../icon-theme.js";
 import { useTreeIcons, treeTypographyStyle } from "../composables/use-tree-icons.js";
 import { basename } from "../paths.js";
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<{
 }>(), { showStatus: true });
 
 const depth = computed(() => props.depth ?? 0);
-const nodes = computed(() => props.nodes ?? buildTree(props.files ?? props.store.files()));
+const nodes = computed(() => props.nodes ?? buildTree(reviewTreeFiles(props.files ?? props.store.files())));
 const showStatus = computed(() => props.showStatus);
 const local = computed(() => props.store.isLocal());
 const rootTypographyStyle = computed(() => treeTypographyStyle(depth.value, props.typography));

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -25,6 +25,9 @@ defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
 
 const reloading = ref(false);
 const remainingCount = computed(() => props.store.view?.files.filter((file) => !file.checked).length ?? 0);
+const totalFileCount = computed(() => props.store.view?.files.length ?? 0);
+const reviewProgressDescription = computed(() =>
+  `${remainingCount.value} of ${totalFileCount.value} ${totalFileCount.value === 1 ? "file" : "files"} unchecked`);
 const hasDirectories = computed(() => reviewTreeFiles(props.store.view?.files ?? []).some((file) => file.path.includes("/")));
 const foldersCollapsed = computed(() => allDirectoriesCollapsed(props.store.view?.files ?? []));
 
@@ -64,7 +67,11 @@ async function reload(): Promise<void> {
     <section v-if="store.view && store.currentRepoId === store.targetRepoId" class="files-section">
       <header>
         <h2>Review Files</h2>
-        <span>{{ remainingCount }}/{{ store.view.files.length }} left</span>
+        <span
+          class="review-progress"
+          :title="reviewProgressDescription"
+          :aria-label="reviewProgressDescription"
+        >{{ remainingCount }}/{{ totalFileCount }} unchecked</span>
         <ReviewFilesToolbar
           :remaining-only="remainingOnly"
           :has-directories="hasDirectories"

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { RefreshCw } from "@lucide/vue";
 import type { FileIconThemeId } from "../../../file-icon-themes.js";
 import type { EffectiveTreeTypography } from "../../../settings.js";
 import type { Store } from "../store.js";
 import FileTree from "./FileTree.vue";
+import ReviewFilesToolbar from "./ReviewFilesToolbar.vue";
 import ReviewingList from "./ReviewingList.vue";
 import type { JumpTarget } from "../tree-jump.js";
+import {
+  collapseAllDirectories,
+  collapseReviewedDirectories,
+  expandAllDirectories,
+  remainingOnly,
+} from "../tree-nav.js";
 
 const props = defineProps<{
   store: Store;
@@ -17,6 +24,9 @@ const props = defineProps<{
 defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
 
 const reloading = ref(false);
+const remainingCount = computed(() => props.store.view?.files.filter((file) => !file.checked).length ?? 0);
+const hasDirectories = computed(() => props.store.view?.files.some((file) => file.path.includes("/")) ?? false);
+
 async function reload(): Promise<void> {
   reloading.value = true;
   try {
@@ -55,13 +65,25 @@ async function reload(): Promise<void> {
         <h2>Review Files</h2>
         <span>{{ store.view.files.length }}</span>
       </header>
+      <ReviewFilesToolbar
+        :remaining-only="remainingOnly"
+        :remaining-count="remainingCount"
+        :total-count="store.view.files.length"
+        :has-directories="hasDirectories"
+        @expand-all="expandAllDirectories"
+        @collapse-reviewed="collapseReviewedDirectories(store.view.files)"
+        @collapse-all="collapseAllDirectories(store.view.files)"
+        @toggle-remaining="remainingOnly = !remainingOnly"
+      />
       <FileTree
+        v-if="!remainingOnly || remainingCount > 0"
         :store="store"
         :icon-theme="iconTheme"
         :typography="typography"
         :jump-targets="jumpTargets"
         @scroll.passive="$emit('scroll')"
       />
+      <p v-else class="remaining-empty">All files reviewed.</p>
     </section>
   </aside>
 </template>
@@ -79,6 +101,7 @@ header span { margin-left: auto; color: var(--faint-foreground); font: 10px var(
 .reload:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .reload:disabled { opacity: .5; cursor: default; }
 .empty { margin: 0; padding: 12px; color: var(--faint-foreground); font-size: 11px; }
+.remaining-empty { margin: 0; padding: 16px 12px; color: var(--muted-foreground); font-size: 11px; text-align: center; }
 .files-section :deep(.tree.root) { flex: 1; min-height: 0; overflow: auto; scrollbar-gutter: stable; }
 .pull-sidebar :deep(.reviewing-list) { padding: 5px 0 8px; }
 </style>

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -10,9 +10,9 @@ import ReviewingList from "./ReviewingList.vue";
 import type { JumpTarget } from "../tree-jump.js";
 import {
   collapseAllDirectories,
-  collapseReviewedDirectories,
   expandAllDirectories,
   remainingOnly,
+  reviewTreeFiles,
 } from "../tree-nav.js";
 
 const props = defineProps<{
@@ -25,7 +25,7 @@ defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
 
 const reloading = ref(false);
 const remainingCount = computed(() => props.store.view?.files.filter((file) => !file.checked).length ?? 0);
-const hasDirectories = computed(() => props.store.view?.files.some((file) => file.path.includes("/")) ?? false);
+const hasDirectories = computed(() => reviewTreeFiles(props.store.view?.files ?? []).some((file) => file.path.includes("/")));
 
 async function reload(): Promise<void> {
   reloading.value = true;
@@ -63,15 +63,12 @@ async function reload(): Promise<void> {
     <section v-if="store.view && store.currentRepoId === store.targetRepoId" class="files-section">
       <header>
         <h2>Review Files</h2>
-        <span>{{ store.view.files.length }}</span>
+        <span>{{ remainingCount }}/{{ store.view.files.length }} left</span>
       </header>
       <ReviewFilesToolbar
         :remaining-only="remainingOnly"
-        :remaining-count="remainingCount"
-        :total-count="store.view.files.length"
         :has-directories="hasDirectories"
         @expand-all="expandAllDirectories"
-        @collapse-reviewed="collapseReviewedDirectories(store.view.files)"
         @collapse-all="collapseAllDirectories(store.view.files)"
         @toggle-remaining="remainingOnly = !remainingOnly"
       />

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -69,12 +69,12 @@ async function reload(): Promise<void> {
     </section>
     <section v-if="store.view && store.currentRepoId === store.targetRepoId" class="files-section">
       <header>
-        <h2>Review Files</h2>
+        <h2><span class="review-title-prefix">Review </span>Files</h2>
         <span
           class="review-progress"
           :title="reviewProgressDescription"
           :aria-label="reviewProgressDescription"
-        >{{ remainingCount }}/{{ totalFileCount }} unreviewed</span>
+        ><span>{{ remainingCount }}/{{ totalFileCount }}</span><span class="review-progress-label"> unreviewed</span></span>
         <ReviewFilesToolbar
           :remaining-only="remainingOnly"
           :has-directories="hasDirectories"
@@ -102,10 +102,10 @@ async function reload(): Promise<void> {
 .pull-sidebar { height: 100%; min-height: 0; display: flex; flex-direction: column; background: var(--panel-background); }
 .pull-section { flex: 1; min-height: 100px; overflow: auto; }
 .has-review .pull-section { flex: 0 1 auto; max-height: 48%; border-bottom: 1px solid var(--workbench-border); }
-.files-section { flex: 1; min-height: 120px; display: flex; flex-direction: column; }
+.files-section { container: review-files / inline-size; flex: 1; min-height: 120px; display: flex; flex-direction: column; }
 header { position: sticky; inset-block-start: 0; z-index: 1; height: 35px; box-sizing: border-box; display: flex; align-items: center; gap: 8px; padding-inline: 12px; background: var(--panel-background); border-bottom: 1px solid var(--workbench-border); }
 h1, h2 { flex: none; margin: 0; color: var(--muted-foreground); font-size: 10px; font-weight: 700; letter-spacing: .55px; text-transform: uppercase; white-space: nowrap; }
-header span { margin-left: auto; color: var(--faint-foreground); font: 10px var(--mono); white-space: nowrap; }
+.review-progress { margin-left: auto; color: var(--faint-foreground); font: 10px var(--mono); white-space: nowrap; }
 .reload { display: flex; padding: 2px; border: 0; border-radius: var(--radius-sm); background: none; color: var(--faint-foreground); cursor: pointer; }
 .reload:hover:not(:disabled) { color: var(--workbench-foreground); background: var(--elevated-background); }
 .reload:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
@@ -114,4 +114,6 @@ header span { margin-left: auto; color: var(--faint-foreground); font: 10px var(
 .remaining-empty { margin: 0; padding: 16px 12px; color: var(--muted-foreground); font-size: 11px; text-align: center; }
 .files-section :deep(.tree.root) { flex: 1; min-height: 0; overflow: auto; scrollbar-gutter: stable; }
 .pull-sidebar :deep(.reviewing-list) { padding: 5px 0 8px; }
+@container review-files (max-width: 250px) { .review-title-prefix { display: none; } }
+@container review-files (max-width: 205px) { .review-progress-label { display: none; } }
 </style>

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -10,6 +10,8 @@ import ReviewingList from "./ReviewingList.vue";
 import type { JumpTarget } from "../tree-jump.js";
 import {
   allDirectoriesCollapsed,
+  collapseFullyReviewedDirectories,
+  hasFullyReviewedDirectories,
   remainingOnly,
   reviewTreeFiles,
   toggleAllDirectories,
@@ -27,8 +29,9 @@ const reloading = ref(false);
 const remainingCount = computed(() => props.store.view?.files.filter((file) => !file.checked).length ?? 0);
 const totalFileCount = computed(() => props.store.view?.files.length ?? 0);
 const reviewProgressDescription = computed(() =>
-  `${remainingCount.value} of ${totalFileCount.value} ${totalFileCount.value === 1 ? "file" : "files"} unchecked`);
+  `${remainingCount.value} of ${totalFileCount.value} ${totalFileCount.value === 1 ? "file" : "files"} unreviewed`);
 const hasDirectories = computed(() => reviewTreeFiles(props.store.view?.files ?? []).some((file) => file.path.includes("/")));
+const hasReviewedDirectories = computed(() => hasFullyReviewedDirectories(props.store.view?.files ?? []));
 const foldersCollapsed = computed(() => allDirectoriesCollapsed(props.store.view?.files ?? []));
 
 async function reload(): Promise<void> {
@@ -71,11 +74,13 @@ async function reload(): Promise<void> {
           class="review-progress"
           :title="reviewProgressDescription"
           :aria-label="reviewProgressDescription"
-        >{{ remainingCount }}/{{ totalFileCount }} unchecked</span>
+        >{{ remainingCount }}/{{ totalFileCount }} unreviewed</span>
         <ReviewFilesToolbar
           :remaining-only="remainingOnly"
           :has-directories="hasDirectories"
+          :has-fully-reviewed-directories="hasReviewedDirectories"
           :all-directories-collapsed="foldersCollapsed"
+          @collapse-reviewed="collapseFullyReviewedDirectories(store.view.files)"
           @toggle-all="toggleAllDirectories(store.view.files)"
           @toggle-remaining="remainingOnly = !remainingOnly"
         />
@@ -99,8 +104,8 @@ async function reload(): Promise<void> {
 .has-review .pull-section { flex: 0 1 auto; max-height: 48%; border-bottom: 1px solid var(--workbench-border); }
 .files-section { flex: 1; min-height: 120px; display: flex; flex-direction: column; }
 header { position: sticky; inset-block-start: 0; z-index: 1; height: 35px; box-sizing: border-box; display: flex; align-items: center; gap: 8px; padding-inline: 12px; background: var(--panel-background); border-bottom: 1px solid var(--workbench-border); }
-h1, h2 { margin: 0; color: var(--muted-foreground); font-size: 10px; font-weight: 700; letter-spacing: .55px; text-transform: uppercase; }
-header span { margin-left: auto; color: var(--faint-foreground); font: 10px var(--mono); }
+h1, h2 { flex: none; margin: 0; color: var(--muted-foreground); font-size: 10px; font-weight: 700; letter-spacing: .55px; text-transform: uppercase; white-space: nowrap; }
+header span { margin-left: auto; color: var(--faint-foreground); font: 10px var(--mono); white-space: nowrap; }
 .reload { display: flex; padding: 2px; border: 0; border-radius: var(--radius-sm); background: none; color: var(--faint-foreground); cursor: pointer; }
 .reload:hover:not(:disabled) { color: var(--workbench-foreground); background: var(--elevated-background); }
 .reload:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -9,9 +9,10 @@ import ReviewFilesToolbar from "./ReviewFilesToolbar.vue";
 import ReviewingList from "./ReviewingList.vue";
 import type { JumpTarget } from "../tree-jump.js";
 import {
-  collapseAllDirectories,
+  allDirectoriesCollapsed,
   remainingOnly,
   reviewTreeFiles,
+  toggleAllDirectories,
 } from "../tree-nav.js";
 
 const props = defineProps<{
@@ -25,6 +26,7 @@ defineEmits<{ selectPr: [prNumber: number]; scroll: [] }>();
 const reloading = ref(false);
 const remainingCount = computed(() => props.store.view?.files.filter((file) => !file.checked).length ?? 0);
 const hasDirectories = computed(() => reviewTreeFiles(props.store.view?.files ?? []).some((file) => file.path.includes("/")));
+const foldersCollapsed = computed(() => allDirectoriesCollapsed(props.store.view?.files ?? []));
 
 async function reload(): Promise<void> {
   reloading.value = true;
@@ -66,7 +68,8 @@ async function reload(): Promise<void> {
         <ReviewFilesToolbar
           :remaining-only="remainingOnly"
           :has-directories="hasDirectories"
-          @collapse-all="collapseAllDirectories(store.view.files)"
+          :all-directories-collapsed="foldersCollapsed"
+          @toggle-all="toggleAllDirectories(store.view.files)"
           @toggle-remaining="remainingOnly = !remainingOnly"
         />
       </header>

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -10,7 +10,6 @@ import ReviewingList from "./ReviewingList.vue";
 import type { JumpTarget } from "../tree-jump.js";
 import {
   collapseAllDirectories,
-  expandAllDirectories,
   remainingOnly,
   reviewTreeFiles,
 } from "../tree-nav.js";
@@ -68,7 +67,6 @@ async function reload(): Promise<void> {
       <ReviewFilesToolbar
         :remaining-only="remainingOnly"
         :has-directories="hasDirectories"
-        @expand-all="expandAllDirectories"
         @collapse-all="collapseAllDirectories(store.view.files)"
         @toggle-remaining="remainingOnly = !remainingOnly"
       />

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -63,13 +63,13 @@ async function reload(): Promise<void> {
       <header>
         <h2>Review Files</h2>
         <span>{{ remainingCount }}/{{ store.view.files.length }} left</span>
+        <ReviewFilesToolbar
+          :remaining-only="remainingOnly"
+          :has-directories="hasDirectories"
+          @collapse-all="collapseAllDirectories(store.view.files)"
+          @toggle-remaining="remainingOnly = !remainingOnly"
+        />
       </header>
-      <ReviewFilesToolbar
-        :remaining-only="remainingOnly"
-        :has-directories="hasDirectories"
-        @collapse-all="collapseAllDirectories(store.view.files)"
-        @toggle-remaining="remainingOnly = !remainingOnly"
-      />
       <FileTree
         v-if="!remainingOnly || remainingCount > 0"
         :store="store"

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import ReviewFilesToolbar from "./ReviewFilesToolbar.vue";
+
+describe("ReviewFilesToolbar", () => {
+  it("exposes every tree action as a mouse-friendly button", async () => {
+    const wrapper = mount(ReviewFilesToolbar, {
+      props: { remainingOnly: false, remainingCount: 3, totalCount: 5, hasDirectories: true },
+    });
+
+    expect(wrapper.text()).toContain("3 of 5 remaining");
+    for (const [label, event] of [
+      ["Expand all folders", "expandAll"],
+      ["Collapse reviewed folders", "collapseReviewed"],
+      ["Collapse all folders", "collapseAll"],
+      ["Show remaining files only", "toggleRemaining"],
+    ] as const) {
+      await wrapper.get(`button[aria-label="${label}"]`).trigger("click");
+      expect(wrapper.emitted(event)).toHaveLength(1);
+    }
+  });
+
+  it("shows the remaining filter as pressed and disables folder actions when unavailable", () => {
+    const wrapper = mount(ReviewFilesToolbar, {
+      props: { remainingOnly: true, remainingCount: 0, totalCount: 1, hasDirectories: false },
+    });
+
+    expect(wrapper.get('[aria-label="Show remaining files only"]').attributes("aria-pressed")).toBe("true");
+    expect(wrapper.findAll("button:disabled")).toHaveLength(3);
+  });
+});

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
@@ -13,7 +13,9 @@ describe("ReviewFilesToolbar", () => {
       ["Collapse all folders", "collapseAll"],
       ["Show remaining files only", "toggleRemaining"],
     ] as const) {
-      await wrapper.get(`button[aria-label="${label}"]`).trigger("click");
+      const button = wrapper.get(`button[aria-label="${label}"]`);
+      expect(button.text()).toBe("");
+      await button.trigger("click");
       expect(wrapper.emitted(event)).toHaveLength(1);
     }
   });

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
@@ -11,7 +11,7 @@ describe("ReviewFilesToolbar", () => {
 
     for (const [label, event] of [
       ["Collapse all folders", "toggleAll"],
-      ["Show remaining files only", "toggleRemaining"],
+      ["Show unchecked files only", "toggleRemaining"],
     ] as const) {
       const button = wrapper.get(`button[aria-label="${label}"]`);
       expect(button.text()).toBe("");
@@ -25,7 +25,7 @@ describe("ReviewFilesToolbar", () => {
       props: { remainingOnly: true, hasDirectories: false, allDirectoriesCollapsed: false },
     });
 
-    expect(wrapper.get('[aria-label="Show remaining files only"]').attributes("aria-pressed")).toBe("true");
+    expect(wrapper.get('[aria-label="Show unchecked files only"]').attributes("aria-pressed")).toBe("true");
     expect(wrapper.findAll("button:disabled")).toHaveLength(1);
   });
 

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
@@ -6,11 +6,11 @@ import ReviewFilesToolbar from "./ReviewFilesToolbar.vue";
 describe("ReviewFilesToolbar", () => {
   it("exposes every tree action as a mouse-friendly button", async () => {
     const wrapper = mount(ReviewFilesToolbar, {
-      props: { remainingOnly: false, hasDirectories: true },
+      props: { remainingOnly: false, hasDirectories: true, allDirectoriesCollapsed: false },
     });
 
     for (const [label, event] of [
-      ["Collapse all folders", "collapseAll"],
+      ["Collapse all folders", "toggleAll"],
       ["Show remaining files only", "toggleRemaining"],
     ] as const) {
       const button = wrapper.get(`button[aria-label="${label}"]`);
@@ -22,10 +22,20 @@ describe("ReviewFilesToolbar", () => {
 
   it("shows the remaining filter as pressed and disables folder actions when unavailable", () => {
     const wrapper = mount(ReviewFilesToolbar, {
-      props: { remainingOnly: true, hasDirectories: false },
+      props: { remainingOnly: true, hasDirectories: false, allDirectoriesCollapsed: false },
     });
 
     expect(wrapper.get('[aria-label="Show remaining files only"]').attributes("aria-pressed")).toBe("true");
     expect(wrapper.findAll("button:disabled")).toHaveLength(1);
+  });
+
+  it("becomes an expand-all action when every folder is collapsed", async () => {
+    const wrapper = mount(ReviewFilesToolbar, {
+      props: { remainingOnly: false, hasDirectories: true, allDirectoriesCollapsed: false },
+    });
+
+    expect(wrapper.find('[aria-label="Collapse all folders"]').exists()).toBe(true);
+    await wrapper.setProps({ allDirectoriesCollapsed: true });
+    expect(wrapper.find('[aria-label="Expand all folders"]').exists()).toBe(true);
   });
 });

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
@@ -10,7 +10,6 @@ describe("ReviewFilesToolbar", () => {
     });
 
     for (const [label, event] of [
-      ["Expand all folders", "expandAll"],
       ["Collapse all folders", "collapseAll"],
       ["Show remaining files only", "toggleRemaining"],
     ] as const) {
@@ -25,6 +24,6 @@ describe("ReviewFilesToolbar", () => {
     });
 
     expect(wrapper.get('[aria-label="Show remaining files only"]').attributes("aria-pressed")).toBe("true");
-    expect(wrapper.findAll("button:disabled")).toHaveLength(2);
+    expect(wrapper.findAll("button:disabled")).toHaveLength(1);
   });
 });

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
@@ -19,8 +19,30 @@ describe("ReviewFilesToolbar", () => {
       ["Collapse fully reviewed folders", "collapseReviewed"],
       ["Show unreviewed files only", "toggleRemaining"],
     ] as const) {
-      const button = wrapper.get(`button[aria-label="${label}"]`);
+      const button = wrapper.get(`.toolbar-action[aria-label="${label}"]`);
       expect(button.text()).toBe("");
+      await button.trigger("click");
+      expect(wrapper.emitted(event)).toHaveLength(1);
+    }
+  });
+
+  it("offers folder actions from the compact overflow menu", async () => {
+    const wrapper = mount(ReviewFilesToolbar, {
+      props: {
+        remainingOnly: false,
+        hasDirectories: true,
+        hasFullyReviewedDirectories: true,
+        allDirectoriesCollapsed: false,
+      },
+    });
+
+    expect(wrapper.get('[aria-label="More review file actions"]').text()).toBe("");
+    for (const [label, event] of [
+      ["Collapse fully reviewed folders", "collapseReviewed"],
+      ["Collapse all folders", "toggleAll"],
+    ] as const) {
+      const button = wrapper.get(`.actions-menu [aria-label="${label}"]`);
+      expect(button.text()).toContain(label);
       await button.trigger("click");
       expect(wrapper.emitted(event)).toHaveLength(1);
     }
@@ -37,7 +59,8 @@ describe("ReviewFilesToolbar", () => {
     });
 
     expect(wrapper.get('[aria-label="Show unreviewed files only"]').attributes("aria-pressed")).toBe("true");
-    expect(wrapper.findAll("button:disabled")).toHaveLength(2);
+    expect(wrapper.findAll('[aria-label="Collapse fully reviewed folders"]:disabled')).toHaveLength(2);
+    expect(wrapper.findAll('[aria-label="Collapse all folders"]:disabled')).toHaveLength(2);
   });
 
   it("becomes an expand-all action when every folder is collapsed", async () => {

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
@@ -6,12 +6,18 @@ import ReviewFilesToolbar from "./ReviewFilesToolbar.vue";
 describe("ReviewFilesToolbar", () => {
   it("exposes every tree action as a mouse-friendly button", async () => {
     const wrapper = mount(ReviewFilesToolbar, {
-      props: { remainingOnly: false, hasDirectories: true, allDirectoriesCollapsed: false },
+      props: {
+        remainingOnly: false,
+        hasDirectories: true,
+        hasFullyReviewedDirectories: true,
+        allDirectoriesCollapsed: false,
+      },
     });
 
     for (const [label, event] of [
       ["Collapse all folders", "toggleAll"],
-      ["Show unchecked files only", "toggleRemaining"],
+      ["Collapse fully reviewed folders", "collapseReviewed"],
+      ["Show unreviewed files only", "toggleRemaining"],
     ] as const) {
       const button = wrapper.get(`button[aria-label="${label}"]`);
       expect(button.text()).toBe("");
@@ -20,18 +26,28 @@ describe("ReviewFilesToolbar", () => {
     }
   });
 
-  it("shows the remaining filter as pressed and disables folder actions when unavailable", () => {
+  it("shows the unreviewed filter as pressed and disables unavailable folder actions", () => {
     const wrapper = mount(ReviewFilesToolbar, {
-      props: { remainingOnly: true, hasDirectories: false, allDirectoriesCollapsed: false },
+      props: {
+        remainingOnly: true,
+        hasDirectories: false,
+        hasFullyReviewedDirectories: false,
+        allDirectoriesCollapsed: false,
+      },
     });
 
-    expect(wrapper.get('[aria-label="Show unchecked files only"]').attributes("aria-pressed")).toBe("true");
-    expect(wrapper.findAll("button:disabled")).toHaveLength(1);
+    expect(wrapper.get('[aria-label="Show unreviewed files only"]').attributes("aria-pressed")).toBe("true");
+    expect(wrapper.findAll("button:disabled")).toHaveLength(2);
   });
 
   it("becomes an expand-all action when every folder is collapsed", async () => {
     const wrapper = mount(ReviewFilesToolbar, {
-      props: { remainingOnly: false, hasDirectories: true, allDirectoriesCollapsed: false },
+      props: {
+        remainingOnly: false,
+        hasDirectories: true,
+        hasFullyReviewedDirectories: false,
+        allDirectoriesCollapsed: false,
+      },
     });
 
     expect(wrapper.find('[aria-label="Collapse all folders"]').exists()).toBe(true);

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.test.ts
@@ -6,13 +6,11 @@ import ReviewFilesToolbar from "./ReviewFilesToolbar.vue";
 describe("ReviewFilesToolbar", () => {
   it("exposes every tree action as a mouse-friendly button", async () => {
     const wrapper = mount(ReviewFilesToolbar, {
-      props: { remainingOnly: false, remainingCount: 3, totalCount: 5, hasDirectories: true },
+      props: { remainingOnly: false, hasDirectories: true },
     });
 
-    expect(wrapper.text()).toContain("3 of 5 remaining");
     for (const [label, event] of [
       ["Expand all folders", "expandAll"],
-      ["Collapse reviewed folders", "collapseReviewed"],
       ["Collapse all folders", "collapseAll"],
       ["Show remaining files only", "toggleRemaining"],
     ] as const) {
@@ -23,10 +21,10 @@ describe("ReviewFilesToolbar", () => {
 
   it("shows the remaining filter as pressed and disables folder actions when unavailable", () => {
     const wrapper = mount(ReviewFilesToolbar, {
-      props: { remainingOnly: true, remainingCount: 0, totalCount: 1, hasDirectories: false },
+      props: { remainingOnly: true, hasDirectories: false },
     });
 
     expect(wrapper.get('[aria-label="Show remaining files only"]').attributes("aria-pressed")).toBe("true");
-    expect(wrapper.findAll("button:disabled")).toHaveLength(3);
+    expect(wrapper.findAll("button:disabled")).toHaveLength(2);
   });
 });

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { ListChecks, ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
+
+defineProps<{
+  remainingOnly: boolean;
+  remainingCount: number;
+  totalCount: number;
+  hasDirectories: boolean;
+}>();
+
+defineEmits<{
+  expandAll: [];
+  collapseReviewed: [];
+  collapseAll: [];
+  toggleRemaining: [];
+}>();
+</script>
+
+<template>
+  <div class="review-files-toolbar" role="toolbar" aria-label="Review file display">
+    <span class="remaining-count">{{ remainingCount }} of {{ totalCount }} remaining</span>
+    <div class="toolbar-actions">
+      <button
+        type="button"
+        :disabled="!hasDirectories"
+        aria-label="Expand all folders"
+        title="Expand all folders"
+        @click="$emit('expandAll')"
+      ><ListChevronsUpDown :size="14" /></button>
+      <button
+        type="button"
+        :disabled="!hasDirectories || remainingOnly"
+        aria-label="Collapse reviewed folders"
+        title="Collapse reviewed folders"
+        @click="$emit('collapseReviewed')"
+      ><ListChecks :size="14" /></button>
+      <button
+        type="button"
+        :disabled="!hasDirectories"
+        aria-label="Collapse all folders"
+        title="Collapse all folders"
+        @click="$emit('collapseAll')"
+      ><ListChevronsDownUp :size="14" /></button>
+      <button
+        type="button"
+        class="filter-button"
+        :class="{ active: remainingOnly }"
+        :aria-pressed="remainingOnly"
+        aria-label="Show remaining files only"
+        title="Show remaining files only"
+        @click="$emit('toggleRemaining')"
+      ><ListFilter :size="14" /></button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.review-files-toolbar { min-height: 31px; flex: none; display: flex; align-items: center; gap: 8px; padding: 3px 7px 3px 12px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); }
+.remaining-count { min-width: 0; margin-right: auto; overflow: hidden; color: var(--faint-foreground); font-size: 10px; white-space: nowrap; text-overflow: ellipsis; }
+.toolbar-actions { display: flex; align-items: center; gap: 2px; }
+.toolbar-actions button { width: 24px; height: 24px; display: grid; place-items: center; padding: 0; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); cursor: pointer; }
+.toolbar-actions button:hover:not(:disabled) { background: var(--elevated-background); color: var(--workbench-foreground); }
+.toolbar-actions button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.toolbar-actions button:disabled { opacity: .35; cursor: default; }
+.toolbar-actions .filter-button.active { background: var(--selection-background); color: var(--accent); }
+</style>

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
@@ -24,8 +24,8 @@ const folderActionLabel = computed(() => props.allDirectoriesCollapsed
       type="button"
       :class="{ active: remainingOnly }"
       :aria-pressed="remainingOnly"
-      aria-label="Show remaining files only"
-      title="Show remaining files only"
+      aria-label="Show unchecked files only"
+      title="Show unchecked files only"
       @click="$emit('toggleRemaining')"
     ><ListFilter :size="16" /></button>
     <button

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
+import { ListChevronsDownUp, ListFilter } from "@lucide/vue";
 
 defineProps<{
   remainingOnly: boolean;
@@ -7,7 +7,6 @@ defineProps<{
 }>();
 
 defineEmits<{
-  expandAll: [];
   collapseAll: [];
   toggleRemaining: [];
 }>();
@@ -18,20 +17,6 @@ defineEmits<{
     <div class="toolbar-actions">
       <button
         type="button"
-        :disabled="!hasDirectories"
-        aria-label="Expand all folders"
-        title="Expand all folders"
-        @click="$emit('expandAll')"
-      ><ListChevronsUpDown :size="14" /><span>Expand</span></button>
-      <button
-        type="button"
-        :disabled="!hasDirectories"
-        aria-label="Collapse all folders"
-        title="Collapse all folders"
-        @click="$emit('collapseAll')"
-      ><ListChevronsDownUp :size="14" /><span>Collapse</span></button>
-      <button
-        type="button"
         class="filter-button"
         :class="{ active: remainingOnly }"
         :aria-pressed="remainingOnly"
@@ -39,6 +24,14 @@ defineEmits<{
         title="Show remaining files only"
         @click="$emit('toggleRemaining')"
       ><ListFilter :size="14" /><span>Remaining</span></button>
+      <button
+        type="button"
+        class="collapse-button"
+        :disabled="!hasDirectories"
+        aria-label="Collapse all folders"
+        title="Collapse all folders"
+        @click="$emit('collapseAll')"
+      ><ListChevronsDownUp :size="14" /></button>
     </div>
   </div>
 </template>
@@ -46,8 +39,10 @@ defineEmits<{
 <style scoped>
 .review-files-toolbar { min-height: 31px; flex: none; display: flex; align-items: center; padding: 3px 7px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); }
 .toolbar-actions { width: 100%; display: flex; align-items: center; gap: 2px; }
-.toolbar-actions button { min-width: 0; height: 24px; flex: 1; display: flex; align-items: center; justify-content: center; gap: 4px; padding: 0 4px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); font: inherit; font-size: 10px; cursor: pointer; }
+.toolbar-actions button { min-width: 0; height: 24px; display: flex; align-items: center; justify-content: center; gap: 4px; padding: 0 4px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); font: inherit; font-size: 10px; cursor: pointer; }
 .toolbar-actions button svg { flex: none; }
+.toolbar-actions .filter-button { flex: 1; }
+.toolbar-actions .collapse-button { width: 24px; flex: none; padding: 0; }
 .toolbar-actions button:hover:not(:disabled) { background: var(--elevated-background); color: var(--workbench-foreground); }
 .toolbar-actions button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .toolbar-actions button:disabled { opacity: .35; cursor: default; }

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { FolderCheck, ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
+import { Ellipsis, FolderCheck, ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
 
 const props = defineProps<{
   remainingOnly: boolean;
@@ -23,38 +23,91 @@ const folderActionLabel = computed(() => props.allDirectoriesCollapsed
 <template>
   <div class="review-files-toolbar" role="toolbar" aria-label="Review file display">
     <button
+      class="toolbar-action"
       type="button"
       :class="{ active: remainingOnly }"
       :aria-pressed="remainingOnly"
       aria-label="Show unreviewed files only"
       title="Show unreviewed files only"
       @click="$emit('toggleRemaining')"
-    ><ListFilter :size="16" /></button>
+    ><ListFilter :size="16" aria-hidden="true" /></button>
     <button
+      class="toolbar-action secondary-action"
       type="button"
       :disabled="!hasFullyReviewedDirectories"
       aria-label="Collapse fully reviewed folders"
       title="Collapse fully reviewed folders"
       @click="$emit('collapseReviewed')"
-    ><FolderCheck :size="16" /></button>
+    ><FolderCheck :size="16" aria-hidden="true" /></button>
     <button
+      class="toolbar-action secondary-action"
       type="button"
       :disabled="!hasDirectories"
       :aria-label="folderActionLabel"
       :title="folderActionLabel"
       @click="$emit('toggleAll')"
     >
-      <ListChevronsUpDown v-if="allDirectoriesCollapsed" :size="16" />
-      <ListChevronsDownUp v-else :size="16" />
+      <ListChevronsUpDown v-if="allDirectoriesCollapsed" :size="16" aria-hidden="true" />
+      <ListChevronsDownUp v-else :size="16" aria-hidden="true" />
     </button>
+    <button
+      class="toolbar-action more-action"
+      type="button"
+      popovertarget="review-files-actions-menu"
+      aria-label="More review file actions"
+      title="More review file actions"
+    ><Ellipsis :size="16" aria-hidden="true" /></button>
+    <div
+      id="review-files-actions-menu"
+      class="actions-menu"
+      popover="auto"
+      role="group"
+      aria-label="More review file actions"
+    >
+      <button
+        type="button"
+        popovertarget="review-files-actions-menu"
+        popovertargetaction="hide"
+        :disabled="!hasFullyReviewedDirectories"
+        aria-label="Collapse fully reviewed folders"
+        @click="$emit('collapseReviewed')"
+      ><FolderCheck :size="15" aria-hidden="true" /><span>Collapse fully reviewed folders</span></button>
+      <button
+        type="button"
+        popovertarget="review-files-actions-menu"
+        popovertargetaction="hide"
+        :disabled="!hasDirectories"
+        :aria-label="folderActionLabel"
+        @click="$emit('toggleAll')"
+      >
+        <ListChevronsUpDown v-if="allDirectoriesCollapsed" :size="15" aria-hidden="true" />
+        <ListChevronsDownUp v-else :size="15" aria-hidden="true" />
+        <span>{{ folderActionLabel }}</span>
+      </button>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .review-files-toolbar { flex: none; display: flex; align-items: center; gap: 4px; }
-.review-files-toolbar button { width: 22px; height: 22px; display: grid; place-items: center; padding: 3px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); cursor: pointer; }
-.review-files-toolbar button:hover:not(:disabled) { background: var(--elevated-background); color: var(--workbench-foreground); }
-.review-files-toolbar button:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
-.review-files-toolbar button:disabled { opacity: .35; cursor: default; }
-.review-files-toolbar button.active { background: var(--selection-background); color: var(--accent); }
+.toolbar-action { width: 22px; height: 22px; display: grid; place-items: center; padding: 3px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); cursor: pointer; }
+.toolbar-action:hover:not(:disabled) { background: var(--elevated-background); color: var(--workbench-foreground); }
+.toolbar-action:focus-visible, .actions-menu button:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
+.toolbar-action:disabled, .actions-menu button:disabled { opacity: .35; cursor: default; }
+.toolbar-action.active { background: var(--selection-background); color: var(--accent); }
+.more-action { display: none; anchor-name: --review-files-actions; }
+.actions-menu {
+  position: fixed; position-anchor: --review-files-actions; position-area: block-end span-inline-start;
+  width: max-content; min-width: 198px; margin: 4px 0 0; padding: 4px;
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-sm);
+  background: var(--elevated-background); color: var(--workbench-foreground);
+  box-shadow: 0 6px 18px var(--workbench-shadow);
+}
+.actions-menu:popover-open { display: flex; flex-direction: column; gap: 1px; }
+.actions-menu button { display: flex; align-items: center; gap: 8px; width: 100%; height: 26px; padding: 0 7px; border: 0; border-radius: var(--radius-sm); background: transparent; color: inherit; cursor: pointer; font: inherit; white-space: nowrap; }
+.actions-menu button:hover:not(:disabled) { background: var(--hover-background); }
+@container review-files (max-width: 280px) {
+  .secondary-action { display: none; }
+  .more-action { display: grid; }
+}
 </style>

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
+import { FolderCheck, ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
 
 const props = defineProps<{
   remainingOnly: boolean;
   hasDirectories: boolean;
+  hasFullyReviewedDirectories: boolean;
   allDirectoriesCollapsed: boolean;
 }>();
 
 defineEmits<{
+  collapseReviewed: [];
   toggleAll: [];
   toggleRemaining: [];
 }>();
@@ -24,10 +26,17 @@ const folderActionLabel = computed(() => props.allDirectoriesCollapsed
       type="button"
       :class="{ active: remainingOnly }"
       :aria-pressed="remainingOnly"
-      aria-label="Show unchecked files only"
-      title="Show unchecked files only"
+      aria-label="Show unreviewed files only"
+      title="Show unreviewed files only"
       @click="$emit('toggleRemaining')"
     ><ListFilter :size="16" /></button>
+    <button
+      type="button"
+      :disabled="!hasFullyReviewedDirectories"
+      aria-label="Collapse fully reviewed folders"
+      title="Collapse fully reviewed folders"
+      @click="$emit('collapseReviewed')"
+    ><FolderCheck :size="16" /></button>
     <button
       type="button"
       :disabled="!hasDirectories"

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
@@ -1,15 +1,21 @@
 <script setup lang="ts">
-import { ListChevronsDownUp, ListFilter } from "@lucide/vue";
+import { computed } from "vue";
+import { ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
 
-defineProps<{
+const props = defineProps<{
   remainingOnly: boolean;
   hasDirectories: boolean;
+  allDirectoriesCollapsed: boolean;
 }>();
 
 defineEmits<{
-  collapseAll: [];
+  toggleAll: [];
   toggleRemaining: [];
 }>();
+
+const folderActionLabel = computed(() => props.allDirectoriesCollapsed
+  ? "Expand all folders"
+  : "Collapse all folders");
 </script>
 
 <template>
@@ -25,10 +31,13 @@ defineEmits<{
     <button
       type="button"
       :disabled="!hasDirectories"
-      aria-label="Collapse all folders"
-      title="Collapse all folders"
-      @click="$emit('collapseAll')"
-    ><ListChevronsDownUp :size="16" /></button>
+      :aria-label="folderActionLabel"
+      :title="folderActionLabel"
+      @click="$emit('toggleAll')"
+    >
+      <ListChevronsUpDown v-if="allDirectoriesCollapsed" :size="16" />
+      <ListChevronsDownUp v-else :size="16" />
+    </button>
   </div>
 </template>
 

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
@@ -1,16 +1,13 @@
 <script setup lang="ts">
-import { ListChecks, ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
+import { ListChevronsDownUp, ListChevronsUpDown, ListFilter } from "@lucide/vue";
 
 defineProps<{
   remainingOnly: boolean;
-  remainingCount: number;
-  totalCount: number;
   hasDirectories: boolean;
 }>();
 
 defineEmits<{
   expandAll: [];
-  collapseReviewed: [];
   collapseAll: [];
   toggleRemaining: [];
 }>();
@@ -18,7 +15,6 @@ defineEmits<{
 
 <template>
   <div class="review-files-toolbar" role="toolbar" aria-label="Review file display">
-    <span class="remaining-count">{{ remainingCount }} of {{ totalCount }} remaining</span>
     <div class="toolbar-actions">
       <button
         type="button"
@@ -26,21 +22,14 @@ defineEmits<{
         aria-label="Expand all folders"
         title="Expand all folders"
         @click="$emit('expandAll')"
-      ><ListChevronsUpDown :size="14" /></button>
-      <button
-        type="button"
-        :disabled="!hasDirectories || remainingOnly"
-        aria-label="Collapse reviewed folders"
-        title="Collapse reviewed folders"
-        @click="$emit('collapseReviewed')"
-      ><ListChecks :size="14" /></button>
+      ><ListChevronsUpDown :size="14" /><span>Expand</span></button>
       <button
         type="button"
         :disabled="!hasDirectories"
         aria-label="Collapse all folders"
         title="Collapse all folders"
         @click="$emit('collapseAll')"
-      ><ListChevronsDownUp :size="14" /></button>
+      ><ListChevronsDownUp :size="14" /><span>Collapse</span></button>
       <button
         type="button"
         class="filter-button"
@@ -49,18 +38,18 @@ defineEmits<{
         aria-label="Show remaining files only"
         title="Show remaining files only"
         @click="$emit('toggleRemaining')"
-      ><ListFilter :size="14" /></button>
+      ><ListFilter :size="14" /><span>Remaining</span></button>
     </div>
   </div>
 </template>
 
 <style scoped>
-.review-files-toolbar { min-height: 31px; flex: none; display: flex; align-items: center; gap: 8px; padding: 3px 7px 3px 12px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); }
-.remaining-count { min-width: 0; margin-right: auto; overflow: hidden; color: var(--faint-foreground); font-size: 10px; white-space: nowrap; text-overflow: ellipsis; }
-.toolbar-actions { display: flex; align-items: center; gap: 2px; }
-.toolbar-actions button { width: 24px; height: 24px; display: grid; place-items: center; padding: 0; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); cursor: pointer; }
+.review-files-toolbar { min-height: 31px; flex: none; display: flex; align-items: center; padding: 3px 7px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); }
+.toolbar-actions { width: 100%; display: flex; align-items: center; gap: 2px; }
+.toolbar-actions button { min-width: 0; height: 24px; flex: 1; display: flex; align-items: center; justify-content: center; gap: 4px; padding: 0 4px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); font: inherit; font-size: 10px; cursor: pointer; }
+.toolbar-actions button svg { flex: none; }
 .toolbar-actions button:hover:not(:disabled) { background: var(--elevated-background); color: var(--workbench-foreground); }
 .toolbar-actions button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .toolbar-actions button:disabled { opacity: .35; cursor: default; }
-.toolbar-actions .filter-button.active { background: var(--selection-background); color: var(--accent); }
+.toolbar-actions .filter-button.active { background: var(--selection-background); color: var(--workbench-foreground); }
 </style>

--- a/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
+++ b/packages/app/src/renderer/src/components/ReviewFilesToolbar.vue
@@ -14,37 +14,29 @@ defineEmits<{
 
 <template>
   <div class="review-files-toolbar" role="toolbar" aria-label="Review file display">
-    <div class="toolbar-actions">
-      <button
-        type="button"
-        class="filter-button"
-        :class="{ active: remainingOnly }"
-        :aria-pressed="remainingOnly"
-        aria-label="Show remaining files only"
-        title="Show remaining files only"
-        @click="$emit('toggleRemaining')"
-      ><ListFilter :size="14" /><span>Remaining</span></button>
-      <button
-        type="button"
-        class="collapse-button"
-        :disabled="!hasDirectories"
-        aria-label="Collapse all folders"
-        title="Collapse all folders"
-        @click="$emit('collapseAll')"
-      ><ListChevronsDownUp :size="14" /></button>
-    </div>
+    <button
+      type="button"
+      :class="{ active: remainingOnly }"
+      :aria-pressed="remainingOnly"
+      aria-label="Show remaining files only"
+      title="Show remaining files only"
+      @click="$emit('toggleRemaining')"
+    ><ListFilter :size="16" /></button>
+    <button
+      type="button"
+      :disabled="!hasDirectories"
+      aria-label="Collapse all folders"
+      title="Collapse all folders"
+      @click="$emit('collapseAll')"
+    ><ListChevronsDownUp :size="16" /></button>
   </div>
 </template>
 
 <style scoped>
-.review-files-toolbar { min-height: 31px; flex: none; display: flex; align-items: center; padding: 3px 7px; border-bottom: 1px solid var(--workbench-border); background: var(--panel-background); }
-.toolbar-actions { width: 100%; display: flex; align-items: center; gap: 2px; }
-.toolbar-actions button { min-width: 0; height: 24px; display: flex; align-items: center; justify-content: center; gap: 4px; padding: 0 4px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); font: inherit; font-size: 10px; cursor: pointer; }
-.toolbar-actions button svg { flex: none; }
-.toolbar-actions .filter-button { flex: 1; }
-.toolbar-actions .collapse-button { width: 24px; flex: none; padding: 0; }
-.toolbar-actions button:hover:not(:disabled) { background: var(--elevated-background); color: var(--workbench-foreground); }
-.toolbar-actions button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
-.toolbar-actions button:disabled { opacity: .35; cursor: default; }
-.toolbar-actions .filter-button.active { background: var(--selection-background); color: var(--workbench-foreground); }
+.review-files-toolbar { flex: none; display: flex; align-items: center; gap: 4px; }
+.review-files-toolbar button { width: 22px; height: 22px; display: grid; place-items: center; padding: 3px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--faint-foreground); cursor: pointer; }
+.review-files-toolbar button:hover:not(:disabled) { background: var(--elevated-background); color: var(--workbench-foreground); }
+.review-files-toolbar button:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
+.review-files-toolbar button:disabled { opacity: .35; cursor: default; }
+.review-files-toolbar button.active { background: var(--selection-background); color: var(--accent); }
 </style>

--- a/packages/app/src/renderer/src/tree-nav.test.ts
+++ b/packages/app/src/renderer/src/tree-nav.test.ts
@@ -2,12 +2,16 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { ChangedFile, PrFile } from "@gander/shared";
 import {
   collapsedDirs,
+  collapseAllDirectories,
+  collapseReviewedDirectories,
   edge,
+  expandAllDirectories,
   filesAt,
   nextUnmarked,
   parentOf,
   pathOf,
   rows,
+  remainingOnly,
   step,
   visibleFiles,
 } from "./tree-nav.js";
@@ -24,7 +28,10 @@ const files = [
 
 const paths = (list: ChangedFile[]): string[] => list.map((f) => f.path);
 
-beforeEach(() => collapsedDirs.clear());
+beforeEach(() => {
+  collapsedDirs.clear();
+  remainingOnly.value = false;
+});
 
 describe("tree navigation", () => {
   // The cursor stops on directories as well as files, the way an explorer list does —
@@ -41,6 +48,36 @@ describe("tree navigation", () => {
       "src", "src/deep", "src/deep/inner.ts", "src/app.ts", "vendor", "README.md",
     ]);
     expect(paths(visibleFiles(files))).toEqual(["src/deep/inner.ts", "src/app.ts", "README.md"]);
+  });
+
+  it("expands and collapses every folder in one action", () => {
+    collapseAllDirectories(files);
+    expect([...collapsedDirs].sort()).toEqual(["src", "src/deep", "vendor"]);
+
+    expandAllDirectories();
+    expect([...collapsedDirs]).toEqual([]);
+  });
+
+  it("collapses reviewed folders while leaving unfinished branches open", () => {
+    const review = [
+      file("done/one.ts", true),
+      file("done/nested/two.ts", true),
+      file("working/checked.ts", true),
+      file("working/left.ts", false),
+    ];
+
+    collapseReviewedDirectories(review);
+
+    expect([...collapsedDirs]).toEqual(["done", "done/nested"]);
+  });
+
+  it("shows only unchecked files and the folders that contain them", () => {
+    remainingOnly.value = true;
+
+    expect(rows(files).map(pathOf)).toEqual([
+      "src/deep", "src/deep/inner.ts", "vendor", "vendor/bundle.js", "README.md",
+    ]);
+    expect(rows(files.map((entry) => file(entry.path, true)))).toEqual([]);
   });
 
   it("stops at the ends rather than wrapping", () => {

--- a/packages/app/src/renderer/src/tree-nav.test.ts
+++ b/packages/app/src/renderer/src/tree-nav.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ChangedFile, PrFile } from "@gander/shared";
 import {
+  collapseFullyReviewedDirectories,
   collapsedDirs,
   edge,
   filesAt,
+  hasFullyReviewedDirectories,
   nextUnmarked,
   parentOf,
   pathOf,
@@ -56,7 +58,29 @@ describe("tree navigation", () => {
     expect([...collapsedDirs]).toEqual([]);
   });
 
-  it("shows only unchecked files and the folders that contain them", () => {
+  it("collapses fully reviewed folders without changing unrelated folders", () => {
+    const reviewState = [
+      file("reviewed/done.ts", true),
+      file("mixed/done.ts", true),
+      file("mixed/todo.ts"),
+      file("vendor/bundle.js"),
+    ];
+    collapsedDirs.add("vendor");
+
+    expect(hasFullyReviewedDirectories(reviewState)).toBe(true);
+    collapseFullyReviewedDirectories(reviewState);
+
+    expect([...collapsedDirs].sort()).toEqual(["reviewed", "vendor"]);
+    expect(rows(reviewState).map(pathOf)).toEqual([
+      "mixed", "mixed/done.ts", "mixed/todo.ts", "reviewed", "vendor",
+    ]);
+  });
+
+  it("has no fully reviewed folder when every folder contains unreviewed work", () => {
+    expect(hasFullyReviewedDirectories(files.map((entry) => file(entry.path)))).toBe(false);
+  });
+
+  it("shows only unreviewed files and the folders that contain them", () => {
     remainingOnly.value = true;
 
     expect(rows(files).map(pathOf)).toEqual([

--- a/packages/app/src/renderer/src/tree-nav.test.ts
+++ b/packages/app/src/renderer/src/tree-nav.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { ChangedFile, PrFile } from "@gander/shared";
 import {
   collapsedDirs,
-  collapseAllDirectories,
   edge,
   filesAt,
   nextUnmarked,
@@ -11,6 +10,7 @@ import {
   rows,
   remainingOnly,
   step,
+  toggleAllDirectories,
   visibleFiles,
 } from "./tree-nav.js";
 
@@ -48,9 +48,12 @@ describe("tree navigation", () => {
     expect(paths(visibleFiles(files))).toEqual(["src/deep/inner.ts", "src/app.ts", "README.md"]);
   });
 
-  it("collapses every folder in one action", () => {
-    collapseAllDirectories(files);
+  it("toggles every folder closed and open", () => {
+    toggleAllDirectories(files);
     expect([...collapsedDirs].sort()).toEqual(["src", "src/deep", "vendor"]);
+
+    toggleAllDirectories(files);
+    expect([...collapsedDirs]).toEqual([]);
   });
 
   it("shows only unchecked files and the folders that contain them", () => {

--- a/packages/app/src/renderer/src/tree-nav.test.ts
+++ b/packages/app/src/renderer/src/tree-nav.test.ts
@@ -4,7 +4,6 @@ import {
   collapsedDirs,
   collapseAllDirectories,
   edge,
-  expandAllDirectories,
   filesAt,
   nextUnmarked,
   parentOf,
@@ -49,12 +48,9 @@ describe("tree navigation", () => {
     expect(paths(visibleFiles(files))).toEqual(["src/deep/inner.ts", "src/app.ts", "README.md"]);
   });
 
-  it("expands and collapses every folder in one action", () => {
+  it("collapses every folder in one action", () => {
     collapseAllDirectories(files);
     expect([...collapsedDirs].sort()).toEqual(["src", "src/deep", "vendor"]);
-
-    expandAllDirectories();
-    expect([...collapsedDirs]).toEqual([]);
   });
 
   it("shows only unchecked files and the folders that contain them", () => {

--- a/packages/app/src/renderer/src/tree-nav.test.ts
+++ b/packages/app/src/renderer/src/tree-nav.test.ts
@@ -3,7 +3,6 @@ import type { ChangedFile, PrFile } from "@gander/shared";
 import {
   collapsedDirs,
   collapseAllDirectories,
-  collapseReviewedDirectories,
   edge,
   expandAllDirectories,
   filesAt,
@@ -56,19 +55,6 @@ describe("tree navigation", () => {
 
     expandAllDirectories();
     expect([...collapsedDirs]).toEqual([]);
-  });
-
-  it("collapses reviewed folders while leaving unfinished branches open", () => {
-    const review = [
-      file("done/one.ts", true),
-      file("done/nested/two.ts", true),
-      file("working/checked.ts", true),
-      file("working/left.ts", false),
-    ];
-
-    collapseReviewedDirectories(review);
-
-    expect([...collapsedDirs]).toEqual(["done", "done/nested"]);
   });
 
   it("shows only unchecked files and the folders that contain them", () => {

--- a/packages/app/src/renderer/src/tree-nav.ts
+++ b/packages/app/src/renderer/src/tree-nav.ts
@@ -40,6 +40,28 @@ function directoryPaths(files: ChangedFile[]): string[] {
   return walk(buildTree(files));
 }
 
+function fullyReviewedDirectoryPaths(files: ChangedFile[]): string[] {
+  const paths: string[] = [];
+  const reviewed = (node: TreeNode): boolean => {
+    if (node.type === "file") return "checked" in node.file && node.file.checked === true;
+
+    const childrenReviewed = node.children.map(reviewed).every(Boolean);
+    if (childrenReviewed) paths.push(node.path);
+    return childrenReviewed;
+  };
+
+  for (const node of buildTree(files)) reviewed(node);
+  return paths;
+}
+
+export function hasFullyReviewedDirectories(files: ChangedFile[]): boolean {
+  return fullyReviewedDirectoryPaths(files).length > 0;
+}
+
+export function collapseFullyReviewedDirectories(files: ChangedFile[]): void {
+  for (const path of fullyReviewedDirectoryPaths(files)) collapsedDirs.add(path);
+}
+
 export function allDirectoriesCollapsed(files: ChangedFile[]): boolean {
   const paths = directoryPaths(files);
   return paths.length > 0 && paths.every((path) => collapsedDirs.has(path));

--- a/packages/app/src/renderer/src/tree-nav.ts
+++ b/packages/app/src/renderer/src/tree-nav.ts
@@ -40,10 +40,6 @@ function directoryPaths(files: ChangedFile[]): string[] {
   return walk(buildTree(files));
 }
 
-export function expandAllDirectories(): void {
-  collapsedDirs.clear();
-}
-
 export function collapseAllDirectories(files: ChangedFile[]): void {
   collapsedDirs.clear();
   for (const path of directoryPaths(files)) collapsedDirs.add(path);

--- a/packages/app/src/renderer/src/tree-nav.ts
+++ b/packages/app/src/renderer/src/tree-nav.ts
@@ -1,6 +1,6 @@
 import { reactive, ref, shallowRef } from "vue";
-import type { ChangedFile, PrFile } from "@gander/shared";
-import { buildTree, filesUnder, type TreeNode } from "./tree.js";
+import type { ChangedFile } from "@gander/shared";
+import { buildTree, type TreeNode } from "./tree.js";
 
 /**
  * Where the keyboard is in the file tree, and which directories are collapsed.
@@ -47,22 +47,6 @@ export function expandAllDirectories(): void {
 export function collapseAllDirectories(files: ChangedFile[]): void {
   collapsedDirs.clear();
   for (const path of directoryPaths(files)) collapsedDirs.add(path);
-}
-
-/** Opens unfinished branches and folds every folder whose files are all reviewed. */
-export function collapseReviewedDirectories(files: ChangedFile[]): void {
-  collapsedDirs.clear();
-  const walk = (nodes: TreeNode[]): void => {
-    for (const node of nodes) {
-      if (node.type !== "dir") continue;
-      const descendants = filesUnder(node).filter((file): file is PrFile => "checked" in file);
-      if (descendants.length > 0 && descendants.every((file) => file.checked)) {
-        collapsedDirs.add(node.path);
-      }
-      walk(node.children);
-    }
-  };
-  walk(buildTree(files));
 }
 
 /** Every row the tree draws, in order, with the contents of a collapsed directory left out. */

--- a/packages/app/src/renderer/src/tree-nav.ts
+++ b/packages/app/src/renderer/src/tree-nav.ts
@@ -40,7 +40,17 @@ function directoryPaths(files: ChangedFile[]): string[] {
   return walk(buildTree(files));
 }
 
-export function collapseAllDirectories(files: ChangedFile[]): void {
+export function allDirectoriesCollapsed(files: ChangedFile[]): boolean {
+  const paths = directoryPaths(files);
+  return paths.length > 0 && paths.every((path) => collapsedDirs.has(path));
+}
+
+export function toggleAllDirectories(files: ChangedFile[]): void {
+  if (allDirectoriesCollapsed(files)) {
+    collapsedDirs.clear();
+    return;
+  }
+
   collapsedDirs.clear();
   for (const path of directoryPaths(files)) collapsedDirs.add(path);
 }

--- a/packages/app/src/renderer/src/tree-nav.ts
+++ b/packages/app/src/renderer/src/tree-nav.ts
@@ -1,6 +1,6 @@
-import { reactive, ref } from "vue";
-import type { ChangedFile } from "@gander/shared";
-import { buildTree, type TreeNode } from "./tree.js";
+import { reactive, ref, shallowRef } from "vue";
+import type { ChangedFile, PrFile } from "@gander/shared";
+import { buildTree, filesUnder, type TreeNode } from "./tree.js";
 
 /**
  * Where the keyboard is in the file tree, and which directories are collapsed.
@@ -11,6 +11,9 @@ import { buildTree, type TreeNode } from "./tree.js";
  * so one flat set is unambiguous.
  */
 export const collapsedDirs = reactive(new Set<string>());
+
+/** Whether the review tree omits files the reviewer has already checked. */
+export const remainingOnly = shallowRef(false);
 
 /**
  * The row the keyboard is on, which is a directory as often as a file. It is separate from
@@ -24,6 +27,44 @@ export function toggleCollapsed(path: string): void {
   else collapsedDirs.add(path);
 }
 
+/** Files currently included in the review tree. Local files have no review state. */
+export function reviewTreeFiles(files: ChangedFile[]): ChangedFile[] {
+  if (!remainingOnly.value) return files;
+  return files.filter((file) => !("checked" in file) || !file.checked);
+}
+
+function directoryPaths(files: ChangedFile[]): string[] {
+  const walk = (nodes: TreeNode[]): string[] => nodes.flatMap((node) =>
+    node.type === "dir" ? [node.path, ...walk(node.children)] : [],
+  );
+  return walk(buildTree(files));
+}
+
+export function expandAllDirectories(): void {
+  collapsedDirs.clear();
+}
+
+export function collapseAllDirectories(files: ChangedFile[]): void {
+  collapsedDirs.clear();
+  for (const path of directoryPaths(files)) collapsedDirs.add(path);
+}
+
+/** Opens unfinished branches and folds every folder whose files are all reviewed. */
+export function collapseReviewedDirectories(files: ChangedFile[]): void {
+  collapsedDirs.clear();
+  const walk = (nodes: TreeNode[]): void => {
+    for (const node of nodes) {
+      if (node.type !== "dir") continue;
+      const descendants = filesUnder(node).filter((file): file is PrFile => "checked" in file);
+      if (descendants.length > 0 && descendants.every((file) => file.checked)) {
+        collapsedDirs.add(node.path);
+      }
+      walk(node.children);
+    }
+  };
+  walk(buildTree(files));
+}
+
 /** Every row the tree draws, in order, with the contents of a collapsed directory left out. */
 export function rows(files: ChangedFile[]): TreeNode[] {
   const walk = (nodes: TreeNode[]): TreeNode[] =>
@@ -31,7 +72,7 @@ export function rows(files: ChangedFile[]): TreeNode[] {
       if (node.type === "file") return [node];
       return collapsedDirs.has(node.path) ? [node] : [node, ...walk(node.children)];
     });
-  return walk(buildTree(files));
+  return walk(buildTree(reviewTreeFiles(files)));
 }
 
 export function pathOf(node: TreeNode): string {


### PR DESCRIPTION
## Summary

- add a compact, mouse-friendly Review Files header toolbar with icon-only unreviewed, collapse-reviewed, and expand/collapse-all actions
- follow VS Code's ViewTitle model for placement while keeping one stateful folder action: mixed/open trees collapse, then the same control changes to Expand All
- make the unreviewed filter hide every reviewed file, including top-level files, and update immediately as files are reviewed
- collapse folders whose entire descendant file set is reviewed without changing unrelated folder state
- label review state consistently as unreviewed and show progress as `7/8 unreviewed`, with a full accessible description
- move folder actions into a VS Code-style More Actions popover when the resizable sidebar cannot fit the full toolbar
- progressively shorten redundant header copy at the 190px minimum while preserving the full accessible progress description
- keep filtered visibility aligned with keyboard navigation and preserve local file-tree behavior

## Readiness

- Simplify: clean
- Code review: clean
- Finalize: clean
- Adversarial review: clean

## Test plan

- `pnpm test` (60 files, 390 tests passed)
- `pnpm typecheck`
- focused Electron E2E proves the toolbar lives in the section header, the same control collapses and expands every folder, reviewed-file filtering, and turning the filter off
- Electron coverage verifies that fully reviewed folders collapse while folders with unreviewed work stay open
- Electron coverage verifies the unreviewed-file tooltip and progress copy as review state changes
- Electron coverage measures header overflow at 190, 205, 206, 226, 250, 251, 264, 280, 281, and 520px
- real-window visual verification at default width, the reported 226px width, the 190px minimum, and with More Actions open
- Impeccable detector clean
