### PR TITLE
Accept large review snapshots

### DIFF
--- a/packages/service/src/server.test.ts
+++ b/packages/service/src/server.test.ts
@@ -51,6 +51,18 @@ describe("service API", () => {
     expect(listed.json()).toEqual([expect.objectContaining({ repoId: "acme/atlas", prNumber: 7 })]);
   });
 
+  it("stores a snapshot whose two text revisions exceed Fastify's default body limit", async () => {
+    const baseContent = "a".repeat(600 * 1024);
+    const headContent = "b".repeat(600 * 1024);
+    const put = await server.inject({
+      method: "PUT", url: "/api/reviews/acme%2Fatlas/7/files", headers: AUTH,
+      payload: { checked: true, path: "pnpm-lock.yaml", baseHash: "b1", headHash: "h1", baseContent, headContent, machine: "studio" },
+    });
+
+    expect(put.statusCode).toBe(200);
+    expect(storage.getSnapshot("acme/atlas", 7, "pnpm-lock.yaml")).toEqual({ baseContent, headContent });
+  });
+
   it("rejects a malformed PUT body with 400 and the zod message", async () => {
     const res = await server.inject({
       method: "PUT", url: "/api/reviews/acme%2Fatlas/7/files", headers: AUTH,

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -4,6 +4,11 @@ import { NewNoteSchema, PrContextSchema, PutFileStateSchema, UpdateNoteSchema } 
 import { handleMcpRequest } from "./mcp.js";
 import type { Storage } from "./storage.js";
 
+// A checkoff carries both diff sides. Generated text files such as lockfiles can
+// exceed Fastify's 1 MiB default even though either revision is ordinary review
+// content. Keep the larger bound on this route instead of every authenticated write.
+const FILE_SNAPSHOT_BODY_LIMIT = 16 * 1024 * 1024;
+
 /** Sends a 400 and returns undefined when the segment is not a positive integer. */
 function positiveInt(name: string, raw: string, reply: FastifyReply): number | undefined {
   const n = Number(raw);
@@ -63,6 +68,7 @@ export function buildServer(opts: {
 
   app.put<{ Params: { repoId: string; prNumber: string } }>(
     "/api/reviews/:repoId/:prNumber/files",
+    { bodyLimit: FILE_SNAPSHOT_BODY_LIMIT },
     async (req, reply) => {
       const prNumber = positiveInt("prNumber", req.params.prNumber, reply);
       if (prNumber === undefined) return;


### PR DESCRIPTION
## Summary
- allow file checkoff payloads up to 16 MiB on the snapshot route
- retain Fastify's default request limit for other service writes
- cover a two-revision snapshot larger than the default 1 MiB limit

## Verification
- pnpm typecheck
- pnpm test (61 files, 410 tests)
- pnpm test:e2e (19 tests)