### PR TITLE
Preserve deploy script stdin

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -55,7 +55,8 @@ mkdir -p "$BACKUP_PATH"
 BACKUP_FILE="gander-$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD).db"
 docker compose run --rm --no-deps \
   -v "${BACKUP_PATH}:/backup" \
-  gander node_modules/.bin/tsx src/migrate-0.6.0.ts /data/gander.db "/backup/${BACKUP_FILE}"
+  gander node_modules/.bin/tsx src/migrate-0.6.0.ts /data/gander.db "/backup/${BACKUP_FILE}" \
+  < /dev/null
 docker compose up -d gander
 REMOTE
 

--- a/bin/deploy.test.ts
+++ b/bin/deploy.test.ts
@@ -35,7 +35,12 @@ beforeEach(() => {
 set -euo pipefail
 printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
 if [[ "$1 $2" == "compose port" ]]; then printf '0.0.0.0:%s\\n' "$FAKE_PORT"; fi
-if [[ "$*" == *"migrate-0.6.0.ts"* && "\${FAKE_MIGRATION_FAIL:-0}" == "1" ]]; then exit 1; fi
+if [[ "$*" == *"migrate-0.6.0.ts"* ]]; then
+  # A real docker compose run inherits stdin. Consume it here so this test
+  # proves the remote deployment script protects its remaining commands.
+  while IFS= read -r _; do :; done
+  if [[ "\${FAKE_MIGRATION_FAIL:-0}" == "1" ]]; then exit 1; fi
+fi
 `);
   executable(join(fakeBin, "curl"), `#!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Summary

- detach the one-off migration container from the remote deploy script stdin
- reproduce stdin consumption in the deploy test so the restart command cannot disappear again

## Test plan

- `bash -n bin/deploy`
- `pnpm vitest run bin/deploy.test.ts`
- `pnpm typecheck`
- `git diff --check`