### PR TITLE
Add note editing and status controls

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -50,6 +50,8 @@ milestone boundary.
 Pressing `n` over a file captures a note against it, stamped with the line
 being read. Notes carry three states: `open` when captured, `addressed` when
 an agent has acted on one, and `resolved` when the reviewer re-checks the file.
+The notes drawer lets the reviewer correct note text or explicitly change a
+note's state when the recorded workflow state needs correcting.
 Agents reach them over MCP at `/mcp` on the review service — see `DEVSTACK.md`
 for registration.
 

--- a/packages/app/e2e/note-lifecycle.spec.ts
+++ b/packages/app/e2e/note-lifecycle.spec.ts
@@ -59,8 +59,24 @@ test("lets the reviewer edit a note and change its status", async ({ world }) =>
     await note.getByRole("button", { name: "Save" }).click();
     await expect(note).toContainText("Updated wording");
 
-    await note.getByRole("combobox", { name: "Status for note" }).selectOption("resolved");
-    await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("resolved");
+    const status = note.getByRole("combobox", { name: "Status for note" });
+    await status.focus();
+    const statusStyle = await status.evaluate((control) => {
+      const pill = control.closest("label");
+      if (!pill) throw new Error("status control is missing its pill");
+      const controlStyle = getComputedStyle(control);
+      const pillStyle = getComputedStyle(pill);
+      return {
+        height: pill.getBoundingClientRect().height,
+        controlOutline: controlStyle.outlineStyle,
+        pillOutline: pillStyle.outlineStyle,
+        textTransform: controlStyle.textTransform,
+      };
+    });
+    expect(statusStyle).toMatchObject({ controlOutline: "none", pillOutline: "solid", textTransform: "none" });
+    expect(statusStyle.height).toBeGreaterThanOrEqual(22);
+    await status.selectOption("resolved");
+    await expect(status).toHaveValue("resolved");
 
     const saved = await agent.notes(repository.repoId, "feature");
     expect(saved.noteCounts).toEqual({ open: 0, addressed: 0, resolved: 1 });

--- a/packages/app/e2e/note-lifecycle.spec.ts
+++ b/packages/app/e2e/note-lifecycle.spec.ts
@@ -15,7 +15,7 @@ test("carries a reviewer note through MCP addressing and reviewer resolution", a
     await review.openNotes();
 
     const note = app.page.getByRole("listitem").filter({ hasText: "Explain why this branch is necessary" });
-    await expect(note.getByText("open", { exact: true })).toBeVisible();
+    await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("open");
 
     const pickedUp = await agent.notes(repository.repoId, "feature");
     expect(pickedUp.noteCounts).toEqual({ open: 1, addressed: 0, resolved: 0 });
@@ -23,16 +23,48 @@ test("carries a reviewer note through MCP addressing and reviewer resolution", a
     await agent.markAddressed(pickedUp.notes[0]!.id, "abc1234", "Removed the unnecessary branch");
 
     await review.fetchOrigin();
-    await expect(note.getByText("addressed", { exact: true })).toBeVisible();
+    await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("addressed");
     await expect(note.getByRole("region", { name: "Agent update" })).toContainText("Removed the unnecessary branch");
     await expect(note.getByRole("region", { name: "Agent update" })).toContainText("abc1234");
 
     await app.page.getByRole("button", { name: "Mark reviewed" }).click();
     await review.fetchOrigin();
-    await expect(note.getByText("resolved", { exact: true })).toBeVisible();
+    await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("resolved");
 
     const completed = await agent.notes(repository.repoId, "feature");
     expect(completed.noteCounts).toEqual({ open: 0, addressed: 0, resolved: 1 });
+  } finally {
+    await agent.close();
+  }
+});
+
+test("lets the reviewer edit a note and change its status", async ({ world }) => {
+  const repository = await world.addRepository({ repoId: "acme/edit-note" });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+  const agent = await new McpDriver(world.serviceUrl, world.serviceToken).connect();
+
+  try {
+    await review.open(repository.title);
+    await review.selectFile("a.rb");
+    await review.addNote("Original wording");
+    await review.openNotes();
+
+    const note = app.page.getByRole("list", { name: "Review notes" }).getByRole("listitem");
+    await expect(note).toContainText("Original wording");
+    await note.getByRole("button", { name: "Edit note" }).click();
+    const editor = note.getByRole("textbox", { name: "Edit note" });
+    await expect(editor).toBeFocused();
+    await editor.fill("Updated wording");
+    await note.getByRole("button", { name: "Save" }).click();
+    await expect(note).toContainText("Updated wording");
+
+    await note.getByRole("combobox", { name: "Status for note" }).selectOption("resolved");
+    await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("resolved");
+
+    const saved = await agent.notes(repository.repoId, "feature");
+    expect(saved.noteCounts).toEqual({ open: 0, addressed: 0, resolved: 1 });
+    expect(saved.notes[0]).toMatchObject({ text: "Updated wording", state: "resolved" });
   } finally {
     await agent.close();
   }

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -1,4 +1,4 @@
-import type { LocalFile, LocalFileEntry, LocalView, LocalWorktree, NewNote, OpenTarget, PrListItem, PrView, RepoEntry } from "@gander/shared";
+import type { LocalFile, LocalFileEntry, LocalView, LocalWorktree, NewNote, OpenTarget, PrListItem, PrView, RepoEntry, UpdateNote } from "@gander/shared";
 import type { AppSettings } from "./settings.js";
 import type { ThemeId } from "./themes.js";
 import type { ConnectionCheck, ServiceStatus } from "./main/connection.js";
@@ -60,6 +60,7 @@ export interface GanderApi {
   closeLocal(): Promise<void>;
   onLocalViewChanged(listener: (update: LocalViewUpdate) => void): () => void;
   addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha">): Promise<PrView>;
+  updateNote(repoId: string, prNumber: number, id: number, input: UpdateNote): Promise<PrView>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<PrView>;
   getSettings(): Promise<AppSettings>;
   updateSettings(settings: AppSettings): Promise<AppSettings>;

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, shell } from "e
 import { hostname } from "node:os";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
-import { type LocalView, type OpenTarget, type RepoEntry } from "@gander/shared";
+import { type LocalView, type OpenTarget, type RepoEntry, type UpdateNote } from "@gander/shared";
 import { connectionIsFromEnvironment, loadConfig, resolveServiceConnection, saveConfig, type GanderConfig } from "./config.js";
 import { checkConnection } from "./connection.js";
 import { parseOpenTarget } from "./cli.js";
@@ -183,6 +183,7 @@ async function bootstrap(): Promise<{ cfg: GanderConfig; git: GitEngine }> {
   ipcMain.handle("gander:reviewedSnapshot", async (_e, repoId: string, n: number, path: string) => reviewer.reviewedSnapshot(repoId, n, path));
   ipcMain.handle("gander:imagePreview", async (_e, repoId: string, n: number, path: string) => reviewer.imagePreview(repoId, n, path));
   ipcMain.handle("gander:addNote", async (_e, repoId: string, n: number, input: { path: string | null; line: number | null; text: string }) => reviewer.addNote(repoId, n, input));
+  ipcMain.handle("gander:updateNote", async (_e, repoId: string, n: number, id: number, input: UpdateNote) => reviewer.updateNote(repoId, n, id, input));
   ipcMain.handle("gander:deleteNote", async (_e, repoId: string, n: number, id: number) => reviewer.deleteNote(repoId, n, id));
   ipcMain.handle("gander:setCheckedMany", async (_e, repoId: string, n: number, paths: string[], checked: boolean) => reviewer.setCheckedMany(repoId, n, paths, checked));
   // Connection is deliberately not part of the settings document: that document is

--- a/packages/app/src/main/review.ts
+++ b/packages/app/src/main/review.ts
@@ -1,4 +1,4 @@
-import type { FileCheckoff, NewNote, PrFile, PrListItem, PrSummary, PrView, ReviewState } from "@gander/shared";
+import type { FileCheckoff, NewNote, PrFile, PrListItem, PrSummary, PrView, ReviewState, UpdateNote } from "@gander/shared";
 import type { GitEngine } from "./git.js";
 import { ServiceConnectionError, STALE_SERVICE_DATA_WRITE_ERROR, type ServiceClient } from "./service-client.js";
 import type { ImagePreview, ImageSide } from "../image-preview.js";
@@ -17,6 +17,7 @@ export interface Reviewer {
   setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<PrView>;
   setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView>;
   addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha">): Promise<PrView>;
+  updateNote(repoId: string, prNumber: number, id: number, input: UpdateNote): Promise<PrView>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<PrView>;
   /** The file as it stood when the reviewer last checked it — the base for the delta view. */
   reviewedSnapshot(repoId: string, prNumber: number, path: string): Promise<string | null>;
@@ -268,6 +269,12 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     },
     async reviewedSnapshot(repoId, prNumber, path) {
       return (await deps.service.getSnapshot(repoId, prNumber, path)).headContent;
+    },
+    async updateNote(repoId, prNumber, id, input) {
+      const entry = requireWritable(repoId, prNumber);
+      const note = await writeServiceState(entry, () => deps.service.updateNote(repoId, prNumber, id, input));
+      entry.view.notes = entry.view.notes.map((candidate) => candidate.id === id ? note : candidate);
+      return entry.view;
     },
     async imagePreview(repoId, prNumber, path) {
       const entry = cache.get(key(repoId, prNumber));

--- a/packages/app/src/main/service-client.test.ts
+++ b/packages/app/src/main/service-client.test.ts
@@ -92,4 +92,17 @@ describe("a request with no body", () => {
     await client.addNote("acme/atlas", 1, { path: "a.rb", line: null, text: "why?", headSha: null });
     expect(seen).toEqual(["application/json"]);
   });
+
+  it("patches a note and validates the saved note", async () => {
+    const url = await serve((app) => {
+      app.patch("/api/reviews/:repoId/:prNumber/notes/:id", async (req) => ({
+        id: 2, path: "a.rb", line: null, text: (req.body as { text: string }).text, state: "resolved",
+        headSha: null, commitRef: null, summary: null, createdAt: new Date().toISOString(),
+      }));
+    });
+    const client = createServiceClient(() => ({ url, token: "t" }));
+
+    await expect(client.updateNote("acme/atlas", 1, 2, { text: "Updated", state: "resolved" }))
+      .resolves.toMatchObject({ id: 2, text: "Updated", state: "resolved" });
+  });
 });

--- a/packages/app/src/main/service-client.ts
+++ b/packages/app/src/main/service-client.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { describeNetworkError } from "./network-error.js";
-import { FileCheckoffSchema, NoteSchema, ReviewStateSchema, unreachableReason, type FileCheckoff, type NewNote, type PrContext, type PutFileState, type Note, type ReviewState } from "@gander/shared";
+import { FileCheckoffSchema, NoteSchema, ReviewStateSchema, unreachableReason, type FileCheckoff, type NewNote, type PrContext, type PutFileState, type Note, type ReviewState, type UpdateNote } from "@gander/shared";
 import { checkServiceStatus, type ServiceStatus } from "./connection.js";
 
 export class ServiceConnectionError extends Error {}
@@ -12,6 +12,7 @@ export interface ServiceClient {
   putFileState(repoId: string, prNumber: number, input: PutFileState): Promise<FileCheckoff>;
   listNotes(repoId: string, prNumber: number): Promise<Note[]>;
   addNote(repoId: string, prNumber: number, input: NewNote): Promise<Note>;
+  updateNote(repoId: string, prNumber: number, id: number, input: UpdateNote): Promise<Note>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<void>;
   setPrContext(repoId: string, prNumber: number, context: PrContext): Promise<void>;
   getSnapshot(repoId: string, prNumber: number, path: string): Promise<{ baseContent: string | null; headContent: string | null }>;
@@ -174,6 +175,10 @@ export function createServiceClient(connection: Connection): ServiceClient {
     addNote: async (repoId, prNumber, input) => {
       const path = `${reviewPath(repoId, prNumber)}/notes`;
       return validate(NoteSchema, path, await req("POST", path, input, { reviewKey: reviewKey(repoId, prNumber) }));
+    },
+    updateNote: async (repoId, prNumber, id, input) => {
+      const path = `${reviewPath(repoId, prNumber)}/notes/${id}`;
+      return validate(NoteSchema, path, await req("PATCH", path, input, { reviewKey: reviewKey(repoId, prNumber) }));
     },
     deleteNote: async (repoId, prNumber, id) => {
       await req("DELETE", `${reviewPath(repoId, prNumber)}/notes/${id}`, undefined, { reviewKey: reviewKey(repoId, prNumber) });

--- a/packages/app/src/preload/api.ts
+++ b/packages/app/src/preload/api.ts
@@ -84,6 +84,7 @@ export function createGanderApi(
     closeLocal: () => call("closeLocal"),
     onLocalViewChanged: (listener) => subscribe("gander:localViewChanged", (update: LocalViewUpdate) => listener(update)),
     addNote: (repoId, prNumber, input) => call("addNote", repoId, prNumber, input),
+    updateNote: (repoId, prNumber, id, input) => call("updateNote", repoId, prNumber, id, input),
     deleteNote: (repoId, prNumber, id) => call("deleteNote", repoId, prNumber, id),
     getConnection: () => call("getConnection"),
     testConnection: (url, token) => call("testConnection", url, token),

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -63,6 +63,7 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
     async reviewedSnapshot() { return null; },
     async imagePreview() { return null; },
     async addNote() {},
+    async updateNote() {},
     async deleteNote() {},
     async setChecked(path: string, checked: boolean) {
       calls.setChecked.push([path, checked]);

--- a/packages/app/src/renderer/src/components/NoteItem.vue
+++ b/packages/app/src/renderer/src/components/NoteItem.vue
@@ -221,16 +221,17 @@ async function changeStatus(event: Event): Promise<void> {
 .location:disabled { color: var(--faint-foreground); cursor: default; }
 .state {
   display: inline-flex; align-items: center; gap: 3px; flex: none;
-  border: 1px solid var(--workbench-border); border-radius: var(--radius-pill); padding: 1px 5px;
-  color: var(--faint-foreground); font: 600 9px var(--mono); letter-spacing: .35px; text-transform: uppercase;
+  min-height: 22px; border: 1px solid var(--workbench-border); border-radius: var(--radius-pill); padding: 0 7px;
+  color: var(--faint-foreground); font-size: 11px; font-weight: 600;
 }
 .status-label { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
 .state select {
-  appearance: none; border: 0; padding: 0; background: transparent; color: inherit;
-  font: inherit; letter-spacing: inherit; text-transform: uppercase; cursor: pointer;
+  appearance: none; border: 0; outline: 0; padding: 0; background: transparent; color: inherit;
+  font: inherit; letter-spacing: normal; text-transform: none; cursor: pointer;
 }
 .state select:disabled { cursor: wait; opacity: .65; }
 .status-chevron { margin-left: -2px; pointer-events: none; }
+.state:focus-within { outline: 1px solid var(--accent); outline-offset: 1px; }
 .state.open { color: var(--accent); }
 .state.addressed { color: var(--warning); }
 .state.resolved { color: var(--success); }
@@ -265,7 +266,7 @@ async function changeStatus(event: Event): Promise<void> {
 .note-actions button { display: inline-flex; align-items: center; gap: 5px; border: 0; padding: 2px 0; background: none; color: var(--muted-foreground); font: inherit; font-size: 10.5px; cursor: pointer; }
 .note-actions .delete { margin-left: auto; color: var(--faint-foreground); }
 .note-actions .delete:hover { color: var(--danger); }
-.location:focus-visible, .state select:focus-visible, .disclosure:focus-visible, .edit-form textarea:focus-visible, .edit-actions button:focus-visible, .note-actions button:focus-visible {
+.location:focus-visible, .disclosure:focus-visible, .edit-form textarea:focus-visible, .edit-actions button:focus-visible, .note-actions button:focus-visible {
   outline: 2px solid var(--accent); outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) { .chevron { transition: none; } }

--- a/packages/app/src/renderer/src/components/NoteItem.vue
+++ b/packages/app/src/renderer/src/components/NoteItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, shallowRef } from "vue";
-import type { Note } from "@gander/shared";
+import { computed, nextTick, shallowRef, useTemplateRef } from "vue";
+import type { Note, NoteState } from "@gander/shared";
 import { basename } from "../paths.js";
 import ConfirmDialog from "./ConfirmDialog.vue";
 import {
@@ -9,6 +9,7 @@ import {
   ChevronDown,
   CircleHelp,
   Copy,
+  Pencil,
   Trash2,
 } from "@lucide/vue";
 
@@ -16,6 +17,7 @@ const props = defineProps<{
   note: Note;
   current: boolean;
   copied: boolean;
+  updateNote: (id: number, input: { text?: string; state?: NoteState }) => Promise<void>;
 }>();
 const emit = defineEmits<{
   navigate: [note: Note];
@@ -25,6 +27,11 @@ const emit = defineEmits<{
 // Deleting a note is the only thing here that cannot be taken back: its text and
 // the line it was captured against go together.
 const confirmingDelete = shallowRef(false);
+const editing = shallowRef(false);
+const draftText = shallowRef(props.note.text);
+const savingEdit = shallowRef(false);
+const changingStatus = shallowRef(false);
+const editInput = useTemplateRef<HTMLTextAreaElement>("editInput");
 
 const deleteDetail = "The note will be removed from the review. This cannot be undone.";
 
@@ -44,6 +51,47 @@ const timestamp = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", time
 function formatTimestamp(value: string): string {
   const date = new Date(value);
   return Number.isNaN(date.valueOf()) ? value : timestamp.format(date);
+}
+
+async function startEditing(): Promise<void> {
+  draftText.value = props.note.text;
+  editing.value = true;
+  await nextTick();
+  editInput.value?.focus();
+}
+
+function cancelEditing(): void {
+  draftText.value = props.note.text;
+  editing.value = false;
+}
+
+async function saveEdit(): Promise<void> {
+  const text = draftText.value.trim();
+  if (text === "" || text === props.note.text) {
+    if (text !== "") cancelEditing();
+    return;
+  }
+  savingEdit.value = true;
+  try {
+    await props.updateNote(props.note.id, { text });
+    await nextTick();
+    if (props.note.text === text) editing.value = false;
+  } finally {
+    savingEdit.value = false;
+  }
+}
+
+async function changeStatus(event: Event): Promise<void> {
+  const select = event.currentTarget as HTMLSelectElement;
+  changingStatus.value = true;
+  try {
+    await props.updateNote(props.note.id, { state: select.value as NoteState });
+    await nextTick();
+    // The store owns the saved value. This also restores the control after a failed write.
+    select.value = props.note.state;
+  } finally {
+    changingStatus.value = false;
+  }
 }
 </script>
 
@@ -65,12 +113,18 @@ function formatTimestamp(value: string): string {
         >
           {{ location }}
         </button>
-        <span class="state" :class="note.state">
+        <label class="state" :class="note.state">
           <CircleHelp v-if="note.state === 'open'" :size="12" aria-hidden="true" />
           <Check v-else-if="note.state === 'addressed'" :size="12" aria-hidden="true" />
           <CheckCheck v-else :size="12" aria-hidden="true" />
-          {{ note.state }}
-        </span>
+          <span class="status-label">Status</span>
+          <select :value="note.state" :aria-label="`Status for note ${note.id}`" :disabled="changingStatus" @change="changeStatus">
+            <option value="open">Open</option>
+            <option value="addressed">Addressed</option>
+            <option value="resolved">Resolved</option>
+          </select>
+          <ChevronDown class="status-chevron" :size="10" aria-hidden="true" />
+        </label>
       </div>
       <button
         class="disclosure"
@@ -91,7 +145,14 @@ function formatTimestamp(value: string): string {
           <h3>Note</h3>
           <time :datetime="note.createdAt">{{ formatTimestamp(note.createdAt) }}</time>
         </div>
-        <p class="message-text">{{ note.text }}</p>
+        <form v-if="editing" class="edit-form" @submit.prevent="saveEdit" @keydown.esc.prevent="cancelEditing">
+          <textarea ref="editInput" v-model="draftText" :aria-label="`Edit note ${note.id}`" :disabled="savingEdit" rows="4" />
+          <div class="edit-actions">
+            <button type="button" :disabled="savingEdit" @click="cancelEditing">Cancel</button>
+            <button class="save" type="submit" :disabled="savingEdit || draftText.trim() === ''">{{ savingEdit ? "Saving…" : "Save" }}</button>
+          </div>
+        </form>
+        <p v-else class="message-text">{{ note.text }}</p>
       </div>
 
       <section v-if="note.summary || note.commitRef" class="agent-update" aria-label="Agent update">
@@ -103,6 +164,15 @@ function formatTimestamp(value: string): string {
       </section>
 
       <div class="note-actions">
+        <button
+          v-if="!editing"
+          type="button"
+          :aria-label="`Edit note ${note.id}`"
+          @click="startEditing"
+        >
+          <Pencil :size="13" aria-hidden="true" />
+          Edit
+        </button>
         <button
           type="button"
           :aria-label="`Copy note ${note.id}`"
@@ -154,6 +224,13 @@ function formatTimestamp(value: string): string {
   border: 1px solid var(--workbench-border); border-radius: var(--radius-pill); padding: 1px 5px;
   color: var(--faint-foreground); font: 600 9px var(--mono); letter-spacing: .35px; text-transform: uppercase;
 }
+.status-label { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+.state select {
+  appearance: none; border: 0; padding: 0; background: transparent; color: inherit;
+  font: inherit; letter-spacing: inherit; text-transform: uppercase; cursor: pointer;
+}
+.state select:disabled { cursor: wait; opacity: .65; }
+.status-chevron { margin-left: -2px; pointer-events: none; }
 .state.open { color: var(--accent); }
 .state.addressed { color: var(--warning); }
 .state.resolved { color: var(--success); }
@@ -174,11 +251,21 @@ function formatTimestamp(value: string): string {
 .message-heading time { min-width: 0; color: var(--faint-foreground); font-size: 9.5px; text-align: right; }
 .message-heading code { overflow: hidden; max-width: 45%; padding: 1px 5px; border-radius: var(--radius-sm); background: var(--badge-background); color: var(--muted-foreground); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
 .message-text { margin: 4px 0 0; min-width: 0; color: var(--workbench-foreground); font-size: 12.5px; line-height: 1.5; overflow-wrap: anywhere; white-space: pre-wrap; }
+.edit-form { margin-top: 6px; }
+.edit-form textarea {
+  box-sizing: border-box; width: 100%; resize: vertical; border: 1px solid var(--accent); border-radius: var(--radius-sm);
+  padding: 7px 8px; background: var(--panel-background); color: var(--workbench-foreground); font: inherit; font-size: 12.5px; line-height: 1.45;
+}
+.edit-actions { display: flex; justify-content: flex-end; gap: 6px; margin-top: 6px; }
+.edit-actions button { border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 3px 9px; background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 11px; cursor: pointer; }
+.edit-actions .save { border-color: var(--accent); background: var(--accent); color: var(--accent-foreground); }
+.edit-actions .save:disabled { opacity: .5; cursor: default; }
+.edit-form textarea:disabled, .edit-actions button:disabled { cursor: wait; }
 .note-actions { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
 .note-actions button { display: inline-flex; align-items: center; gap: 5px; border: 0; padding: 2px 0; background: none; color: var(--muted-foreground); font: inherit; font-size: 10.5px; cursor: pointer; }
 .note-actions .delete { margin-left: auto; color: var(--faint-foreground); }
 .note-actions .delete:hover { color: var(--danger); }
-.location:focus-visible, .disclosure:focus-visible, .note-actions button:focus-visible {
+.location:focus-visible, .state select:focus-visible, .disclosure:focus-visible, .edit-form textarea:focus-visible, .edit-actions button:focus-visible, .note-actions button:focus-visible {
   outline: 2px solid var(--accent); outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) { .chevron { transition: none; } }

--- a/packages/app/src/renderer/src/components/NotesDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/NotesDrawer.test.ts
@@ -30,6 +30,7 @@ function store(notes: PrView["notes"], overrides: Partial<Store> = {}): Store {
     view: view(notes),
     selectedPath: null,
     async deleteNote() {},
+    async updateNote() {},
     select() {},
     ...overrides,
   } as unknown as Store;
@@ -109,7 +110,7 @@ describe("NotesDrawer", () => {
 
     const addressed = wrapper.get("[data-note-id='2']");
     expect(addressed.text()).toContain("addressed.ts:9");
-    expect(addressed.get(".state").text()).toBe("addressed");
+    expect((addressed.get("select[aria-label='Status for note 2']").element as HTMLSelectElement).value).toBe("addressed");
     expect(addressed.text()).toContain("Could this preserve the existing caller contract?");
     expect(addressed.find("[data-note-body]").isVisible()).toBe(false);
   });
@@ -145,6 +146,34 @@ describe("NotesDrawer", () => {
     expect(deleteNote).not.toHaveBeenCalled();
     await open.get("dialog.confirm button.danger").trigger("click");
     expect(deleteNote).toHaveBeenCalledWith(1);
+  });
+
+  it("edits note text and changes status through labeled controls", async () => {
+    const updateNote = vi.fn(async () => {});
+    const wrapper = mount(NotesDrawer, { props: { store: store(notes, { updateNote }), dock: "right" } });
+    const open = wrapper.get("[data-note-id='1']");
+
+    await open.get("button[aria-label='Edit note 1']").trigger("click");
+    const editor = open.get("textarea[aria-label='Edit note 1']");
+    await editor.setValue("Use the shared helper instead");
+    await open.get("form.edit-form").trigger("submit");
+    expect(updateNote).toHaveBeenCalledWith(1, { text: "Use the shared helper instead" });
+
+    await open.get("select[aria-label='Status for note 1']").setValue("resolved");
+    expect(updateNote).toHaveBeenCalledWith(1, { state: "resolved" });
+  });
+
+  it("cancels an edit without saving it", async () => {
+    const updateNote = vi.fn(async () => {});
+    const wrapper = mount(NotesDrawer, { props: { store: store(notes, { updateNote }), dock: "right" } });
+    const open = wrapper.get("[data-note-id='1']");
+
+    await open.get("button[aria-label='Edit note 1']").trigger("click");
+    await open.get("textarea[aria-label='Edit note 1']").setValue("Discard this");
+    await open.get(".edit-actions button[type='button']").trigger("click");
+
+    expect(updateNote).not.toHaveBeenCalled();
+    expect(open.text()).toContain("Why does this branch need");
   });
 
   it("deletes nothing when the confirmation is dismissed", async () => {

--- a/packages/app/src/renderer/src/components/NotesDrawer.vue
+++ b/packages/app/src/renderer/src/components/NotesDrawer.vue
@@ -108,6 +108,7 @@ async function copyAll(): Promise<void> {
         :note="note"
         :current="note.path === store.selectedPath"
         :copied="copiedNoteId === note.id"
+        :update-note="store.updateNote"
         @navigate="goTo"
         @copy="copyNote"
         @delete="store.deleteNote"

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -58,6 +58,7 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     closeLocal: async () => {},
     onLocalViewChanged: () => () => {},
     addNote: async () => prView(),
+    updateNote: async () => prView(),
     deleteNote: async () => prView(),
     getSettings: async () => ({
       editor: { fontFamily: "monospace", fontSize: 16 },

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -1,6 +1,6 @@
 import { reactive } from "vue";
 import { isUnreachableReason } from "@gander/shared";
-import type { ChangedFile, LocalFile, LocalFileEntry, LocalView, LocalWorktree, OpenTarget, PrListItem, PrView, RepoEntry } from "@gander/shared";
+import type { ChangedFile, LocalFile, LocalFileEntry, LocalView, LocalWorktree, NoteState, OpenTarget, PrListItem, PrView, RepoEntry } from "@gander/shared";
 import type { GanderApi } from "./api.js";
 import type { ImagePreview } from "../../api.js";
 import type { ServiceStatus } from "../../api.js";
@@ -63,6 +63,7 @@ export interface Store {
   reviewedSnapshot(path: string): Promise<string | null>;
   imagePreview(path: string): Promise<ImagePreview | null>;
   addNote(text: string, path: string | null, line: number | null): Promise<void>;
+  updateNote(id: number, input: { text?: string; state?: NoteState }): Promise<void>;
   deleteNote(id: number): Promise<void>;
   select(path: string): void;
   files(): ChangedFile[];
@@ -331,6 +332,12 @@ export function createStore(api: GanderApi): Store {
       await guard(async () => {
         const { repoId, prNumber } = requireOpenPr();
         store.view = await api.deleteNote(repoId, prNumber, id);
+      });
+    },
+    async updateNote(id, input) {
+      await guard(async () => {
+        const { repoId, prNumber } = requireOpenPr();
+        store.view = await api.updateNote(repoId, prNumber, id, input);
       });
     },
     select(path: string) {

--- a/packages/service/contract.json
+++ b/packages/service/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.0",
   "routes": [
     "DELETE /api/reviews/:repoId/:prNumber/notes/:id",
     "DELETE /mcp",
@@ -10,6 +10,7 @@
     "GET /healthz",
     "GET /mcp",
     "OPTIONS /mcp",
+    "PATCH /api/reviews/:repoId/:prNumber/notes/:id",
     "PATCH /mcp",
     "POST /api/reviews/:repoId/:prNumber/notes",
     "POST /mcp",
@@ -528,6 +529,24 @@
         "prNumber",
         "files"
       ]
+    },
+    "UpdateNoteSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "addressed",
+            "resolved"
+          ]
+        }
+      }
     }
   },
   "mcpTools": [

--- a/packages/service/src/server.test.ts
+++ b/packages/service/src/server.test.ts
@@ -126,6 +126,22 @@ describe("service API", () => {
       expect(res.statusCode).toBe(400);
     });
 
+    it("edits note text and state", async () => {
+      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 3, text: "Before", headSha: null });
+      const updated = await server.inject({
+        method: "PATCH", url: `${url}/${note.id}`, headers: AUTH,
+        payload: { text: "After", state: "resolved" },
+      });
+
+      expect(updated.statusCode).toBe(200);
+      expect(updated.json()).toMatchObject({ id: note.id, text: "After", state: "resolved" });
+    });
+
+    it("rejects empty note updates and missing notes", async () => {
+      expect((await server.inject({ method: "PATCH", url: `${url}/999`, headers: AUTH, payload: {} })).statusCode).toBe(400);
+      expect((await server.inject({ method: "PATCH", url: `${url}/999`, headers: AUTH, payload: { text: "Changed" } })).statusCode).toBe(404);
+    });
+
     it("404s on deleting a note that is not there", async () => {
       expect((await server.inject({ method: "DELETE", url: `${url}/999`, headers: AUTH })).statusCode).toBe(404);
     });

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -1,6 +1,6 @@
 import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
 import type { ZodError } from "zod";
-import { NewNoteSchema, PrContextSchema, PutFileStateSchema } from "@gander/shared";
+import { NewNoteSchema, PrContextSchema, PutFileStateSchema, UpdateNoteSchema } from "@gander/shared";
 import { handleMcpRequest } from "./mcp.js";
 import type { Storage } from "./storage.js";
 
@@ -131,6 +131,21 @@ export function buildServer(opts: {
         return reply.code(404).send({ error: `no note ${id} on ${req.params.repoId}#${prNumber}` });
       }
       return reply.code(204).send();
+    },
+  );
+
+  app.patch<{ Params: { repoId: string; prNumber: string; id: string } }>(
+    "/api/reviews/:repoId/:prNumber/notes/:id",
+    async (req, reply) => {
+      const prNumber = positiveInt("prNumber", req.params.prNumber, reply);
+      if (prNumber === undefined) return;
+      const id = positiveInt("id", req.params.id, reply);
+      if (id === undefined) return;
+      const parsed = UpdateNoteSchema.safeParse(req.body);
+      if (!parsed.success) return badRequest(reply, parsed.error);
+      const note = opts.storage.updateNote(req.params.repoId, prNumber, id, parsed.data);
+      if (!note) return reply.code(404).send({ error: `no note ${id} on ${req.params.repoId}#${prNumber}` });
+      return note;
     },
   );
 

--- a/packages/service/src/storage.test.ts
+++ b/packages/service/src/storage.test.ts
@@ -130,6 +130,18 @@ describe("storage", () => {
       expect(marked).toMatchObject({ state: "addressed", commitRef: "abc1234", summary: "Dropped the retry" });
     });
 
+    it("lets the reviewer edit note text and correct its state within one review", () => {
+      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Old text", headSha: null });
+
+      expect(storage.updateNote("acme/atlas", 8, note.id, { text: "Wrong review" })).toBeNull();
+      expect(storage.updateNote("acme/atlas", 7, note.id, { text: "Updated text", state: "resolved" })).toMatchObject({
+        id: note.id,
+        text: "Updated text",
+        state: "resolved",
+      });
+      expect(storage.listNotes("acme/atlas", 7)[0]).toMatchObject({ text: "Updated text", state: "resolved" });
+    });
+
     it("refuses to re-address a note the reviewer already resolved", () => {
       const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
       storage.markNoteAddressed(q.id, { commitRef: "abc1234", summary: "Dropped the retry" });

--- a/packages/service/src/storage.ts
+++ b/packages/service/src/storage.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { gzipSync, gunzipSync } from "node:zlib";
-import type { FileCheckoff, MarkAddressed, NewNote, PrContext, PutFileState, Note, ReviewState } from "@gander/shared";
+import type { FileCheckoff, MarkAddressed, NewNote, PrContext, PutFileState, Note, ReviewState, UpdateNote } from "@gander/shared";
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS reviews (
@@ -57,6 +57,7 @@ export interface Storage {
   markNoteAddressed(id: number, input: MarkAddressed): Note | null;
   listNotes(repoId: string, prNumber: number): Note[];
   addNote(repoId: string, prNumber: number, input: NewNote): Note;
+  updateNote(repoId: string, prNumber: number, id: number, input: UpdateNote): Note | null;
   deleteNote(repoId: string, prNumber: number, id: number): boolean;
   close(): void;
 }
@@ -216,6 +217,25 @@ export function openStorage(dbPath: string): Storage {
         .run(rid, input.path, input.line, input.text, input.headSha);
       const row = db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(lastInsertRowid) as NoteRow;
       return rowToNote(row);
+    },
+
+    updateNote(repoId, prNumber, id, input) {
+      const rid = reviewId(repoId, prNumber);
+      const assignments: string[] = [];
+      const values: Array<string | number> = [];
+      if (input.text !== undefined) {
+        assignments.push("text = ?");
+        values.push(input.text);
+      }
+      if (input.state !== undefined) {
+        assignments.push("state = ?");
+        values.push(input.state);
+      }
+      if (assignments.length === 0) return null;
+      const changed = db.prepare(`UPDATE notes SET ${assignments.join(", ")} WHERE id = ? AND review_id = ?`)
+        .run(...values, id, rid).changes;
+      if (changed === 0) return null;
+      return rowToNote(db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(id) as NoteRow);
     },
 
     deleteNote(repoId, prNumber, id) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
  *
  * Not the app's release version: releases happen far more often than the contract moves.
  */
-export const SERVICE_VERSION = "0.4.0";
+export const SERVICE_VERSION = "0.5.0";
 
 export const FileStatusSchema = z.enum(["A", "M", "D", "R"]);
 export type FileStatus = z.infer<typeof FileStatusSchema>;
@@ -78,6 +78,14 @@ export const NewNoteSchema = z.object({
   headSha: z.string().min(1).nullable(),
 });
 export type NewNote = z.infer<typeof NewNoteSchema>;
+
+export const UpdateNoteSchema = z.object({
+  text: z.string().min(1).optional(),
+  state: NoteStateSchema.optional(),
+}).refine((input) => input.text !== undefined || input.state !== undefined, {
+  message: "text or state is required",
+});
+export type UpdateNote = z.infer<typeof UpdateNoteSchema>;
 
 /** What the service remembers about a pull request, so agents can be told which one they are on. */
 export const PrContextSchema = z.object({


### PR DESCRIPTION
## Summary
- edit reviewer note text inline with Save and Cancel actions
- change a note between open, addressed, and resolved from the notes drawer
- persist updates through a versioned service PATCH contract

## Verification
- `pnpm typecheck`
- `pnpm test` — 396 passed
- `pnpm test:e2e` — 18 passed
- real Electron visual inspection of the edit state
- Impeccable interface detector — clean