### PR TITLE
Allow notes to be addressed directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,12 @@ separate from the selected file, because a directory has nothing to show in the 
 passing over one leaves the reader on the file they were already reading.
 
 **Note lifecycle:** `open` (reviewer captures with `n`) → `in_progress` (agent
-claims it over MCP) → `addressed` (agent records the outcome, with an optional
-commit ref) → `resolved` (reviewer re-checks the file). An in-progress note can
-name the reviewer decision blocking it. Resolution is always the reviewer's act;
-no MCP tool may resolve anything. The MCP contract is deliberately three tools —
+claims work that spans time over MCP) → `addressed` (agent records the outcome,
+with an optional commit ref) → `resolved` (reviewer re-checks the file). Work
+completed in one exchange can move directly from `open` to `addressed`. An
+in-progress note can name the reviewer decision blocking it. Resolution is
+always the reviewer's act; no MCP tool may resolve anything. The MCP contract is
+deliberately three tools —
 `get_review_notes`, `mark_note_in_progress`, and `mark_note_addressed`. Agents
 discuss notes with the reviewer in their active session; MCP carries the
 reviewer's notes and the durable work state. Agents have `git` and `gh` for code.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -49,10 +49,11 @@ milestone boundary.
 
 Pressing `n` over a file captures a note against it, stamped with the line
 being read. Notes carry four states: `open` when captured, `in_progress` when an
-agent claims one, `addressed` when the agent records its outcome, and `resolved`
-when the reviewer re-checks the file. A claimed note can record the reviewer
-decision blocking it, and the notes drawer separates those blockers from active
-work.
+agent claims work that spans time, `addressed` when the agent records its
+outcome, and `resolved` when the reviewer re-checks the file. A claimed note can
+record the reviewer decision blocking it, and the notes drawer separates those
+blockers from active work. Work completed in one exchange can move directly
+from `open` to `addressed`.
 The notes drawer lets the reviewer correct note text or explicitly change a
 note's state when the recorded workflow state needs correcting.
 Agents reach them over MCP at `/mcp` on the review service — see `DEVSTACK.md`

--- a/packages/service/contract.json
+++ b/packages/service/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "0.7.0",
   "routes": [
     "DELETE /api/reviews/:repoId/:prNumber/notes/:id",
     "DELETE /mcp",
@@ -707,7 +707,7 @@
     },
     {
       "name": "mark_note_addressed",
-      "description": "Record the outcome after an in-progress note has been acted on. A code change can name its commit; an answered question has no commit. This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
+      "description": "Record the outcome after an open or in-progress note has been acted on. A code change can name its commit; an answered question has no commit. This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/packages/service/src/mcp.test.ts
+++ b/packages/service/src/mcp.test.ts
@@ -137,12 +137,11 @@ describe("MCP endpoint", () => {
     await client.close();
   });
 
-  it("marks a note addressed, and the state is really in storage", async () => {
+  it("marks an open note addressed without claiming it first", async () => {
     storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
     const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null, sourceContext: null });
 
     const client = await connect();
-    await client.callTool({ name: "mark_note_in_progress", arguments: { id: q.id } });
     await client.callTool({
       name: "mark_note_addressed",
       arguments: { id: q.id, commitRef: "abc1234", summary: "Dropped the retry" },
@@ -206,11 +205,26 @@ describe("MCP endpoint", () => {
     await client.close();
   });
 
-  it("refuses to mark a note that is not in progress", async () => {
+  it("distinguishes missing, addressed, and resolved notes when addressing fails", async () => {
+    const addressed = storage.addNote("acme/atlas", 7, { path: "addressed.rb", line: null, text: "Address me", headSha: null, sourceContext: null });
+    storage.markNoteAddressed(addressed.id, { commitRef: null, summary: "Done" });
+    const resolved = storage.addNote("acme/atlas", 7, { path: "resolved.rb", line: null, text: "Resolve me", headSha: null, sourceContext: null });
+    storage.markNoteAddressed(resolved.id, { commitRef: null, summary: "Done" });
+    storage.putFileState("acme/atlas", 7, {
+      checked: true, path: "resolved.rb", baseHash: "b", headHash: "h",
+      baseContent: "old", headContent: "new", machine: "test",
+    });
+
     const client = await connect();
-    const result = await client.callTool({ name: "mark_note_addressed", arguments: { id: 999, summary: "Nothing to change" } });
-    expect(result.isError).toBe(true);
-    expect(textOf(result as { content?: unknown })).toContain("not in progress");
+    for (const [id, message] of [
+      [999, "Note 999 does not exist."],
+      [addressed.id, `Note ${addressed.id} is already addressed.`],
+      [resolved.id, `Note ${resolved.id} is already resolved.`],
+    ] as const) {
+      const result = await client.callTool({ name: "mark_note_addressed", arguments: { id, summary: "Nothing to change" } });
+      expect(result.isError).toBe(true);
+      expect(textOf(result as { content?: unknown })).toBe(message);
+    }
     await client.close();
   });
 

--- a/packages/service/src/mcp.ts
+++ b/packages/service/src/mcp.ts
@@ -162,7 +162,7 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
     {
       title: "Mark a review note addressed",
       description:
-        "Record the outcome after an in-progress note has been acted on. A code change can name its commit; an answered question has no commit. " +
+        "Record the outcome after an open or in-progress note has been acted on. A code change can name its commit; an answered question has no commit. " +
         "This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
       inputSchema: {
         id: z.number().int().positive().describe("Note id from get_review_notes."),
@@ -173,8 +173,12 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
     async ({ id, commitRef, summary }) => {
       const marked = storage.markNoteAddressed(id, { commitRef: commitRef ?? null, summary: summary ?? null });
       if (marked === null) {
+        const state = storage.getNoteState(id);
+        const message = state === null
+          ? `Note ${id} does not exist.`
+          : `Note ${id} is already ${state}.`;
         return {
-          content: [{ type: "text", text: `Note ${id} is not in progress — it does not exist, is still open, or was already addressed or resolved.` }],
+          content: [{ type: "text", text: message }],
           isError: true,
         };
       }

--- a/packages/service/src/storage.test.ts
+++ b/packages/service/src/storage.test.ts
@@ -132,10 +132,10 @@ describe("storage", () => {
 
     it("an agent marks a note addressed with a commit and note", () => {
       const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why the retry?", headSha: null, sourceContext: null });
-      expect(storage.markNoteAddressed(q.id, { commitRef: "abc1234", summary: "Dropped the retry" })).toBeNull();
-      storage.markNoteInProgress(q.id, { note: null });
       const marked = storage.markNoteAddressed(q.id, { commitRef: "abc1234", summary: "Dropped the retry" });
       expect(marked).toMatchObject({ state: "addressed", commitRef: "abc1234", summary: "Dropped the retry" });
+      expect(storage.getNoteState(q.id)).toBe("addressed");
+      expect(storage.getNoteState(999)).toBeNull();
     });
 
     it("claims a note, records why it is waiting, then addresses it without a commit", () => {

--- a/packages/service/src/storage.ts
+++ b/packages/service/src/storage.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { gzipSync, gunzipSync } from "node:zlib";
-import type { FileCheckoff, MarkAddressed, MarkInProgress, NewNote, PrContext, PutFileState, Note, ReviewState, UpdateNote } from "@gander/shared";
+import type { FileCheckoff, MarkAddressed, MarkInProgress, NewNote, NoteState, PrContext, PutFileState, Note, ReviewState, UpdateNote } from "@gander/shared";
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS reviews (
@@ -56,6 +56,7 @@ export interface Storage {
   /** Every pull request recorded as part of the same stack, with how many open notes each holds. */
   listStackMembers(repoId: string, stackId: number): Array<{ prNumber: number; headRef: string | null; title: string | null; position: number | null; openNotes: number }>;
   findPrByHeadRef(repoId: string, headRef: string): number | null;
+  getNoteState(id: number): NoteState | null;
   markNoteInProgress(id: number, input: MarkInProgress): Note | null;
   markNoteAddressed(id: number, input: MarkAddressed): Note | null;
   listNotes(repoId: string, prNumber: number): Note[];
@@ -197,6 +198,11 @@ export function openStorage(dbPath: string): Storage {
       return row?.pr_number ?? null;
     },
 
+    getNoteState(id) {
+      const row = db.prepare("SELECT state FROM notes WHERE id = ?").get(id) as { state: NoteState } | undefined;
+      return row?.state ?? null;
+    },
+
     markNoteInProgress(id, input) {
       // Calling the claim tool again updates whether already-started work is active or
       // waiting, without manufacturing another state transition.
@@ -210,12 +216,12 @@ export function openStorage(dbPath: string): Storage {
     },
 
     markNoteAddressed(id, input) {
-      // Only claimed work can be addressed. Re-addressing a resolved one would
-      // undo the reviewer's own act, and the spec puts resolution solely in their hands.
+      // Claiming is useful for work that spans time, but a note handled in one exchange
+      // can go straight from open to addressed. Neither path may undo reviewer resolution.
       const changed = db.prepare(`
         UPDATE notes
         SET state = 'addressed', in_progress_note = NULL, commit_ref = ?, summary = ?, addressed_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-        WHERE id = ? AND state = 'in_progress'
+        WHERE id = ? AND state IN ('open', 'in_progress')
       `).run(input.commitRef, input.summary, id).changes;
       if (changed === 0) return null;
       return rowToNote(db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(id) as NoteRow);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
  *
  * Not the app's release version: releases happen far more often than the contract moves.
  */
-export const SERVICE_VERSION = "0.6.0";
+export const SERVICE_VERSION = "0.7.0";
 
 export const FileStatusSchema = z.enum(["A", "M", "D", "R"]);
 export type FileStatus = z.infer<typeof FileStatusSchema>;


### PR DESCRIPTION
## Summary
- allow mark_note_addressed to move open or in-progress notes to addressed
- return specific errors for missing, addressed, and resolved notes
- bump the service contract to 0.7.0 and document the direct transition

## Verification
- pnpm typecheck
- pnpm test (405 tests)
- focused regression test proven against the old transition rule
- adversarial review clean

Closes #120