### PR TITLE
Support concurrent note work

### DIFF
--- a/.agents/skills/review-with-gander/SKILL.md
+++ b/.agents/skills/review-with-gander/SKILL.md
@@ -48,10 +48,19 @@ worktree's endpoint and bearer token from `.env`.
 Treat a note as work, not as a checkbox:
 
 1. Inspect the named file, line, and current diff.
-2. Make the requested change or explain why it should not change.
-3. Run the verification appropriate to the change.
-4. Commit and push the result when code changed.
-5. Mark the note addressed with a concrete summary:
+2. Claim it before starting:
+
+```bash
+bin/mcp call mark_note_in_progress id=NOTE_ID
+```
+
+3. Make the requested change or explain why it should not change. If work needs a
+   reviewer decision, call `mark_note_in_progress` again with
+   `note="DECISION NEEDED"`.
+4. Run the verification appropriate to the change.
+5. Commit and push the result when code changed.
+6. Mark the note addressed with a concrete summary. Include `commitRef` only when
+   the outcome produced a commit:
 
 ```bash
 bin/mcp call mark_note_addressed id=NOTE_ID commitRef=COMMIT_SHA summary="WHAT CHANGED"
@@ -64,7 +73,7 @@ file; the MCP contract has no reply tool.
 
 ## Diagnose the bridge
 
-- `bin/mcp check` verifies health, authentication, MCP negotiation, and the two
+- `bin/mcp check` verifies health, authentication, MCP negotiation, and the three
   required tools.
 - `bin/mcp tools` lists the live contract.
 - `bin/mcp tui` opens MCP Inspector's terminal UI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,13 +130,15 @@ needs one answer to what is visible. The cursor walks directories as well as fil
 separate from the selected file, because a directory has nothing to show in the diff:
 passing over one leaves the reader on the file they were already reading.
 
-**Note lifecycle:** `open` (reviewer captures with `n`) → `addressed` (agent,
-over MCP, with optional commit ref and summary) → `resolved` (reviewer re-checks
-the file). Resolution is always the reviewer's act; no MCP tool may resolve
-anything. The MCP contract is deliberately two tools — `get_review_notes` and
-`mark_note_addressed`. Agents discuss notes with the reviewer in their active
-session; MCP carries the reviewer's notes and the durable completion state. Agents
-have `git` and `gh` for code. Keep the contract small.
+**Note lifecycle:** `open` (reviewer captures with `n`) → `in_progress` (agent
+claims it over MCP) → `addressed` (agent records the outcome, with an optional
+commit ref) → `resolved` (reviewer re-checks the file). An in-progress note can
+name the reviewer decision blocking it. Resolution is always the reviewer's act;
+no MCP tool may resolve anything. The MCP contract is deliberately three tools —
+`get_review_notes`, `mark_note_in_progress`, and `mark_note_addressed`. Agents
+discuss notes with the reviewer in their active session; MCP carries the
+reviewer's notes and the durable work state. Agents have `git` and `gh` for code.
+Keep the contract small.
 
 `GANDER_SERVICE_URL` and `GANDER_TOKEN` override the config file at *connection*
 time, not load time (`resolveServiceConnection` in `main/config.ts`) — otherwise
@@ -149,9 +151,13 @@ Steve asks to repair a stale local config, update that file directly instead of
 adding migrations or compatibility branches. Add explicit schema versions and
 migrations only when backward compatibility becomes a product requirement.
 
-`SCHEMA` in `storage.ts` is the only supported SQLite shape. There is no upgrade
-path for databases created by an earlier build; recreate the sole user's database
-after a schema change.
+`SCHEMA` in `storage.ts` is the current SQLite shape. Local databases are disposable
+while the project is young, but the hosted database contains authored production
+review state and must never be recreated. For a schema-changing deploy, add a small
+one-off migration, make `bin/deploy` back up the hosted database before it runs, and
+test the migration directly. Do not add automatic startup migrations, schema-version
+machinery, or backward-compatibility branches until supporting other users requires
+them. Remove obsolete one-off migrations once production has moved past them.
 
 ## Testing
 

--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -238,12 +238,13 @@ claude mcp add --transport http gander "$GANDER_SERVICE_URL/mcp" \
   --header "Authorization: Bearer $GANDER_TOKEN"
 ```
 
-Run it in the repository being reviewed, not in this one. Two tools appear:
+Run it in the repository being reviewed, not in this one. Three tools appear:
 
 | Tool | Purpose |
 |------|---------|
-| `get_review_notes` | Notes for a repo + branch (or pull request number), with counts for every state; addressed and resolved notes can be included explicitly |
-| `mark_note_addressed` | Flags one as acted on, with an optional commit ref and summary |
+| `get_review_notes` | Notes for a repo + branch (or pull request number), with captured source and counts for every state; `since` accepts a last-seen note id |
+| `mark_note_in_progress` | Claims a note; its optional note records why work is waiting on the reviewer |
+| `mark_note_addressed` | Records the outcome with a required summary and an optional commit ref |
 
 Discuss notes in the active agent session. Nothing over MCP replies to or resolves
 a note. Resolution stays the reviewer's act, made by re-reviewing the file in the

--- a/bin/deploy
+++ b/bin/deploy
@@ -20,6 +20,7 @@ cd "$(dirname "$0")/.."
 
 HOST="${GANDER_DEPLOY_HOST:?set GANDER_DEPLOY_HOST to the ssh destination running the service}"
 REMOTE_PATH="${GANDER_DEPLOY_PATH:-/home/deploy/docker/gander}"
+BACKUP_PATH="${GANDER_BACKUP_PATH:-${REMOTE_PATH%/*}/gander-backups}"
 REF="master"
 
 while [[ $# -gt 0 ]]; do
@@ -30,9 +31,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "==> Deploying ${REF} to ${HOST}:${REMOTE_PATH}"
-ssh "$HOST" bash -euo pipefail -s -- "$REMOTE_PATH" "$REF" <<'REMOTE'
+ssh "$HOST" bash -euo pipefail -s -- "$REMOTE_PATH" "$REF" "$BACKUP_PATH" <<'REMOTE'
 REMOTE_PATH="$1"
 REF="$2"
+BACKUP_PATH="$3"
 cd "$REMOTE_PATH"
 if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
   echo "Refusing to deploy from a checkout with local changes: ${REMOTE_PATH}" >&2
@@ -47,7 +49,14 @@ if git symbolic-ref -q HEAD >/dev/null; then
   git merge --quiet --ff-only "origin/${REF}"
 fi
 echo "    now at $(git log --oneline -1)"
-docker compose up -d --build
+docker compose build gander
+docker compose stop gander
+mkdir -p "$BACKUP_PATH"
+BACKUP_FILE="gander-$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD).db"
+docker compose run --rm --no-deps \
+  -v "${BACKUP_PATH}:/backup" \
+  gander node_modules/.bin/tsx src/migrate-0.6.0.ts /data/gander.db "/backup/${BACKUP_FILE}"
+docker compose up -d gander
 REMOTE
 
 # Read both facts from the deployed checkout and Compose project. This keeps tag

--- a/bin/deploy.test.ts
+++ b/bin/deploy.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
 set -euo pipefail
 printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
 if [[ "$1 $2" == "compose port" ]]; then printf '0.0.0.0:%s\\n' "$FAKE_PORT"; fi
+if [[ "$*" == *"migrate-0.6.0.ts"* && "\${FAKE_MIGRATION_FAIL:-0}" == "1" ]]; then exit 1; fi
 `);
   executable(join(fakeBin, "curl"), `#!/usr/bin/env bash
 set -euo pipefail
@@ -53,6 +54,7 @@ function deploy(): ReturnType<typeof spawnSync> {
       PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
       GANDER_DEPLOY_HOST: "local-test",
       GANDER_DEPLOY_PATH: remote,
+      GANDER_BACKUP_PATH: join(dir, "backups"),
       FAKE_CURL_LOG: curlLog,
       FAKE_DOCKER_LOG: dockerLog,
       FAKE_PORT: "19420",
@@ -68,6 +70,34 @@ describe("bin/deploy", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("Serving contract version 0.1.0");
     expect(readFileSync(curlLog, "utf8")).toContain("http://127.0.0.1:19420/healthz");
+    expect(readFileSync(dockerLog, "utf8").trim().split("\n")).toEqual([
+      "compose build gander",
+      "compose stop gander",
+      expect.stringMatching(/^compose run --rm --no-deps -v .+\/backups:\/backup gander node_modules\/\.bin\/tsx src\/migrate-0\.6\.0\.ts \/data\/gander\.db \/backup\/gander-\d{8}T\d{6}Z-[a-f0-9]+\.db$/),
+      "compose up -d gander",
+      "compose port gander 8390",
+    ]);
+  });
+
+  it("leaves the service stopped when the backup or migration fails", () => {
+    const result = spawnSync(command, ["--ref", "v0.1.0"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        GANDER_DEPLOY_HOST: "local-test",
+        GANDER_DEPLOY_PATH: remote,
+        GANDER_BACKUP_PATH: join(dir, "backups"),
+        FAKE_CURL_LOG: curlLog,
+        FAKE_DOCKER_LOG: dockerLog,
+        FAKE_PORT: "19420",
+        FAKE_SERVICE_VERSION: "0.1.0",
+        FAKE_MIGRATION_FAIL: "1",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(readFileSync(dockerLog, "utf8")).not.toContain("compose up -d gander");
   });
 
   it("refuses to build a remote checkout with local changes", () => {

--- a/bin/mcp
+++ b/bin/mcp
@@ -140,7 +140,7 @@ cmd_check() {
     const fs = require("node:fs");
     const payload = JSON.parse(fs.readFileSync(0, "utf8"));
     const names = (payload.result?.tools ?? []).map((tool) => tool.name).sort();
-    const required = ["get_review_notes", "mark_note_addressed"];
+    const required = ["get_review_notes", "mark_note_in_progress", "mark_note_addressed"];
     const missing = required.filter((name) => !names.includes(name));
     if (missing.length > 0) {
       console.error("Missing core MCP tools: " + missing.join(", "));

--- a/bin/mcp.test.ts
+++ b/bin/mcp.test.ts
@@ -60,7 +60,7 @@ if [[ " $* " == *" --format json "* ]]; then
   if [[ -n "\${MCP_TEST_TOOLS_RESPONSE:-}" ]]; then
     printf '%s\n' "$MCP_TEST_TOOLS_RESPONSE"
   else
-    printf '%s\n' '{"result":{"tools":[{"name":"mark_note_addressed"},{"name":"get_review_notes"}]}}'
+    printf '%s\n' '{"result":{"tools":[{"name":"mark_note_addressed"},{"name":"mark_note_in_progress"},{"name":"get_review_notes"}]}}'
   fi
 else
   printf '%s\n' '{"ok":true}'
@@ -83,7 +83,7 @@ describe.skipIf(platform === "win32")("bin/mcp", () => {
 
     expect(result.status, result.output).toBe(0);
     expect(result.output).toContain("MCP OK");
-    expect(result.output).toContain("get_review_notes, mark_note_addressed");
+    expect(result.output).toContain("get_review_notes, mark_note_addressed, mark_note_in_progress");
     expect(result.output).not.toContain("test-token");
 
     const args = readFileSync(argsFile, "utf8");
@@ -113,7 +113,7 @@ describe.skipIf(platform === "win32")("bin/mcp", () => {
     const result = run("check");
 
     expect(result.status).toBe(1);
-    expect(result.output).toContain("Missing core MCP tools: mark_note_addressed");
+    expect(result.output).toContain("Missing core MCP tools: mark_note_in_progress, mark_note_addressed");
     expect(result.output).toContain("tool contract is invalid");
   });
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -48,16 +48,20 @@ for, so notes came in immediately after M1 rather than waiting for a
 milestone boundary.
 
 Pressing `n` over a file captures a note against it, stamped with the line
-being read. Notes carry three states: `open` when captured, `addressed` when
-an agent has acted on one, and `resolved` when the reviewer re-checks the file.
+being read. Notes carry four states: `open` when captured, `in_progress` when an
+agent claims one, `addressed` when the agent records its outcome, and `resolved`
+when the reviewer re-checks the file. A claimed note can record the reviewer
+decision blocking it, and the notes drawer separates those blockers from active
+work.
 The notes drawer lets the reviewer correct note text or explicitly change a
 note's state when the recorded workflow state needs correcting.
 Agents reach them over MCP at `/mcp` on the review service — see `DEVSTACK.md`
 for registration.
 
 Agents discuss notes with the reviewer in their active session. Once the work is
-complete, they record the durable completion state through MCP with an optional
-commit ref and summary.
+complete, they record the durable outcome through MCP with a summary and an
+optional commit ref. Notes also carry immutable source context from the head
+revision at capture time, and agents can fetch only notes after a last-seen id.
 
 Each opened pull request records its own branch, which is how the service maps an
 agent's working branch to a pull request without holding GitHub credentials.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -34,10 +34,13 @@ curl -s http://127.0.0.1:8390/healthz     # {"ok":true,"version":"..."}
 
 The database is a SQLite file on the `gander-data` volume, at `/data/gander.db`.
 It is the only state; back up the volume and you have backed up every review.
+Local databases are disposable, but never delete or recreate the hosted database.
+When a release changes its schema, `bin/deploy` stops the service, writes a timestamped
+backup outside the checkout, runs that release's explicit migration, and only then
+starts the new service. Set `GANDER_BACKUP_PATH` to choose the host backup directory;
+it defaults to a `gander-backups` directory beside the deployed checkout.
 
-To update by hand: `git pull && docker compose up -d --build`.
-
-`bin/deploy` does the same over ssh, then waits for the container and checks that
+Use `bin/deploy` to update the hosted service. It also waits for the container and checks that
 what came back answers the contract version the deployed ref declares — a service left
 behind the app is the failure worth catching at deploy time rather than mid-review:
 

--- a/packages/app/e2e/drivers/mcp.ts
+++ b/packages/app/e2e/drivers/mcp.ts
@@ -2,8 +2,16 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 interface NotePayload {
-  noteCounts: { open: number; addressed: number; resolved: number };
-  notes: Array<{ id: number; file: string | null; line: number | null; text: string; state: string }>;
+  lastNoteId: number | null;
+  noteCounts: { open: number; in_progress: number; addressed: number; resolved: number };
+  notes: Array<{
+    id: number;
+    file: string | null;
+    line: number | null;
+    text: string;
+    state: string;
+    sourceContext: { startLine: number; lines: string[] } | null;
+  }>;
 }
 
 function textOf(result: { content?: unknown }): string {
@@ -23,18 +31,25 @@ export class McpDriver {
     return this;
   }
 
-  async notes(repo: string, branch: string): Promise<NotePayload> {
+  async notes(repo: string, branch: string, since?: number): Promise<NotePayload> {
     const result = await this.client.callTool({
       name: "get_review_notes",
-      arguments: { repo, branch, includeAddressed: true, includeResolved: true },
+      arguments: { repo, branch, includeAddressed: true, includeResolved: true, ...(since === undefined ? {} : { since }) },
     });
     return JSON.parse(textOf(result as { content?: unknown })) as NotePayload;
   }
 
-  async markAddressed(id: number, commitRef: string, summary: string): Promise<void> {
+  async markInProgress(id: number, note?: string): Promise<void> {
+    await this.client.callTool({
+      name: "mark_note_in_progress",
+      arguments: { id, ...(note === undefined ? {} : { note }) },
+    });
+  }
+
+  async markAddressed(id: number, summary: string, commitRef?: string): Promise<void> {
     await this.client.callTool({
       name: "mark_note_addressed",
-      arguments: { id, commitRef, summary },
+      arguments: { id, summary, ...(commitRef === undefined ? {} : { commitRef }) },
     });
   }
 

--- a/packages/app/e2e/note-lifecycle.spec.ts
+++ b/packages/app/e2e/note-lifecycle.spec.ts
@@ -18,21 +18,29 @@ test("carries a reviewer note through MCP addressing and reviewer resolution", a
     await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("open");
 
     const pickedUp = await agent.notes(repository.repoId, "feature");
-    expect(pickedUp.noteCounts).toEqual({ open: 1, addressed: 0, resolved: 0 });
+    expect(pickedUp.noteCounts).toEqual({ open: 1, in_progress: 0, addressed: 0, resolved: 0 });
     expect(pickedUp.notes).toHaveLength(1);
-    await agent.markAddressed(pickedUp.notes[0]!.id, "abc1234", "Removed the unnecessary branch");
+    expect(pickedUp.notes[0]!.sourceContext?.lines).toContain("class A");
+
+    await agent.markInProgress(pickedUp.notes[0]!.id, "Need the reviewer to choose the intended behavior");
+    await review.fetchOrigin();
+    await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("in_progress");
+    await expect(note.getByRole("region", { name: "Waiting on reviewer" })).toContainText("choose the intended behavior");
+    expect((await agent.notes(repository.repoId, "feature", pickedUp.lastNoteId!)).notes).toEqual([]);
+
+    await agent.markAddressed(pickedUp.notes[0]!.id, "The reviewer confirmed the branch is required");
 
     await review.fetchOrigin();
     await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("addressed");
-    await expect(note.getByRole("region", { name: "Agent update" })).toContainText("Removed the unnecessary branch");
-    await expect(note.getByRole("region", { name: "Agent update" })).toContainText("abc1234");
+    await expect(note.getByRole("region", { name: "Agent update" })).toContainText("The reviewer confirmed the branch is required");
+    await expect(note.getByRole("region", { name: "Waiting on reviewer" })).toHaveCount(0);
 
     await app.page.getByRole("button", { name: "Mark reviewed" }).click();
     await review.fetchOrigin();
     await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("resolved");
 
     const completed = await agent.notes(repository.repoId, "feature");
-    expect(completed.noteCounts).toEqual({ open: 0, addressed: 0, resolved: 1 });
+    expect(completed.noteCounts).toEqual({ open: 0, in_progress: 0, addressed: 0, resolved: 1 });
   } finally {
     await agent.close();
   }
@@ -79,7 +87,7 @@ test("lets the reviewer edit a note and change its status", async ({ world }) =>
     await expect(status).toHaveValue("resolved");
 
     const saved = await agent.notes(repository.repoId, "feature");
-    expect(saved.noteCounts).toEqual({ open: 0, addressed: 0, resolved: 1 });
+    expect(saved.noteCounts).toEqual({ open: 0, in_progress: 0, addressed: 0, resolved: 1 });
     expect(saved.notes[0]).toMatchObject({ text: "Updated wording", state: "resolved" });
   } finally {
     await agent.close();

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -59,7 +59,7 @@ export interface GanderApi {
   localImagePreview(path: string): Promise<ImagePreview>;
   closeLocal(): Promise<void>;
   onLocalViewChanged(listener: (update: LocalViewUpdate) => void): () => void;
-  addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha">): Promise<PrView>;
+  addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha" | "sourceContext">): Promise<PrView>;
   updateNote(repoId: string, prNumber: number, id: number, input: UpdateNote): Promise<PrView>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<PrView>;
   getSettings(): Promise<AppSettings>;

--- a/packages/app/src/main/review.test.ts
+++ b/packages/app/src/main/review.test.ts
@@ -102,6 +102,22 @@ describe("review pipeline", () => {
     expect(a.changedSince).toBe(false);
   });
 
+  it("captures source around the selected line when a note is created", async () => {
+    await reviewer.openPr("acme/atlas", 1);
+
+    const view = await reviewer.addNote("acme/atlas", 1, { path: "a.rb", line: 2, text: "Why this method?" });
+
+    expect(view.notes[0]).toMatchObject({
+      path: "a.rb",
+      line: 2,
+      headSha: view.pr.headSha,
+      sourceContext: {
+        startLine: 1,
+        lines: ["class A", "  def go; end", "end", ""],
+      },
+    });
+  });
+
   it("setChecked persists through the service and survives re-open", async () => {
     await reviewer.openPr("acme/atlas", 1);
     const view = await reviewer.setChecked("acme/atlas", 1, "a.rb", true);

--- a/packages/app/src/main/review.ts
+++ b/packages/app/src/main/review.ts
@@ -16,7 +16,7 @@ export interface Reviewer {
   refreshPr(repoId: string, prNumber: number): Promise<PrView>;
   setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<PrView>;
   setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView>;
-  addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha">): Promise<PrView>;
+  addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha" | "sourceContext">): Promise<PrView>;
   updateNote(repoId: string, prNumber: number, id: number, input: UpdateNote): Promise<PrView>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<PrView>;
   /** The file as it stood when the reviewer last checked it — the base for the delta view. */
@@ -263,7 +263,19 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     async addNote(repoId, prNumber, input) {
       const entry = requireWritable(repoId, prNumber);
       const { view } = entry;
-      const note = await writeServiceState(entry, () => deps.service.addNote(repoId, prNumber, { ...input, headSha: view.pr.headSha }));
+      const file = input.path === null ? undefined : view.files.find((candidate) => candidate.path === input.path);
+      const lines = file?.headContent?.split("\n") ?? [];
+      const sourceContext = input.line === null || input.line > lines.length
+        ? null
+        : {
+            startLine: Math.max(1, input.line - 2),
+            lines: lines.slice(Math.max(0, input.line - 3), input.line + 2),
+          };
+      const note = await writeServiceState(entry, () => deps.service.addNote(repoId, prNumber, {
+        ...input,
+        headSha: view.pr.headSha,
+        sourceContext,
+      }));
       view.notes = [...view.notes, note];
       return view;
     },

--- a/packages/app/src/main/service-client.test.ts
+++ b/packages/app/src/main/service-client.test.ts
@@ -84,12 +84,13 @@ describe("a request with no body", () => {
         seen.push(req.headers["content-type"]);
         return reply.code(201).send({
           id: 1, path: "a.rb", line: null, text: "why?", state: "open",
-          headSha: null, commitRef: null, summary: null, createdAt: new Date().toISOString(),
+          headSha: null, sourceContext: null, inProgressNote: null,
+          commitRef: null, summary: null, createdAt: new Date().toISOString(),
         });
       });
     });
     const client = createServiceClient(() => ({ url, token: "t" }));
-    await client.addNote("acme/atlas", 1, { path: "a.rb", line: null, text: "why?", headSha: null });
+    await client.addNote("acme/atlas", 1, { path: "a.rb", line: null, text: "why?", headSha: null, sourceContext: null });
     expect(seen).toEqual(["application/json"]);
   });
 
@@ -97,7 +98,8 @@ describe("a request with no body", () => {
     const url = await serve((app) => {
       app.patch("/api/reviews/:repoId/:prNumber/notes/:id", async (req) => ({
         id: 2, path: "a.rb", line: null, text: (req.body as { text: string }).text, state: "resolved",
-        headSha: null, commitRef: null, summary: null, createdAt: new Date().toISOString(),
+        headSha: null, sourceContext: null, inProgressNote: null,
+        commitRef: null, summary: null, createdAt: new Date().toISOString(),
       }));
     });
     const client = createServiceClient(() => ({ url, token: "t" }));

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -218,6 +218,8 @@ describe("FileTree", () => {
       text: "Check this line",
       state: "open",
       headSha: "b",
+      sourceContext: null,
+      inProgressNote: null,
       commitRef: null,
       summary: null,
       createdAt: "2026-08-18T00:00:00.000Z",
@@ -251,13 +253,15 @@ describe("FileTree", () => {
   it("counts unresolved notes on a file and leaves resolved ones out", () => {
     const target = file("app/models/member.rb");
     const other = file("app/models/local.rb");
-    const note = (id: number, path: string, state: "open" | "addressed" | "resolved") => ({
+    const note = (id: number, path: string, state: "open" | "in_progress" | "addressed" | "resolved") => ({
       id,
       path,
       line: id,
       text: `Note ${id}`,
       state,
       headSha: "b",
+      sourceContext: null,
+      inProgressNote: null,
       commitRef: null,
       summary: null,
       createdAt: "2026-08-18T00:00:00.000Z",
@@ -286,6 +290,8 @@ describe("FileTree", () => {
       text: "Check this line",
       state: "open" as const,
       headSha: "b",
+      sourceContext: null,
+      inProgressNote: null,
       commitRef: null,
       summary: null,
       createdAt: "2026-08-18T00:00:00.000Z",

--- a/packages/app/src/renderer/src/components/NoteItem.vue
+++ b/packages/app/src/renderer/src/components/NoteItem.vue
@@ -7,6 +7,7 @@ import {
   Check,
   CheckCheck,
   ChevronDown,
+  CircleDot,
   CircleHelp,
   Copy,
   Pencil,
@@ -37,13 +38,17 @@ const deleteDetail = "The note will be removed from the review. This cannot be u
 
 // A keyed note instance survives service refreshes, so a reviewer's disclosure
 // choice remains stable when the Note object is replaced.
-const expanded = shallowRef(props.note.state === "open");
+const expanded = shallowRef(props.note.state === "open" || props.note.state === "in_progress");
 const bodyId = computed(() => `note-body-${props.note.id}`);
 const titleId = computed(() => `note-title-${props.note.id}`);
 const location = computed(() => {
   if (props.note.path === null) return "This pull request";
   const name = basename(props.note.path);
   return props.note.line === null ? name : `${name}:${props.note.line}`;
+});
+const sourceLines = computed(() => {
+  const context = props.note.sourceContext;
+  return context?.lines.map((text, index) => ({ number: context.startLine + index, text })) ?? [];
 });
 
 const timestamp = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" });
@@ -115,11 +120,13 @@ async function changeStatus(event: Event): Promise<void> {
         </button>
         <label class="state" :class="note.state">
           <CircleHelp v-if="note.state === 'open'" :size="12" aria-hidden="true" />
+          <CircleDot v-else-if="note.state === 'in_progress'" :size="12" aria-hidden="true" />
           <Check v-else-if="note.state === 'addressed'" :size="12" aria-hidden="true" />
           <CheckCheck v-else :size="12" aria-hidden="true" />
           <span class="status-label">Status</span>
           <select :value="note.state" :aria-label="`Status for note ${note.id}`" :disabled="changingStatus" @change="changeStatus">
             <option value="open">Open</option>
+            <option value="in_progress">In progress</option>
             <option value="addressed">Addressed</option>
             <option value="resolved">Resolved</option>
           </select>
@@ -154,6 +161,19 @@ async function changeStatus(event: Event): Promise<void> {
         </form>
         <p v-else class="message-text">{{ note.text }}</p>
       </div>
+
+      <section v-if="note.sourceContext" class="source-context" aria-label="Captured source context">
+        <code>
+          <span v-for="sourceLine in sourceLines" :key="sourceLine.number" :class="{ target: sourceLine.number === note.line }">
+            <b>{{ sourceLine.number }}</b>{{ sourceLine.text }}
+          </span>
+        </code>
+      </section>
+
+      <section v-if="note.state === 'in_progress' && note.inProgressNote" class="agent-progress" aria-label="Waiting on reviewer">
+        <div class="message-heading"><h3>Waiting on you</h3></div>
+        <p class="message-text">{{ note.inProgressNote }}</p>
+      </section>
 
       <section v-if="note.summary || note.commitRef" class="agent-update" aria-label="Agent update">
         <div class="message-heading">
@@ -233,6 +253,7 @@ async function changeStatus(event: Event): Promise<void> {
 .status-chevron { margin-left: -2px; pointer-events: none; }
 .state:focus-within { outline: 1px solid var(--accent); outline-offset: 1px; }
 .state.open { color: var(--accent); }
+.state.in_progress { color: var(--warning); }
 .state.addressed { color: var(--warning); }
 .state.resolved { color: var(--success); }
 .disclosure {
@@ -243,8 +264,15 @@ async function changeStatus(event: Event): Promise<void> {
 .chevron { color: var(--faint-foreground); transition: transform 120ms ease; }
 .chevron.expanded { transform: rotate(180deg); }
 .note-body { padding: 1px 10px 11px; }
-.note-message, .agent-update { min-width: 0; border-radius: var(--radius-md); }
+.note-message, .agent-progress, .agent-update { min-width: 0; border-radius: var(--radius-md); }
 .note-message { padding: 9px 10px; background: var(--input-background); border: 1px solid var(--workbench-border); }
+.source-context { margin-top: 8px; overflow: auto; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background); }
+.source-context code { display: block; min-width: max-content; padding: 6px 0; font: 10.5px/1.5 var(--mono); }
+.source-context span { display: block; min-height: 1.5em; padding: 0 9px 0 0; white-space: pre; }
+.source-context span.target { background: var(--selection-background); }
+.source-context b { display: inline-block; width: 34px; margin-right: 8px; color: var(--faint-foreground); font-weight: 400; text-align: right; user-select: none; }
+.agent-progress { margin: 8px 0 0 12px; padding: 9px 10px; border-left: 1px solid var(--warning); background: color-mix(in srgb, var(--warning) 6%, transparent); }
+.agent-progress .message-heading h3 { color: var(--warning); }
 .agent-update { margin: 8px 0 0 12px; padding: 9px 10px; border-left: 1px solid var(--accent); background: color-mix(in srgb, var(--accent) 6%, transparent); }
 .message-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; min-width: 0; }
 .message-heading h3 { margin: 0; color: var(--muted-foreground); font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase; }

--- a/packages/app/src/renderer/src/components/NotesDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/NotesDrawer.test.ts
@@ -44,6 +44,8 @@ const notes: PrView["notes"] = [
     text: "Why does this branch need to handle the shared path this way?",
     state: "open",
     headSha: "b",
+    sourceContext: { startLine: 35, lines: ["before", "context", "target", "after", "later"] },
+    inProgressNote: null,
     commitRef: null,
     summary: null,
     createdAt: "2026-08-18T00:00:00.000Z",
@@ -55,6 +57,8 @@ const notes: PrView["notes"] = [
     text: "Could this preserve the existing caller contract?",
     state: "addressed",
     headSha: "b",
+    sourceContext: null,
+    inProgressNote: null,
     commitRef: "abc1234",
     summary: "Kept the contract and added coverage.",
     createdAt: "2026-08-18T01:00:00.000Z",
@@ -86,6 +90,8 @@ describe("NotesDrawer", () => {
           text: "Why?",
           state: "open",
           headSha: "b",
+          sourceContext: null,
+          inProgressNote: null,
           commitRef: null,
           summary: null,
           createdAt: "2026-08-18T00:00:00.000Z",
@@ -113,6 +119,44 @@ describe("NotesDrawer", () => {
     expect((addressed.get("select[aria-label='Status for note 2']").element as HTMLSelectElement).value).toBe("addressed");
     expect(addressed.text()).toContain("Could this preserve the existing caller contract?");
     expect(addressed.find("[data-note-body]").isVisible()).toBe(false);
+  });
+
+  it("separates active work from notes waiting on the reviewer", () => {
+    const inProgress = {
+      ...notes[0]!,
+      id: 3,
+      state: "in_progress" as const,
+      inProgressNote: null,
+    };
+    const waiting = {
+      ...notes[0]!,
+      id: 4,
+      state: "in_progress" as const,
+      inProgressNote: "Choose whether this should retry.",
+    };
+    const wrapper = mount(NotesDrawer, { props: { store: store([inProgress, waiting]), dock: "right" } });
+
+    expect(wrapper.findAll(".group-heading").map((heading) => heading.text())).toEqual([
+      "In progress 1",
+      "Waiting on you 1",
+    ]);
+    expect(wrapper.get("[data-note-id='4'] [aria-label='Waiting on reviewer']").text()).toContain("Choose whether this should retry.");
+  });
+
+  it("keeps a note expanded while its state moves between groups", async () => {
+    const wrapper = mount(NotesDrawer, { props: { store: store([notes[0]!]), dock: "right" } });
+    expect(wrapper.get("[data-note-id='1'] button[aria-expanded]").attributes("aria-expanded")).toBe("true");
+
+    await wrapper.setProps({
+      store: store([{
+        ...notes[0]!,
+        state: "addressed",
+        summary: "Answered in the active session.",
+      }]),
+    });
+
+    expect(wrapper.get("[data-note-id='1'] button[aria-expanded]").attributes("aria-expanded")).toBe("true");
+    expect(wrapper.get("[data-note-id='1'] [aria-label='Agent update']").text()).toContain("Answered in the active session.");
   });
 
   it("exposes a keyboard-operable disclosure and labeled agent update", async () => {
@@ -212,6 +256,7 @@ describe("NotesDrawer", () => {
 
     await wrapper.get("button[aria-label='Copy all notes']").trigger("click");
     expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("### src/a-very-long-file-name.ts:37 — open"));
+    expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("37: target"));
     expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining("### src/addressed.ts:9 — addressed"));
   });
 });

--- a/packages/app/src/renderer/src/components/NotesDrawer.vue
+++ b/packages/app/src/renderer/src/components/NotesDrawer.vue
@@ -10,6 +10,20 @@ const props = defineProps<{ store: Store; dock: "right" | "bottom" }>();
 const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addNote: [] }>();
 
 const notes = computed(() => props.store.view?.notes ?? []);
+const noteGroups = computed(() => [
+  { key: "open", label: "Open", notes: notes.value.filter((note) => note.state === "open") },
+  { key: "in-progress", label: "In progress", notes: notes.value.filter((note) => note.state === "in_progress" && note.inProgressNote === null) },
+  { key: "waiting", label: "Waiting on you", notes: notes.value.filter((note) => note.state === "in_progress" && note.inProgressNote !== null) },
+  { key: "addressed", label: "Addressed", notes: notes.value.filter((note) => note.state === "addressed") },
+  { key: "resolved", label: "Resolved", notes: notes.value.filter((note) => note.state === "resolved") },
+].filter((group) => group.notes.length > 0));
+type NoteRow =
+  | { key: string; kind: "heading"; label: string; count: number }
+  | { key: string; kind: "note"; note: Note };
+const noteRows = computed<NoteRow[]>(() => noteGroups.value.flatMap((group) => [
+  { key: `heading-${group.key}`, kind: "heading" as const, label: group.label, count: group.notes.length },
+  ...group.notes.map((note) => ({ key: `note-${note.id}`, kind: "note" as const, note })),
+]));
 const copiedNoteId = shallowRef<number | null>(null);
 const copiedAll = shallowRef(false);
 
@@ -31,6 +45,14 @@ function noteMarkdown(note: Note): string {
   if (note.summary || note.commitRef) {
     const commit = note.commitRef ? ` (${note.commitRef})` : "";
     parts.push("", `Agent update${commit}: ${note.summary ?? "Addressed"}`);
+  }
+  if (note.state === "in_progress" && note.inProgressNote) parts.push("", `Waiting on reviewer: ${note.inProgressNote}`);
+  if (note.sourceContext) {
+    const { startLine, lines } = note.sourceContext;
+    const source = lines
+      .map((line, index) => `${startLine + index}: ${line}`)
+      .join("\n");
+    parts.push("", "```", source, "```");
   }
   return parts.join("\n");
 }
@@ -102,17 +124,19 @@ async function copyAll(): Promise<void> {
     </div>
 
     <ul v-else aria-label="Review notes">
-      <NoteItem
-        v-for="note in notes"
-        :key="note.id"
-        :note="note"
-        :current="note.path === store.selectedPath"
-        :copied="copiedNoteId === note.id"
-        :update-note="store.updateNote"
-        @navigate="goTo"
-        @copy="copyNote"
-        @delete="store.deleteNote"
-      />
+      <template v-for="row in noteRows" :key="row.key">
+        <li v-if="row.kind === 'heading'" class="group-heading" role="presentation">{{ row.label }} <span>{{ row.count }}</span></li>
+        <NoteItem
+          v-else
+          :note="row.note"
+          :current="row.note.path === store.selectedPath"
+          :copied="copiedNoteId === row.note.id"
+          :update-note="store.updateNote"
+          @navigate="goTo"
+          @copy="copyNote"
+          @delete="store.deleteNote"
+        />
+      </template>
     </ul>
   </aside>
 </template>
@@ -149,6 +173,13 @@ header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; borde
 kbd { font: 11px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 1px 5px; }
 
 ul { list-style: none; margin: 0; padding: 0; }
+.group-heading {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 7px 10px; border-bottom: 1px solid var(--workbench-border);
+  background: var(--input-background); color: var(--muted-foreground);
+  font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase;
+}
+.group-heading span { color: var(--faint-foreground); }
 @container notes (max-width: 330px) {
   .copy-all span, .add span { display: none; }
 }

--- a/packages/service/contract.json
+++ b/packages/service/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.6.0",
   "routes": [
     "DELETE /api/reviews/:repoId/:prNumber/notes/:id",
     "DELETE /mcp",
@@ -124,6 +124,26 @@
         "summary"
       ]
     },
+    "MarkInProgressSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "note": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "note"
+      ]
+    },
     "NewNoteSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -165,13 +185,42 @@
               "type": "null"
             }
           ]
+        },
+        "sourceContext": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "startLine": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "lines": {
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "startLine",
+                "lines"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
         "path",
         "line",
         "text",
-        "headSha"
+        "headSha",
+        "sourceContext"
       ]
     },
     "NoteSchema": {
@@ -213,11 +262,50 @@
           "type": "string",
           "enum": [
             "open",
+            "in_progress",
             "addressed",
             "resolved"
           ]
         },
         "headSha": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sourceContext": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "startLine": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "lines": {
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "startLine",
+                "lines"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "inProgressNote": {
           "anyOf": [
             {
               "type": "string"
@@ -258,9 +346,33 @@
         "text",
         "state",
         "headSha",
+        "sourceContext",
+        "inProgressNote",
         "commitRef",
         "summary",
         "createdAt"
+      ]
+    },
+    "NoteSourceContextSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "startLine": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "lines": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "startLine",
+        "lines"
       ]
     },
     "NoteStateSchema": {
@@ -268,6 +380,7 @@
       "type": "string",
       "enum": [
         "open",
+        "in_progress",
         "addressed",
         "resolved"
       ]
@@ -542,6 +655,7 @@
           "type": "string",
           "enum": [
             "open",
+            "in_progress",
             "addressed",
             "resolved"
           ]
@@ -552,7 +666,7 @@
   "mcpTools": [
     {
       "name": "get_review_notes",
-      "description": "Notes the reviewer has left on a pull request, with the file and line each one is about. Derive repo and branch from the working directory. Returns open notes by default — those are the ones still needing work. The response always counts open, addressed, and resolved notes so hidden states are visible. The response names the branch, title, and stack position of the pull request the notes belong to: check it matches the checkout being worked in, because a stacked pull request's sibling is a different branch with different notes.",
+      "description": "Notes the reviewer has left on a pull request, with the file and line each one is about. Derive repo and branch from the working directory. Returns open and in-progress notes by default — those are the ones still needing work. The response always counts open, in-progress, addressed, and resolved notes so hidden states are visible. The response names the branch, title, and stack position of the pull request the notes belong to: check it matches the checkout being worked in, because a stacked pull request's sibling is a different branch with different notes.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -577,6 +691,12 @@
           "includeResolved": {
             "description": "Also return notes the reviewer has resolved. Defaults to false.",
             "type": "boolean"
+          },
+          "since": {
+            "description": "Return only notes with an id greater than this last-seen note id.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
           }
         },
         "required": [
@@ -587,7 +707,7 @@
     },
     {
       "name": "mark_note_addressed",
-      "description": "Record that a note has been acted on. Use it only once the work is actually done and committed. This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
+      "description": "Record the outcome after an in-progress note has been acted on. A code change can name its commit; an answered question has no commit. This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -598,12 +718,39 @@
             "description": "Note id from get_review_notes."
           },
           "commitRef": {
-            "description": "Commit that addressed it.",
-            "type": "string"
+            "description": "Commit that addressed it, when the outcome changed code.",
+            "type": "string",
+            "minLength": 1
           },
           "summary": {
-            "description": "One line on what changed.",
-            "type": "string"
+            "type": "string",
+            "minLength": 1,
+            "description": "One line recording the outcome."
+          }
+        },
+        "required": [
+          "id",
+          "summary"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "mark_note_in_progress",
+      "description": "Claim a note when work starts. Pass note when work is waiting on a reviewer decision; omit it while work is active.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Note id from get_review_notes."
+          },
+          "note": {
+            "description": "Why this work is waiting on the reviewer.",
+            "type": "string",
+            "minLength": 1
           }
         },
         "required": [

--- a/packages/service/src/mcp.test.ts
+++ b/packages/service/src/mcp.test.ts
@@ -52,13 +52,13 @@ describe("MCP endpoint", () => {
   it("offers only the note pickup and completion tools", async () => {
     const client = await connect();
     const names = (await client.listTools()).tools.map((t) => t.name).sort();
-    expect(names).toEqual(["get_review_notes", "mark_note_addressed"]);
+    expect(names).toEqual(["get_review_notes", "mark_note_addressed", "mark_note_in_progress"]);
     await client.close();
   });
 
   it("returns the reviewer's open notes for a branch", async () => {
     storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
-    storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Why the retry here?", headSha: null });
+    storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Why the retry here?", headSha: null, sourceContext: null });
 
     const client = await connect();
     const result = await client.callTool({
@@ -72,15 +72,16 @@ describe("MCP endpoint", () => {
     expect(payload.title).toBe("Feature");
     expect(payload.notes).toEqual([{
       id: expect.any(Number), file: "a.rb", line: 12, text: "Why the retry here?", state: "open",
-      capturedAtSha: null, lineMayHaveMoved: false,
+      capturedAtSha: null, sourceContext: null, lineMayHaveMoved: false,
     }]);
     await client.close();
   });
 
   it("hides addressed notes unless they are asked for", async () => {
     storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
-    const done = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "handled", headSha: null });
-    storage.addNote("acme/atlas", 7, { path: "b.rb", line: null, text: "still open", headSha: null });
+    const done = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "handled", headSha: null, sourceContext: null });
+    storage.addNote("acme/atlas", 7, { path: "b.rb", line: null, text: "still open", headSha: null, sourceContext: null });
+    storage.markNoteInProgress(done.id, { note: null });
     storage.markNoteAddressed(done.id, { commitRef: "abc", summary: null });
 
     const client = await connect();
@@ -88,11 +89,11 @@ describe("MCP endpoint", () => {
       name: "get_review_notes",
       arguments: { repo: "acme/atlas", branch: "feat/thing" },
     })) as { content?: unknown })) as {
-      noteCounts: { open: number; addressed: number; resolved: number };
+      noteCounts: { open: number; in_progress: number; addressed: number; resolved: number };
       notes: unknown[];
     };
     expect(openOnly.notes).toHaveLength(1);
-    expect(openOnly.noteCounts).toEqual({ open: 1, addressed: 1, resolved: 0 });
+    expect(openOnly.noteCounts).toEqual({ open: 1, in_progress: 0, addressed: 1, resolved: 0 });
 
     const both = JSON.parse(textOf((await client.callTool({
       name: "get_review_notes",
@@ -104,7 +105,8 @@ describe("MCP endpoint", () => {
 
   it("explains when resolved notes are hidden and returns them when asked", async () => {
     storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
-    const resolved = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "handled", headSha: null });
+    const resolved = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "handled", headSha: null, sourceContext: null });
+    storage.markNoteInProgress(resolved.id, { note: null });
     storage.markNoteAddressed(resolved.id, { commitRef: "abc1234", summary: "Dropped the retry" });
     storage.putFileState("acme/atlas", 7, {
       checked: true, path: "a.rb", baseHash: "base", headHash: "head",
@@ -116,13 +118,13 @@ describe("MCP endpoint", () => {
       name: "get_review_notes",
       arguments: { repo: "acme/atlas", branch: "feat/thing" },
     })) as { content?: unknown })) as {
-      noteCounts: { open: number; addressed: number; resolved: number };
+      noteCounts: { open: number; in_progress: number; addressed: number; resolved: number };
       message: string;
       notes: unknown[];
     };
     expect(openOnly.notes).toEqual([]);
-    expect(openOnly.noteCounts).toEqual({ open: 0, addressed: 0, resolved: 1 });
-    expect(openOnly.message).toBe("No open notes returned. 1 resolved note is hidden; pass includeResolved: true to retrieve it.");
+    expect(openOnly.noteCounts).toEqual({ open: 0, in_progress: 0, addressed: 0, resolved: 1 });
+    expect(openOnly.message).toBe("No open or in-progress notes returned. 1 resolved note is hidden; pass includeResolved: true to retrieve it.");
 
     const withResolved = JSON.parse(textOf((await client.callTool({
       name: "get_review_notes",
@@ -130,16 +132,17 @@ describe("MCP endpoint", () => {
     })) as { content?: unknown })) as { notes: Array<Record<string, unknown>> };
     expect(withResolved.notes).toEqual([{
       id: resolved.id, file: "a.rb", line: null, text: "handled", state: "resolved",
-      commitRef: "abc1234", summary: "Dropped the retry", capturedAtSha: null, lineMayHaveMoved: false,
+      commitRef: "abc1234", summary: "Dropped the retry", capturedAtSha: null, sourceContext: null, lineMayHaveMoved: false,
     }]);
     await client.close();
   });
 
   it("marks a note addressed, and the state is really in storage", async () => {
     storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
-    const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
+    const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null, sourceContext: null });
 
     const client = await connect();
+    await client.callTool({ name: "mark_note_in_progress", arguments: { id: q.id } });
     await client.callTool({
       name: "mark_note_addressed",
       arguments: { id: q.id, commitRef: "abc1234", summary: "Dropped the retry" },
@@ -150,11 +153,64 @@ describe("MCP endpoint", () => {
     await client.close();
   });
 
-  it("refuses to mark a note that is not open", async () => {
+  it("claims a note, exposes a reviewer blocker, and addresses a question without a commit", async () => {
+    storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
+    const q = storage.addNote("acme/atlas", 7, {
+      path: "a.rb", line: 2, text: "Which behavior?", headSha: "sha-1",
+      sourceContext: { startLine: 1, lines: ["one", "two", "three"] },
+    });
+
     const client = await connect();
-    const result = await client.callTool({ name: "mark_note_addressed", arguments: { id: 999 } });
+    await client.callTool({
+      name: "mark_note_in_progress",
+      arguments: { id: q.id, note: "Need the reviewer to choose A or B" },
+    });
+    const claimed = JSON.parse(textOf((await client.callTool({
+      name: "get_review_notes", arguments: { repo: "acme/atlas", branch: "feat/thing" },
+    })) as { content?: unknown })) as { noteCounts: Record<string, number>; notes: Array<Record<string, unknown>> };
+    expect(claimed.noteCounts).toEqual({ open: 0, in_progress: 1, addressed: 0, resolved: 0 });
+    expect(claimed.notes[0]).toMatchObject({
+      id: q.id,
+      state: "in_progress",
+      inProgressNote: "Need the reviewer to choose A or B",
+      sourceContext: { startLine: 1, lines: ["one", "two", "three"] },
+    });
+
+    await client.callTool({
+      name: "mark_note_addressed",
+      arguments: { id: q.id, summary: "The reviewer chose A." },
+    });
+    expect(storage.listNotes("acme/atlas", 7)[0]).toMatchObject({
+      state: "addressed", commitRef: null, summary: "The reviewer chose A.", inProgressNote: null,
+    });
+    await client.close();
+  });
+
+  it("returns only notes after the last-seen id", async () => {
+    storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
+    const first = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 1, text: "First", headSha: null, sourceContext: null });
+    const second = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 2, text: "Second", headSha: null, sourceContext: null });
+
+    const client = await connect();
+    const incremental = JSON.parse(textOf((await client.callTool({
+      name: "get_review_notes", arguments: { repo: "acme/atlas", branch: "feat/thing", since: first.id },
+    })) as { content?: unknown })) as { lastNoteId: number; notes: Array<{ id: number }> };
+    expect(incremental.lastNoteId).toBe(second.id);
+    expect(incremental.notes.map((note) => note.id)).toEqual([second.id]);
+
+    const none = JSON.parse(textOf((await client.callTool({
+      name: "get_review_notes", arguments: { repo: "acme/atlas", branch: "feat/thing", since: second.id },
+    })) as { content?: unknown })) as { message: string; notes: unknown[] };
+    expect(none.notes).toEqual([]);
+    expect(none.message).toBe(`No new open or in-progress notes after note ${second.id}.`);
+    await client.close();
+  });
+
+  it("refuses to mark a note that is not in progress", async () => {
+    const client = await connect();
+    const result = await client.callTool({ name: "mark_note_addressed", arguments: { id: 999, summary: "Nothing to change" } });
     expect(result.isError).toBe(true);
-    expect(textOf(result as { content?: unknown })).toContain("not open");
+    expect(textOf(result as { content?: unknown })).toContain("not in progress");
     await client.close();
   });
 
@@ -196,7 +252,7 @@ describe("MCP endpoint", () => {
     storage.setPrContext("acme/atlas", 8, {
       headRef: "feat/frontend", title: "Frontend", headSha: "sha-2", stackId: 99, stackSize: 2, stackPosition: 2,
     });
-    storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Why?", headSha: "sha-1" });
+    storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Why?", headSha: "sha-1", sourceContext: null });
 
     const client = await connect();
     const text = textOf((await client.callTool({
@@ -218,8 +274,8 @@ describe("MCP endpoint", () => {
     storage.setPrContext("acme/atlas", 8, {
       headRef: "feat/frontend", title: "Frontend", headSha: "sha-2", stackId: 99, stackSize: 2, stackPosition: 2,
     });
-    storage.addNote("acme/atlas", 7, { path: "a.rb", line: 1, text: "on backend", headSha: null });
-    storage.addNote("acme/atlas", 8, { path: "b.ts", line: 1, text: "on frontend", headSha: null });
+    storage.addNote("acme/atlas", 7, { path: "a.rb", line: 1, text: "on backend", headSha: null, sourceContext: null });
+    storage.addNote("acme/atlas", 8, { path: "b.ts", line: 1, text: "on frontend", headSha: null, sourceContext: null });
 
     const client = await connect();
     const text = textOf((await client.callTool({
@@ -235,7 +291,7 @@ describe("MCP endpoint", () => {
     storage.setPrContext("acme/atlas", 7, {
       headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null,
     });
-    storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "captured at sha-1", headSha: "sha-1" });
+    storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "captured at sha-1", headSha: "sha-1", sourceContext: null });
 
     const client = await connect();
     const stillCurrent = JSON.parse(textOf((await client.callTool({

--- a/packages/service/src/mcp.ts
+++ b/packages/service/src/mcp.ts
@@ -4,8 +4,8 @@ import { z } from "zod";
 import type { Storage } from "./storage.js";
 
 /**
- * The MCP contract is deliberately tiny: agents read the reviewer's notes and say when
- * they have acted on one. Nothing here reads diffs, lists files, touches
+ * The MCP contract is deliberately tiny: agents read the reviewer's notes, claim the
+ * ones they start, and say when they have acted on one. Nothing here reads diffs, lists files, touches
  * checkoffs, or resolves a note — resolution is the reviewer's act alone, made in
  * the app by re-checking the file. Agents already have git and gh for code; this carries
  * only the reviewer's notes and their durable completion state.
@@ -30,8 +30,8 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
       title: "Get review notes",
       description:
         "Notes the reviewer has left on a pull request, with the file and line each one is about. " +
-        "Derive repo and branch from the working directory. Returns open notes by default — those are the ones still needing work. " +
-        "The response always counts open, addressed, and resolved notes so hidden states are visible. " +
+        "Derive repo and branch from the working directory. Returns open and in-progress notes by default — those are the ones still needing work. " +
+        "The response always counts open, in-progress, addressed, and resolved notes so hidden states are visible. " +
         "The response names the branch, title, and stack position of the pull request the notes belong to: check it matches the checkout being worked in, " +
         "because a stacked pull request's sibling is a different branch with different notes.",
       inputSchema: {
@@ -40,30 +40,33 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
         prNumber: z.number().int().positive().optional().describe("Pull request number, if known."),
         includeAddressed: z.boolean().optional().describe("Also return notes already marked addressed. Defaults to false."),
         includeResolved: z.boolean().optional().describe("Also return notes the reviewer has resolved. Defaults to false."),
+        since: z.number().int().nonnegative().optional().describe("Return only notes with an id greater than this last-seen note id."),
       },
     },
-    async ({ repo, branch, prNumber, includeAddressed, includeResolved }) => {
+    async ({ repo, branch, prNumber, includeAddressed, includeResolved, since }) => {
       const resolved = resolvePr(repo, prNumber, branch);
       if (typeof resolved === "string") return { content: [{ type: "text", text: resolved }], isError: true };
 
       const context = storage.getPrContext(repo, resolved);
       const members = context?.stackId == null ? [] : storage.listStackMembers(repo, context.stackId);
-      const wanted = new Set(["open"]);
+      const wanted = new Set(["open", "in_progress"]);
       if (includeAddressed === true) wanted.add("addressed");
       if (includeResolved === true) wanted.add("resolved");
       const allNotes = storage.listNotes(repo, resolved);
-      const noteCounts: Record<"open" | "addressed" | "resolved", number> = { open: 0, addressed: 0, resolved: 0 };
+      const noteCounts: Record<"open" | "in_progress" | "addressed" | "resolved", number> = { open: 0, in_progress: 0, addressed: 0, resolved: 0 };
       for (const note of allNotes) noteCounts[note.state] += 1;
       const notes = allNotes
-        .filter((q) => wanted.has(q.state))
+        .filter((q) => wanted.has(q.state) && (since === undefined || q.id > since))
         .map((q) => ({
           id: q.id,
           file: q.path,
           line: q.line,
           text: q.text,
           state: q.state,
-          ...(q.state === "open" ? {} : { commitRef: q.commitRef, summary: q.summary }),
+          ...(q.state === "in_progress" ? { inProgressNote: q.inProgressNote } : {}),
+          ...(q.state === "addressed" || q.state === "resolved" ? { commitRef: q.commitRef, summary: q.summary } : {}),
           capturedAtSha: q.headSha,
+          sourceContext: q.sourceContext,
           // The branch may have moved since the reviewer read it, in which case the line
           // number is the one they saw, not necessarily the one there now.
           lineMayHaveMoved: q.headSha !== null && context !== null && q.headSha !== context.headSha,
@@ -71,6 +74,10 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
 
       const hiddenStates = (["addressed", "resolved"] as const)
         .filter((state) => !wanted.has(state) && noteCounts[state] > 0);
+      const wantedLabels = [...wanted].map((state) => state.replace("_", "-"));
+      const wantedLabel = wantedLabels.length === 1
+        ? wantedLabels[0]!
+        : `${wantedLabels.slice(0, -1).join(", ")}${wantedLabels.length > 2 ? "," : ""} or ${wantedLabels.at(-1)}`;
       let message: string;
       if (notes.length === 0 && hiddenStates.length > 0) {
         const includeFlag = { addressed: "includeAddressed", resolved: "includeResolved" } as const;
@@ -79,9 +86,11 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
           .map((state) => `${noteCounts[state]} ${state} note${noteCounts[state] === 1 ? "" : "s"}`)
           .join(" and ");
         const flags = hiddenStates.map((state) => `${includeFlag[state]}: true`).join(" and ");
-        message = `No ${[...wanted].join(" or ")} notes returned. ${hidden} ${hiddenCount === 1 ? "is" : "are"} hidden; pass ${flags} to retrieve ${hiddenCount === 1 ? "it" : "them"}.`;
+        message = `No ${wantedLabel} notes returned. ${hidden} ${hiddenCount === 1 ? "is" : "are"} hidden; pass ${flags} to retrieve ${hiddenCount === 1 ? "it" : "them"}.`;
       } else if (notes.length === 0 && allNotes.length === 0) {
         message = "No notes exist for this pull request.";
+      } else if (notes.length === 0 && since !== undefined) {
+        message = `No new ${wantedLabel} notes after note ${since}.`;
       } else {
         message = `Returned ${notes.length} of ${allNotes.length} note${allNotes.length === 1 ? "" : "s"} on this pull request.`;
       }
@@ -93,6 +102,7 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
         branch: context?.headRef ?? null,
         title: context?.title ?? null,
         headSha: context?.headSha ?? null,
+        lastNoteId: allNotes.at(-1)?.id ?? null,
         noteCounts,
         message,
         stack: context?.stackSize == null || context.stackPosition == null
@@ -125,23 +135,46 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
   );
 
   server.registerTool(
+    "mark_note_in_progress",
+    {
+      title: "Mark a review note in progress",
+      description:
+        "Claim a note when work starts. Pass note when work is waiting on a reviewer decision; omit it while work is active.",
+      inputSchema: {
+        id: z.number().int().positive().describe("Note id from get_review_notes."),
+        note: z.string().min(1).optional().describe("Why this work is waiting on the reviewer."),
+      },
+    },
+    async ({ id, note }) => {
+      const marked = storage.markNoteInProgress(id, { note: note ?? null });
+      if (marked === null) {
+        return {
+          content: [{ type: "text", text: `Note ${id} is not open or in progress — it does not exist, or it was already addressed or resolved.` }],
+          isError: true,
+        };
+      }
+      return { content: [{ type: "text", text: `Note ${id} marked in progress.` }] };
+    },
+  );
+
+  server.registerTool(
     "mark_note_addressed",
     {
       title: "Mark a review note addressed",
       description:
-        "Record that a note has been acted on. Use it only once the work is actually done and committed. " +
+        "Record the outcome after an in-progress note has been acted on. A code change can name its commit; an answered question has no commit. " +
         "This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
       inputSchema: {
         id: z.number().int().positive().describe("Note id from get_review_notes."),
-        commitRef: z.string().optional().describe("Commit that addressed it."),
-        summary: z.string().optional().describe("One line on what changed."),
+        commitRef: z.string().min(1).optional().describe("Commit that addressed it, when the outcome changed code."),
+        summary: z.string().min(1).describe("One line recording the outcome."),
       },
     },
     async ({ id, commitRef, summary }) => {
       const marked = storage.markNoteAddressed(id, { commitRef: commitRef ?? null, summary: summary ?? null });
       if (marked === null) {
         return {
-          content: [{ type: "text", text: `Note ${id} is not open — it does not exist, or it was already addressed or resolved.` }],
+          content: [{ type: "text", text: `Note ${id} is not in progress — it does not exist, is still open, or was already addressed or resolved.` }],
           isError: true,
         };
       }

--- a/packages/service/src/migrate-0.6.0.test.ts
+++ b/packages/service/src/migrate-0.6.0.test.ts
@@ -1,0 +1,66 @@
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const serviceRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const command = join(serviceRoot, "node_modules/.bin/tsx");
+const script = join(serviceRoot, "src/migrate-0.6.0.ts");
+let dir: string;
+
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "gander-migrate-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe("0.6.0 production database migration", () => {
+  it("backs up the database before adding the note-state columns", () => {
+    const databasePath = join(dir, "gander.db");
+    const backupPath = join(dir, "gander.backup.db");
+    const database = new Database(databasePath);
+    database.exec(`
+      CREATE TABLE notes (
+        id INTEGER PRIMARY KEY,
+        text TEXT NOT NULL,
+        state TEXT NOT NULL DEFAULT 'open',
+        head_sha TEXT,
+        commit_ref TEXT,
+        summary TEXT,
+        addressed_at TEXT,
+        created_at TEXT NOT NULL
+      );
+      INSERT INTO notes (id, text, state, created_at)
+      VALUES (41, 'Keep this review note', 'open', '2026-08-19T12:30:00.000Z');
+    `);
+    database.close();
+
+    const result = spawnSync(command, [script, databasePath, backupPath], { encoding: "utf8" });
+    expect(result.status, result.stderr).toBe(0);
+    expect(statSync(backupPath).mode & 0o777).toBe(0o600);
+
+    const backup = new Database(backupPath, { readonly: true });
+    expect(backup.pragma("integrity_check", { simple: true })).toBe("ok");
+    expect(backup.prepare("SELECT id, text, state, created_at FROM notes").get()).toEqual({
+      id: 41,
+      text: "Keep this review note",
+      state: "open",
+      created_at: "2026-08-19T12:30:00.000Z",
+    });
+    expect((backup.pragma("table_info(notes)") as Array<{ name: string }>).map(({ name }) => name)).not.toContain("source_context");
+    backup.close();
+
+    const migrated = new Database(databasePath, { readonly: true });
+    expect((migrated.pragma("table_info(notes)") as Array<{ name: string }>).map(({ name }) => name)).toEqual(expect.arrayContaining([
+      "source_context",
+      "in_progress_note",
+    ]));
+    expect(migrated.prepare("SELECT id, text, state, created_at FROM notes").get()).toEqual({
+      id: 41,
+      text: "Keep this review note",
+      state: "open",
+      created_at: "2026-08-19T12:30:00.000Z",
+    });
+    migrated.close();
+  });
+});

--- a/packages/service/src/migrate-0.6.0.ts
+++ b/packages/service/src/migrate-0.6.0.ts
@@ -1,0 +1,47 @@
+import Database from "better-sqlite3";
+import { chmodSync, existsSync, renameSync } from "node:fs";
+
+const [databasePath = "/data/gander.db", backupPath] = process.argv.slice(2);
+
+async function main(): Promise<void> {
+  if (!backupPath) throw new Error("Usage: migrate-0.6.0.ts DATABASE_PATH BACKUP_PATH");
+  if (!existsSync(databasePath)) {
+    console.log("No existing database; the service will create the current schema.");
+    return;
+  }
+  if (existsSync(backupPath)) throw new Error(`Refusing to overwrite backup: ${backupPath}`);
+  const partialBackupPath = `${backupPath}.partial`;
+  if (existsSync(partialBackupPath)) throw new Error(`Remove the incomplete backup before retrying: ${partialBackupPath}`);
+
+  const database = new Database(databasePath);
+  try {
+    await database.backup(partialBackupPath);
+    chmodSync(partialBackupPath, 0o600);
+
+    const backup = new Database(partialBackupPath, { readonly: true });
+    try {
+      const integrity = backup.pragma("integrity_check", { simple: true });
+      if (integrity !== "ok") throw new Error(`Backup integrity check failed: ${String(integrity)}`);
+    } finally {
+      backup.close();
+    }
+    renameSync(partialBackupPath, backupPath);
+
+    const columns = new Set((database.pragma("table_info(notes)") as Array<{ name: string }>).map((column) => column.name));
+    const missing = ["source_context", "in_progress_note"].filter((column) => !columns.has(column));
+    database.transaction(() => {
+      if (!columns.has("source_context")) database.exec("ALTER TABLE notes ADD COLUMN source_context TEXT");
+      if (!columns.has("in_progress_note")) database.exec("ALTER TABLE notes ADD COLUMN in_progress_note TEXT");
+    })();
+
+    console.log(`Backed up ${databasePath} to ${backupPath}`);
+    console.log(missing.length > 0 ? "Applied the 0.6.0 note-state migration." : "The 0.6.0 note-state migration was already applied.");
+  } finally {
+    database.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/service/src/server.test.ts
+++ b/packages/service/src/server.test.ts
@@ -93,9 +93,13 @@ describe("service API", () => {
     const url = "/api/reviews/acme%2Fatlas/7/notes";
 
     it("creates, lists, and deletes a note", async () => {
-      const created = await server.inject({ method: "POST", url, headers: AUTH, payload: { path: "a.rb", line: 3, text: "Why?", headSha: "sha-1" } });
+      const created = await server.inject({
+        method: "POST", url, headers: AUTH,
+        payload: { path: "a.rb", line: 3, text: "Why?", headSha: "sha-1", sourceContext: { startLine: 1, lines: ["one", "two", "three"] } },
+      });
       expect(created.statusCode).toBe(201);
       const id = created.json().id as number;
+      expect(created.json().sourceContext).toEqual({ startLine: 1, lines: ["one", "two", "three"] });
 
       const listed = await server.inject({ method: "GET", url, headers: AUTH });
       expect(listed.json()).toHaveLength(1);
@@ -106,7 +110,8 @@ describe("service API", () => {
     });
 
     it("lists a resolved note with the agent's commit and note", async () => {
-      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
+      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null, sourceContext: null });
+      storage.markNoteInProgress(note.id, { note: null });
       storage.markNoteAddressed(note.id, { commitRef: "abc1234", summary: "Dropped the retry" });
       storage.putFileState("acme/atlas", 7, {
         checked: true, path: "a.rb", baseHash: "base", headHash: "head",
@@ -127,7 +132,7 @@ describe("service API", () => {
     });
 
     it("edits note text and state", async () => {
-      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 3, text: "Before", headSha: null });
+      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 3, text: "Before", headSha: null, sourceContext: null });
       const updated = await server.inject({
         method: "PATCH", url: `${url}/${note.id}`, headers: AUTH,
         payload: { text: "After", state: "resolved" },

--- a/packages/service/src/storage.test.ts
+++ b/packages/service/src/storage.test.ts
@@ -106,32 +106,61 @@ describe("storage", () => {
 
   describe("notes", () => {
     it("stores a note against a file and reads it back as open", () => {
-      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Why the retry here?", headSha: null });
-      expect(q).toMatchObject({ path: "a.rb", line: 12, text: "Why the retry here?", state: "open" });
+      const q = storage.addNote("acme/atlas", 7, {
+        path: "a.rb", line: 12, text: "Why the retry here?", headSha: null,
+        sourceContext: { startLine: 10, lines: ["before", "near", "target", "after"] },
+      });
+      expect(q).toMatchObject({
+        path: "a.rb", line: 12, text: "Why the retry here?", state: "open",
+        sourceContext: { startLine: 10, lines: ["before", "near", "target", "after"] },
+      });
       expect(storage.listNotes("acme/atlas", 7)).toEqual([q]);
     });
 
     it("keeps a pull-request-level note, which has no file", () => {
-      const q = storage.addNote("acme/atlas", 7, { path: null, line: null, text: "Squash before merge", headSha: null });
+      const q = storage.addNote("acme/atlas", 7, { path: null, line: null, text: "Squash before merge", headSha: null, sourceContext: null });
       expect(q.path).toBeNull();
       expect(storage.listNotes("acme/atlas", 7)).toHaveLength(1);
     });
 
     it("scopes notes to one review", () => {
-      storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "on seven", headSha: null });
-      storage.addNote("acme/atlas", 8, { path: "a.rb", line: null, text: "on eight", headSha: null });
+      storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "on seven", headSha: null, sourceContext: null });
+      storage.addNote("acme/atlas", 8, { path: "a.rb", line: null, text: "on eight", headSha: null, sourceContext: null });
       expect(storage.listNotes("acme/atlas", 7).map((q) => q.text)).toEqual(["on seven"]);
       expect(storage.listNotes("acme/atlas", 8).map((q) => q.text)).toEqual(["on eight"]);
     });
 
     it("an agent marks a note addressed with a commit and note", () => {
-      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why the retry?", headSha: null });
+      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why the retry?", headSha: null, sourceContext: null });
+      expect(storage.markNoteAddressed(q.id, { commitRef: "abc1234", summary: "Dropped the retry" })).toBeNull();
+      storage.markNoteInProgress(q.id, { note: null });
       const marked = storage.markNoteAddressed(q.id, { commitRef: "abc1234", summary: "Dropped the retry" });
       expect(marked).toMatchObject({ state: "addressed", commitRef: "abc1234", summary: "Dropped the retry" });
     });
 
+    it("claims a note, records why it is waiting, then addresses it without a commit", () => {
+      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Which behavior?", headSha: null, sourceContext: null });
+
+      expect(storage.markNoteInProgress(q.id, { note: null })).toMatchObject({ state: "in_progress", inProgressNote: null });
+      expect(storage.markNoteInProgress(q.id, { note: "Need the reviewer to choose A or B" })).toMatchObject({
+        state: "in_progress",
+        inProgressNote: "Need the reviewer to choose A or B",
+      });
+      expect(storage.markNoteInProgress(q.id, { note: null })).toMatchObject({
+        state: "in_progress",
+        inProgressNote: null,
+      });
+      storage.markNoteInProgress(q.id, { note: "Need the reviewer to choose A or B" });
+      expect(storage.markNoteAddressed(q.id, { commitRef: null, summary: "The reviewer chose A." })).toMatchObject({
+        state: "addressed",
+        inProgressNote: null,
+        commitRef: null,
+        summary: "The reviewer chose A.",
+      });
+    });
+
     it("lets the reviewer edit note text and correct its state within one review", () => {
-      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Old text", headSha: null });
+      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: 12, text: "Old text", headSha: null, sourceContext: null });
 
       expect(storage.updateNote("acme/atlas", 8, note.id, { text: "Wrong review" })).toBeNull();
       expect(storage.updateNote("acme/atlas", 7, note.id, { text: "Updated text", state: "resolved" })).toMatchObject({
@@ -143,7 +172,8 @@ describe("storage", () => {
     });
 
     it("refuses to re-address a note the reviewer already resolved", () => {
-      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null });
+      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null, sourceContext: null });
+      storage.markNoteInProgress(q.id, { note: null });
       storage.markNoteAddressed(q.id, { commitRef: "abc1234", summary: "Dropped the retry" });
       storage.putFileState("acme/atlas", 7, {
         checked: true, path: "a.rb", baseHash: "b", headHash: "h",
@@ -156,9 +186,11 @@ describe("storage", () => {
     });
 
     it("re-checking a file resolves its addressed notes and leaves open ones alone", () => {
-      const answered = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "answered", headSha: null });
-      const unanswered = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "still open", headSha: null });
-      const elsewhere = storage.addNote("acme/atlas", 7, { path: "b.rb", line: null, text: "other file", headSha: null });
+      const answered = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "answered", headSha: null, sourceContext: null });
+      const unanswered = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "still open", headSha: null, sourceContext: null });
+      const elsewhere = storage.addNote("acme/atlas", 7, { path: "b.rb", line: null, text: "other file", headSha: null, sourceContext: null });
+      storage.markNoteInProgress(answered.id, { note: null });
+      storage.markNoteInProgress(elsewhere.id, { note: null });
       storage.markNoteAddressed(answered.id, { commitRef: "c1", summary: null });
       storage.markNoteAddressed(elsewhere.id, { commitRef: "c2", summary: null });
 
@@ -187,7 +219,7 @@ describe("storage", () => {
     });
 
     it("deletes only within its own review", () => {
-      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "keep me", headSha: null });
+      const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "keep me", headSha: null, sourceContext: null });
       // The same id offered against a different pull request must not delete it.
       expect(storage.deleteNote("acme/atlas", 8, q.id)).toBe(false);
       expect(storage.listNotes("acme/atlas", 7)).toHaveLength(1);

--- a/packages/service/src/storage.ts
+++ b/packages/service/src/storage.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { gzipSync, gunzipSync } from "node:zlib";
-import type { FileCheckoff, MarkAddressed, NewNote, PrContext, PutFileState, Note, ReviewState, UpdateNote } from "@gander/shared";
+import type { FileCheckoff, MarkAddressed, MarkInProgress, NewNote, PrContext, PutFileState, Note, ReviewState, UpdateNote } from "@gander/shared";
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS reviews (
@@ -34,6 +34,8 @@ CREATE TABLE IF NOT EXISTS notes (
   text TEXT NOT NULL,
   state TEXT NOT NULL DEFAULT 'open',
   head_sha TEXT,
+  source_context TEXT,
+  in_progress_note TEXT,
   commit_ref TEXT,
   summary TEXT,
   addressed_at TEXT,
@@ -54,6 +56,7 @@ export interface Storage {
   /** Every pull request recorded as part of the same stack, with how many open notes each holds. */
   listStackMembers(repoId: string, stackId: number): Array<{ prNumber: number; headRef: string | null; title: string | null; position: number | null; openNotes: number }>;
   findPrByHeadRef(repoId: string, headRef: string): number | null;
+  markNoteInProgress(id: number, input: MarkInProgress): Note | null;
   markNoteAddressed(id: number, input: MarkAddressed): Note | null;
   listNotes(repoId: string, prNumber: number): Note[];
   addNote(repoId: string, prNumber: number, input: NewNote): Note;
@@ -62,7 +65,7 @@ export interface Storage {
   close(): void;
 }
 
-interface NoteRow { id: number; path: string | null; line: number | null; text: string; state: string; head_sha: string | null; commit_ref: string | null; summary: string | null; created_at: string }
+interface NoteRow { id: number; path: string | null; line: number | null; text: string; state: string; head_sha: string | null; source_context: string | null; in_progress_note: string | null; commit_ref: string | null; summary: string | null; created_at: string }
 interface FileStateRow { path: string; checked: number; base_hash: string | null; head_hash: string | null; checked_at: string | null; machine: string | null }
 
 const rowToCheckoff = (r: FileStateRow): FileCheckoff => ({
@@ -75,11 +78,13 @@ const rowToNote = (r: NoteRow): Note => ({
   id: r.id, path: r.path, line: r.line, text: r.text,
   state: r.state as Note["state"],
   headSha: r.head_sha,
+  sourceContext: r.source_context === null ? null : JSON.parse(r.source_context) as Note["sourceContext"],
+  inProgressNote: r.in_progress_note,
   commitRef: r.commit_ref, summary: r.summary,
   createdAt: r.created_at,
 });
 
-const NOTE_COLUMNS = "id, path, line, text, state, head_sha, commit_ref, summary, created_at";
+const NOTE_COLUMNS = "id, path, line, text, state, head_sha, source_context, in_progress_note, commit_ref, summary, created_at";
 const FILE_STATE_COLUMNS = "path, checked, base_hash, head_hash, checked_at, machine";
 
 const pack = (s: string | null): Buffer | null => (s === null ? null : gzipSync(Buffer.from(s, "utf8")));
@@ -192,13 +197,25 @@ export function openStorage(dbPath: string): Storage {
       return row?.pr_number ?? null;
     },
 
+    markNoteInProgress(id, input) {
+      // Calling the claim tool again updates whether already-started work is active or
+      // waiting, without manufacturing another state transition.
+      const changed = db.prepare(`
+        UPDATE notes
+        SET state = 'in_progress', in_progress_note = ?
+        WHERE id = ? AND state IN ('open', 'in_progress')
+      `).run(input.note, id).changes;
+      if (changed === 0) return null;
+      return rowToNote(db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(id) as NoteRow);
+    },
+
     markNoteAddressed(id, input) {
-      // Only an open note can be addressed. Re-addressing a resolved one would
+      // Only claimed work can be addressed. Re-addressing a resolved one would
       // undo the reviewer's own act, and the spec puts resolution solely in their hands.
       const changed = db.prepare(`
         UPDATE notes
-        SET state = 'addressed', commit_ref = ?, summary = ?, addressed_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-        WHERE id = ? AND state = 'open'
+        SET state = 'addressed', in_progress_note = NULL, commit_ref = ?, summary = ?, addressed_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+        WHERE id = ? AND state = 'in_progress'
       `).run(input.commitRef, input.summary, id).changes;
       if (changed === 0) return null;
       return rowToNote(db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(id) as NoteRow);
@@ -213,8 +230,8 @@ export function openStorage(dbPath: string): Storage {
     addNote(repoId, prNumber, input) {
       const rid = reviewId(repoId, prNumber);
       const { lastInsertRowid } = db
-        .prepare("INSERT INTO notes (review_id, path, line, text, head_sha) VALUES (?, ?, ?, ?, ?)")
-        .run(rid, input.path, input.line, input.text, input.headSha);
+        .prepare("INSERT INTO notes (review_id, path, line, text, head_sha, source_context) VALUES (?, ?, ?, ?, ?, ?)")
+        .run(rid, input.path, input.line, input.text, input.headSha, input.sourceContext === null ? null : JSON.stringify(input.sourceContext));
       const row = db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(lastInsertRowid) as NoteRow;
       return rowToNote(row);
     },
@@ -230,6 +247,7 @@ export function openStorage(dbPath: string): Storage {
       if (input.state !== undefined) {
         assignments.push("state = ?");
         values.push(input.state);
+        if (input.state !== "in_progress") assignments.push("in_progress_note = NULL");
       }
       if (assignments.length === 0) return null;
       const changed = db.prepare(`UPDATE notes SET ${assignments.join(", ")} WHERE id = ? AND review_id = ?`)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
  *
  * Not the app's release version: releases happen far more often than the contract moves.
  */
-export const SERVICE_VERSION = "0.5.0";
+export const SERVICE_VERSION = "0.6.0";
 
 export const FileStatusSchema = z.enum(["A", "M", "D", "R"]);
 export type FileStatus = z.infer<typeof FileStatusSchema>;
@@ -49,8 +49,16 @@ export const PutFileStateSchema = z.discriminatedUnion("checked", [
 ]);
 export type PutFileState = z.infer<typeof PutFileStateSchema>;
 
-export const NoteStateSchema = z.enum(["open", "addressed", "resolved"]);
+export const NoteStateSchema = z.enum(["open", "in_progress", "addressed", "resolved"]);
 export type NoteState = z.infer<typeof NoteStateSchema>;
+
+export const NoteSourceContextSchema = z.object({
+  /** 1-based line number of the first captured line. */
+  startLine: z.number().int().positive(),
+  /** Immutable lines from the head revision the reviewer was reading. */
+  lines: z.array(z.string()).min(1),
+});
+export type NoteSourceContext = z.infer<typeof NoteSourceContextSchema>;
 
 export const NoteSchema = z.object({
   id: z.number().int().positive(),
@@ -62,6 +70,10 @@ export const NoteSchema = z.object({
   state: NoteStateSchema,
   /** Head the branch was at when the note was captured. */
   headSha: z.string().nullable(),
+  /** Source surrounding the selected line, captured before the branch can move. */
+  sourceContext: NoteSourceContextSchema.nullable(),
+  /** Why an in-progress note is waiting for the reviewer. */
+  inProgressNote: z.string().nullable(),
   /** Commit an agent named when it marked the note addressed. */
   commitRef: z.string().nullable(),
   /** One-line summary an agent left when it marked the note addressed. */
@@ -76,6 +88,8 @@ export const NewNoteSchema = z.object({
   text: z.string().min(1),
   /** Head the branch was at when this was captured, so a moved line can be spotted later. */
   headSha: z.string().min(1).nullable(),
+  /** Source surrounding the selected line, captured from the same head revision. */
+  sourceContext: NoteSourceContextSchema.nullable(),
 });
 export type NewNote = z.infer<typeof NewNoteSchema>;
 
@@ -104,6 +118,11 @@ export const MarkAddressedSchema = z.object({
   summary: z.string().min(1).nullable(),
 });
 export type MarkAddressed = z.infer<typeof MarkAddressedSchema>;
+
+export const MarkInProgressSchema = z.object({
+  note: z.string().min(1).nullable(),
+});
+export type MarkInProgress = z.infer<typeof MarkInProgressSchema>;
 
 export interface PrSummary {
   number: number;


### PR DESCRIPTION
## Summary

- add in-progress and reviewer-blocked note states with incremental MCP fetches
- preserve captured source context and show the full lifecycle in the Notes drawer
- back up and explicitly migrate the hosted SQLite database during deployment

## Readiness

- simplify and code review: clean
- production migration received a focused adversarial review
- Impeccable UI detector: clean

## Test plan

- `pnpm typecheck`
- `pnpm test` — 61 files, 404 tests
- Electron note lifecycle — 2 tests passed
- `bash -n bin/deploy`
- `git diff --check`

Closes #115