### PR TITLE
Distinguish partial review status

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -4,7 +4,7 @@
 
 ## Platform
 
-Electron desktop application
+web
 
 ## Users
 

--- a/packages/app/e2e/review-files-toolbar.spec.ts
+++ b/packages/app/e2e/review-files-toolbar.spec.ts
@@ -40,17 +40,25 @@ test("review file toolbar controls folder disclosure and remaining files", async
   // A reviewed top-level file cannot be hidden by folding a parent folder. This is the
   // important behavior: Remaining filters files, rather than merely collapsing directories.
   await review.checkFile("a.rb");
+  await review.file("src/main.ts").getByRole("checkbox").click();
+  const partialDirectory = review.file("src").getByRole("checkbox");
+  await expect(partialDirectory).toHaveAttribute("aria-checked", "mixed");
+  const warningColor = await app.page.evaluate(() => {
+    const probe = document.createElement("span");
+    probe.style.color = "var(--warning)";
+    document.body.append(probe);
+    const color = getComputedStyle(probe).color;
+    probe.remove();
+    return color;
+  });
+  expect(await partialDirectory.evaluate((element) => getComputedStyle(element).color)).toBe(warningColor);
 
   const remaining = toolbar.getByRole("button", { name: "Show unreviewed files only" });
   await remaining.click();
   await expect(remaining).toHaveAttribute("aria-pressed", "true");
-  await expect(progress).toHaveText("5/6 unreviewed");
-  await expect(review.file("a.rb")).toHaveCount(0);
-  await expect(review.file("src/main.ts")).toBeVisible();
-
-  await review.file("src/main.ts").getByRole("checkbox").click();
-  await expect(review.file("src/main.ts")).toHaveCount(0);
   await expect(progress).toHaveText("4/6 unreviewed");
+  await expect(review.file("a.rb")).toHaveCount(0);
+  await expect(review.file("src/main.ts")).toHaveCount(0);
 
   await remaining.click();
   await expect(remaining).toHaveAttribute("aria-pressed", "false");

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -110,6 +110,20 @@ describe("FileTree", () => {
     file("config/routes.rb", true),
   ];
 
+  it("distinguishes a partially reviewed directory from a fully reviewed one", () => {
+    const { store } = fakeStore(prView(1, treeFiles));
+    const wrapper = mount(FileTree, { props: { store, iconTheme: "catppuccin-mocha" } });
+    const partial = dirRow(wrapper, "app").find(".cb");
+    const complete = dirRow(wrapper, "config").find(".cb");
+
+    expect(partial.classes()).toContain("part");
+    expect(partial.attributes("aria-checked")).toBe("mixed");
+    expect(partial.find(".lucide-minus").exists()).toBe(true);
+    expect(complete.classes()).toContain("on");
+    expect(complete.attributes("aria-checked")).toBe("true");
+    expect(complete.find(".lucide-check").exists()).toBe(true);
+  });
+
   it("checking a directory issues exactly one batched setCheckedMany call covering every descendant, and never calls setChecked", async () => {
     const { store, calls } = fakeStore(prView(1, treeFiles));
     const wrapper = mount(FileTree, { props: { store, iconTheme: "catppuccin-mocha" } });

--- a/packages/app/src/renderer/src/components/FileTree.vue
+++ b/packages/app/src/renderer/src/components/FileTree.vue
@@ -60,6 +60,11 @@ function dirStateFor(node: TreeNode & { type: "dir" }): "all" | "some" | "none" 
   return dirStates.value.get(node.path) ?? "none";
 }
 
+function dirAriaChecked(node: TreeNode & { type: "dir" }): boolean | "mixed" {
+  const state = dirStateFor(node);
+  return state === "some" ? "mixed" : state === "all";
+}
+
 // Directory paths carry no PR identity, and `store.openPr` reassigns `view` in one step
 // (never through a null in between), so switching PRs within the same repo never unmounts
 // this component. Clear stale collapse state whenever the reviewed PR changes.
@@ -117,7 +122,7 @@ function jumpShortcut(path: string): string | undefined {
           class="cb"
           :class="{ on: dirStateFor(node) === 'all', part: dirStateFor(node) === 'some' }"
           role="checkbox"
-          :aria-checked="dirStateFor(node) === 'all'"
+          :aria-checked="dirAriaChecked(node)"
           tabindex="0"
           @click.stop="checkDir(node)"
           @keydown.enter.space.stop.prevent="checkDir(node)"
@@ -199,7 +204,7 @@ function jumpShortcut(path: string): string | undefined {
 .st.R { color: var(--info); }
 .cb { width: 15px; height: 15px; flex: none; border: 1.5px solid var(--faint-foreground); border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 11px; color: transparent; }
 .cb.on { border-color: var(--success); color: var(--success); }
-.cb.part { border-color: var(--success); color: var(--success); }
+.cb.part { border-color: var(--warning); color: var(--warning); }
 .tnode.checked .fname { color: var(--faint-foreground); }
 
 .jump-match { padding: 0; border-radius: 1px; background: var(--accent); color: var(--accent-foreground); font-weight: 750; }


### PR DESCRIPTION
## Summary

- render partially reviewed directories with the warning color while keeping completed directories green
- expose partial directory checkboxes as `aria-checked="mixed"`
- cover the semantic and resolved-color states in component and Electron tests
- classify Gander's web-rendered Electron interface as `web` for Impeccable routing

## Readiness

- Simplify: clean
- Code review: clean, no findings
- Finalize: clean
- Adversarial review: skipped for this low-risk presentation-only change

## Test Plan

- `pnpm test` — 61 files, 405 tests passed
- `pnpm typecheck`
- `pnpm exec playwright test e2e/review-files-toolbar.spec.ts` — 3 passed
- `git diff --check origin/master...HEAD`
- regression proof: the Electron color assertion fails with the original green partial-state rule and passes with the warning token restored
