### PR TITLE
Add note status filtering toolbar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,14 @@ to Gander review notes, read
 from the current worktree; do not register its MCP endpoint globally or reuse
 another worktree's port, token, config, database, or process.
 
+For user-requested code or product changes, create a feature branch, commit and
+push the work, create a pull request, and open that exact pull request in this
+checkout's Gander app. The pull-request review is also Steve's QA session: leave
+the app open on the PR so he can inspect the code and exercise the behavior in one
+flow. Run `bin/mcp check` before handing it back. Stop before publication only
+when Steve explicitly asks not to create a PR or when a concrete blocker requires
+his decision.
+
 **Electron install trap:** Electron 33's extract-zip silently truncates under
 Node 24, leaving a `node_modules/electron/dist` of a few hundred KB while the
 install script exits 0. Electron then fails to launch. The root `postinstall` hook runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,12 @@ flow. Run `bin/mcp check` before handing it back. Stop before publication only
 when Steve explicitly asks not to create a PR or when a concrete blocker requires
 his decision.
 
+Do not hand back an empty review when the changed UI depends on authored state.
+Populate this checkout's disposable local review with representative, clearly
+labeled QA data across the states needed to exercise the feature, then leave the
+relevant surface open in Gander. Never seed or alter the hosted review database
+for QA.
+
 **Electron install trap:** Electron 33's extract-zip silently truncates under
 Node 24, leaving a `node_modules/electron/dist` of a few hundred KB while the
 install script exits 0. Electron then fails to launch. The root `postinstall` hook runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ allocated per-checkout by outport. Don't start packages by hand — the app read
 its port and token from the generated `.env`. `DEVSTACK.md` covers the stack,
 worktrees, and MCP registration.
 
-When Steve asks to open the current PR in Gander, dogfood a change, or respond
+When the user asks to open the current PR in Gander, dogfood a change, or respond
 to Gander review notes, read
 `.agents/skills/review-with-gander/SKILL.md` and follow it. Use the CLI bridge
 from the current worktree; do not register its MCP endpoint globally or reuse
@@ -86,11 +86,11 @@ another worktree's port, token, config, database, or process.
 
 For user-requested code or product changes, create a feature branch, commit and
 push the work, create a pull request, and open that exact pull request in this
-checkout's Gander app. The pull-request review is also Steve's QA session: leave
-the app open on the PR so he can inspect the code and exercise the behavior in one
+checkout's Gander app. The pull-request review is also the user's QA session: leave
+the app open on the PR so they can inspect the code and exercise the behavior in one
 flow. Run `bin/mcp check` before handing it back. Stop before publication only
-when Steve explicitly asks not to create a PR or when a concrete blocker requires
-his decision.
+when the user explicitly asks not to create a PR or when a concrete blocker requires
+their decision.
 
 Do not hand back an empty review when the changed UI depends on authored state.
 Populate this checkout's disposable local review with representative, clearly
@@ -161,7 +161,7 @@ saving config would write a machine-specific allocated port into
 
 App config is intentionally not backward-compatible while its shape remains in
 major flux and there is only one maintainer install. Keep validation strict; when
-Steve asks to repair a stale local config, update that file directly instead of
+the user asks to repair a stale local config, update that file directly instead of
 adding migrations or compatibility branches. Add explicit schema versions and
 migrations only when backward compatibility becomes a product requirement.
 

--- a/packages/app/e2e/note-lifecycle.spec.ts
+++ b/packages/app/e2e/note-lifecycle.spec.ts
@@ -35,8 +35,14 @@ test("carries a reviewer note through MCP addressing and reviewer resolution", a
     await expect(note.getByRole("region", { name: "Agent update" })).toContainText("The reviewer confirmed the branch is required");
     await expect(note.getByRole("region", { name: "Waiting on reviewer" })).toHaveCount(0);
 
+    const noteFilter = app.page.getByRole("combobox", { name: "Filter notes by status" });
+    await noteFilter.selectOption("addressed");
+    await expect(note).toBeVisible();
+
     await app.page.getByRole("button", { name: "Mark reviewed" }).click();
     await review.fetchOrigin();
+    await expect(app.page.getByText("No notes have this status.")).toBeVisible();
+    await noteFilter.selectOption("resolved");
     await expect(note.getByRole("combobox", { name: "Status for note" })).toHaveValue("resolved");
 
     const completed = await agent.notes(repository.repoId, "feature");

--- a/packages/app/src/renderer/src/components/NotesDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/NotesDrawer.test.ts
@@ -143,6 +143,55 @@ describe("NotesDrawer", () => {
     expect(wrapper.get("[data-note-id='4'] [aria-label='Waiting on reviewer']").text()).toContain("Choose whether this should retry.");
   });
 
+  it("filters note groups by lifecycle status while keeping both in-progress groups", async () => {
+    const inProgress = {
+      ...notes[0]!,
+      id: 3,
+      state: "in_progress" as const,
+      inProgressNote: null,
+    };
+    const waiting = {
+      ...notes[0]!,
+      id: 4,
+      state: "in_progress" as const,
+      inProgressNote: "Choose whether this should retry.",
+    };
+    const resolved = { ...notes[0]!, id: 5, state: "resolved" as const };
+    const wrapper = mount(NotesDrawer, {
+      props: { store: store([...notes, inProgress, waiting, resolved]), dock: "right" },
+    });
+    const filter = wrapper.get("select[aria-label='Filter notes by status']");
+
+    expect(filter.findAll("option").map((option) => option.text())).toEqual([
+      "All statuses (5)",
+      "Open (1)",
+      "In progress (2)",
+      "Addressed (1)",
+      "Resolved (1)",
+    ]);
+
+    await filter.setValue("in_progress");
+    expect(wrapper.findAll("[data-note-id]").map((note) => note.attributes("data-note-id"))).toEqual(["3", "4"]);
+    expect(wrapper.findAll(".group-heading").map((heading) => heading.text())).toEqual([
+      "In progress 1",
+      "Waiting on you 1",
+    ]);
+
+    await filter.setValue("resolved");
+    expect(wrapper.findAll("[data-note-id]").map((note) => note.attributes("data-note-id"))).toEqual(["5"]);
+    expect(wrapper.get(".group-heading").text()).toBe("Resolved 1");
+  });
+
+  it("keeps the toolbar available when a status has no notes", async () => {
+    const wrapper = mount(NotesDrawer, { props: { store: store(notes), dock: "right" } });
+    await wrapper.get("select[aria-label='Filter notes by status']").setValue("resolved");
+
+    expect(wrapper.get(".filtered-empty").text()).toContain("No notes have this status.");
+    await wrapper.get(".filtered-empty button").trigger("click");
+    expect((wrapper.get("select[aria-label='Filter notes by status']").element as HTMLSelectElement).value).toBe("all");
+    expect(wrapper.findAll("[data-note-id]")).toHaveLength(2);
+  });
+
   it("keeps a note expanded while its state moves between groups", async () => {
     const wrapper = mount(NotesDrawer, { props: { store: store([notes[0]!]), dock: "right" } });
     expect(wrapper.get("[data-note-id='1'] button[aria-expanded]").attributes("aria-expanded")).toBe("true");

--- a/packages/app/src/renderer/src/components/NotesDrawer.vue
+++ b/packages/app/src/renderer/src/components/NotesDrawer.vue
@@ -1,21 +1,33 @@
 <script setup lang="ts">
 import { computed, shallowRef } from "vue";
-import type { Note } from "@gander/shared";
-import { Copy, MessageSquare, PanelBottom, PanelRight, Plus, X } from "@lucide/vue";
+import type { Note, NoteState } from "@gander/shared";
+import { MessageSquare, PanelBottom, PanelRight, Plus, X } from "@lucide/vue";
 import type { Store } from "../store.js";
 import { revealLine } from "../selection.js";
 import NoteItem from "./NoteItem.vue";
+import NotesToolbar, { type NoteStatusFilter } from "./NotesToolbar.vue";
 
 const props = defineProps<{ store: Store; dock: "right" | "bottom" }>();
 const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addNote: [] }>();
 
 const notes = computed(() => props.store.view?.notes ?? []);
+const statusFilter = shallowRef<NoteStatusFilter>("all");
+const statusCounts = computed<Record<NoteStatusFilter, number>>(() => ({
+  all: notes.value.length,
+  open: countNotes("open"),
+  in_progress: countNotes("in_progress"),
+  addressed: countNotes("addressed"),
+  resolved: countNotes("resolved"),
+}));
+const visibleNotes = computed(() => statusFilter.value === "all"
+  ? notes.value
+  : notes.value.filter((note) => note.state === statusFilter.value));
 const noteGroups = computed(() => [
-  { key: "open", label: "Open", notes: notes.value.filter((note) => note.state === "open") },
-  { key: "in-progress", label: "In progress", notes: notes.value.filter((note) => note.state === "in_progress" && note.inProgressNote === null) },
-  { key: "waiting", label: "Waiting on you", notes: notes.value.filter((note) => note.state === "in_progress" && note.inProgressNote !== null) },
-  { key: "addressed", label: "Addressed", notes: notes.value.filter((note) => note.state === "addressed") },
-  { key: "resolved", label: "Resolved", notes: notes.value.filter((note) => note.state === "resolved") },
+  { key: "open", label: "Open", notes: visibleNotes.value.filter((note) => note.state === "open") },
+  { key: "in-progress", label: "In progress", notes: visibleNotes.value.filter((note) => note.state === "in_progress" && note.inProgressNote === null) },
+  { key: "waiting", label: "Waiting on you", notes: visibleNotes.value.filter((note) => note.state === "in_progress" && note.inProgressNote !== null) },
+  { key: "addressed", label: "Addressed", notes: visibleNotes.value.filter((note) => note.state === "addressed") },
+  { key: "resolved", label: "Resolved", notes: visibleNotes.value.filter((note) => note.state === "resolved") },
 ].filter((group) => group.notes.length > 0));
 type NoteRow =
   | { key: string; kind: "heading"; label: string; count: number }
@@ -26,6 +38,10 @@ const noteRows = computed<NoteRow[]>(() => noteGroups.value.flatMap((group) => [
 ]));
 const copiedNoteId = shallowRef<number | null>(null);
 const copiedAll = shallowRef(false);
+
+function countNotes(state: NoteState): number {
+  return notes.value.filter((note) => note.state === state).length;
+}
 
 function goTo(q: { path: string | null; line: number | null }): void {
   if (q.path === null) return;
@@ -84,25 +100,6 @@ async function copyAll(): Promise<void> {
       <h2 class="title">Notes</h2>
       <span class="count">{{ notes.length }}</span>
       <button
-        v-if="notes.length > 0"
-        class="copy-all"
-        aria-label="Copy all notes"
-        title="Copy all notes"
-        @click="copyAll"
-      >
-        <Copy :size="13" aria-hidden="true" />
-        <span>{{ copiedAll ? "Copied" : "Copy all" }}</span>
-      </button>
-      <button
-        class="add"
-        aria-label="Add note (N)"
-        title="Add note (N)"
-        @click="emit('addNote')"
-      >
-        <Plus :size="14" aria-hidden="true" />
-        <span>Add</span>
-      </button>
-      <button
         class="close dockbtn"
         :aria-label="dock === 'right' ? 'Dock notes below the diff' : 'Dock notes beside the diff'"
         :title="dock === 'right' ? 'Dock below the diff' : 'Dock beside the diff'"
@@ -115,12 +112,25 @@ async function copyAll(): Promise<void> {
       </button>
     </header>
 
+    <NotesToolbar
+      v-model="statusFilter"
+      :counts="statusCounts"
+      :copied-all="copiedAll"
+      @copy-all="copyAll"
+      @add-note="emit('addNote')"
+    />
+
     <div v-if="notes.length === 0" class="empty">
       <p>Capture a note about the selected file or line.</p>
       <button type="button" @click="emit('addNote')">
         <Plus :size="14" aria-hidden="true" />
         Add note <kbd>N</kbd>
       </button>
+    </div>
+
+    <div v-else-if="visibleNotes.length === 0" class="empty filtered-empty">
+      <p>No notes have this status.</p>
+      <button type="button" @click="statusFilter = 'all'">Show all notes</button>
     </div>
 
     <ul v-else aria-label="Review notes">
@@ -146,15 +156,7 @@ async function copyAll(): Promise<void> {
 header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--workbench-border); color: var(--muted-foreground); flex: none; }
 .title { margin: 0; font-size: 12px; font-weight: 600; letter-spacing: .3px; text-transform: uppercase; }
 .count { font: 11px var(--mono); background: var(--badge-background); border-radius: var(--radius-pill); padding: 1px 7px; }
-.add, .copy-all {
-  display: flex; align-items: center; gap: 4px;
-  background: none; border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
-  color: var(--workbench-foreground); padding: 3px 7px; font: inherit; font-size: 11px; cursor: pointer;
-}
-.copy-all { margin-left: auto; }
-.add:first-of-type { margin-left: auto; }
-.add:hover, .copy-all:hover { border-color: var(--accent); color: var(--accent); }
-.dockbtn { margin-left: 0; }
+.dockbtn { margin-left: auto; }
 .dockbtn + .close { margin-left: 0; }
 .close { margin-left: auto; background: none; border: none; color: var(--faint-foreground); cursor: pointer; display: flex; }
 .close:hover { color: var(--workbench-foreground); }
@@ -167,7 +169,7 @@ header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; borde
   color: var(--accent-foreground); padding: 5px 9px; font: inherit; font-size: 12px; font-weight: 600; cursor: pointer;
 }
 .empty button kbd { color: var(--workbench-foreground); }
-.add:focus-visible, .copy-all:focus-visible, .empty button:focus-visible, .close:focus-visible {
+.empty button:focus-visible, .close:focus-visible {
   outline: 2px solid var(--accent); outline-offset: 2px;
 }
 kbd { font: 11px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 1px 5px; }
@@ -180,7 +182,4 @@ ul { list-style: none; margin: 0; padding: 0; }
   font: 600 9.5px var(--mono); letter-spacing: .4px; text-transform: uppercase;
 }
 .group-heading span { color: var(--faint-foreground); }
-@container notes (max-width: 330px) {
-  .copy-all span, .add span { display: none; }
-}
 </style>

--- a/packages/app/src/renderer/src/components/NotesToolbar.vue
+++ b/packages/app/src/renderer/src/components/NotesToolbar.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { NoteState } from "@gander/shared";
+import { ChevronDown, Copy, ListFilter, Plus } from "@lucide/vue";
+
+export type NoteStatusFilter = "all" | NoteState;
+
+const props = defineProps<{
+  counts: Record<NoteStatusFilter, number>;
+  copiedAll: boolean;
+}>();
+const filter = defineModel<NoteStatusFilter>({ required: true });
+defineEmits<{ addNote: []; copyAll: [] }>();
+
+const options = computed<{ value: NoteStatusFilter; label: string }[]>(() => [
+  { value: "all", label: `All statuses (${props.counts.all})` },
+  { value: "open", label: `Open (${props.counts.open})` },
+  { value: "in_progress", label: `In progress (${props.counts.in_progress})` },
+  { value: "addressed", label: `Addressed (${props.counts.addressed})` },
+  { value: "resolved", label: `Resolved (${props.counts.resolved})` },
+]);
+</script>
+
+<template>
+  <div class="notes-toolbar" role="toolbar" aria-label="Note display and actions">
+    <label class="status-filter">
+      <ListFilter :size="14" aria-hidden="true" />
+      <select v-model="filter" aria-label="Filter notes by status" :disabled="counts.all === 0">
+        <option v-for="option in options" :key="option.value" :value="option.value">{{ option.label }}</option>
+      </select>
+      <ChevronDown class="filter-chevron" :size="13" aria-hidden="true" />
+    </label>
+
+    <div class="toolbar-actions">
+      <button
+        v-if="counts.all > 0"
+        type="button"
+        aria-label="Copy all notes"
+        title="Copy all notes"
+        @click="$emit('copyAll')"
+      >
+        <Copy :size="13" aria-hidden="true" />
+        <span>{{ copiedAll ? "Copied" : "Copy all" }}</span>
+      </button>
+      <button
+        type="button"
+        aria-label="Add note (N)"
+        title="Add note (N)"
+        @click="$emit('addNote')"
+      >
+        <Plus :size="14" aria-hidden="true" />
+        <span>Add</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.notes-toolbar {
+  flex: none; display: flex; align-items: center; gap: 8px;
+  min-height: 36px; padding: 5px 8px;
+  border-bottom: 1px solid var(--workbench-border);
+  background: var(--input-background);
+}
+.status-filter {
+  position: relative; flex: 0 1 154px; min-width: 112px; height: 26px;
+  display: flex; align-items: center; color: var(--faint-foreground);
+}
+.status-filter > svg:first-child { position: absolute; left: 7px; pointer-events: none; }
+.status-filter select {
+  width: 100%; height: 100%; min-width: 0; appearance: none;
+  padding: 0 25px 0 27px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
+  background: var(--panel-background); color: var(--workbench-foreground);
+  font: inherit; font-size: 11px; cursor: pointer;
+}
+.status-filter:hover select:not(:disabled) { border-color: var(--muted-foreground); }
+.status-filter:focus-within { color: var(--accent); }
+.status-filter select:focus-visible,
+.toolbar-actions button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.status-filter select:disabled { opacity: .5; cursor: default; }
+.filter-chevron { position: absolute; right: 7px; pointer-events: none; }
+.toolbar-actions { display: flex; align-items: center; gap: 4px; margin-left: auto; }
+.toolbar-actions button {
+  height: 26px; display: flex; align-items: center; gap: 4px;
+  padding: 0 7px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md);
+  background: var(--panel-background); color: var(--workbench-foreground);
+  font: inherit; font-size: 11px; white-space: nowrap; cursor: pointer;
+}
+.toolbar-actions button:hover { border-color: var(--accent); color: var(--accent); }
+
+@container notes (max-width: 330px) {
+  .toolbar-actions button { width: 26px; justify-content: center; padding: 0; }
+  .toolbar-actions span { display: none; }
+}
+</style>


### PR DESCRIPTION
## Summary
- add an extensible second-row notes toolbar with status filtering and live counts
- preserve active and waiting-on-reviewer subgroups under the in-progress filter
- keep Copy All and Add responsive while leaving room for future sorting and filter actions
- document that Gander changes are published and opened in Gander so PR review and QA happen together

## Readiness
- Simplify: clean
- Code review: clean, 0 critical findings
- Adversarial review: skipped; low-risk renderer-only change
- Finalize: passed

## Test plan
- pnpm test (407 tests)
- pnpm typecheck
- focused Electron note lifecycle E2E (2 tests)
- visual QA in the Electron renderer at the narrow notes-drawer width
- Impeccable detector on changed Vue components