### PR TITLE
Move note capture into the notes pane

### DIFF
--- a/packages/app/e2e/drivers/review.ts
+++ b/packages/app/e2e/drivers/review.ts
@@ -41,6 +41,7 @@ export class ReviewDriver {
 
   async addNote(text: string): Promise<void> {
     await this.page.getByRole("button", { name: "Add note (N)" }).click();
+    await expect(this.page.getByRole("complementary", { name: "Notes" })).toBeVisible();
     const input = this.page.getByPlaceholder("What needs answering or changing here?");
     await input.fill(text);
     await input.press("Enter");
@@ -48,8 +49,9 @@ export class ReviewDriver {
   }
 
   async openNotes(): Promise<void> {
-    await this.page.getByRole("button", { name: "Notes", exact: true }).click();
-    await expect(this.page.getByRole("heading", { name: "Notes", exact: true })).toBeVisible();
+    const heading = this.page.getByRole("heading", { name: "Notes", exact: true });
+    if (!await heading.isVisible()) await this.page.getByRole("button", { name: "Notes", exact: true }).click();
+    await expect(heading).toBeVisible();
   }
 
   async expectProgress(done: number, total: number): Promise<void> {

--- a/packages/app/e2e/drivers/workbench.ts
+++ b/packages/app/e2e/drivers/workbench.ts
@@ -4,7 +4,7 @@ export class WorkbenchDriver {
   constructor(readonly page: Page) {}
 
   async openPullRequests(): Promise<void> {
-    const button = this.page.getByRole("button", { name: "Pull Requests" });
+    const button = this.page.getByRole("button", { name: "Pull Requests", exact: true });
     await expect(button).toBeEnabled();
     await button.click();
     await expect(this.page.getByRole("complementary", { name: "Pull Requests" })).toBeVisible();

--- a/packages/app/e2e/keyboard-focus.spec.ts
+++ b/packages/app/e2e/keyboard-focus.spec.ts
@@ -23,10 +23,13 @@ test("routes review shortcuts from Monaco without stealing typed note text", asy
   await expect(note).toHaveValue("Keep this letter: m");
   await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "false");
   await note.press("Escape");
+  await expect(app.page.getByRole("heading", { name: "Notes", exact: true })).toBeVisible();
 
   await editor.click();
   await app.page.keyboard.press("m");
   await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "true");
+  await app.page.keyboard.press("Shift+N");
+  await expect(app.page.getByRole("heading", { name: "Notes", exact: true })).toHaveCount(0);
   await app.page.keyboard.press("Shift+N");
   await expect(app.page.getByRole("heading", { name: "Notes", exact: true })).toBeVisible();
 
@@ -36,5 +39,5 @@ test("routes review shortcuts from Monaco without stealing typed note text", asy
   await editor.click();
   await app.page.keyboard.press("]");
   await app.page.keyboard.press("n");
-  await expect(app.page.locator("#note-target")).toContainText("line 2");
+  await expect(app.page.getByRole("form", { name: "New note" })).toContainText("a.rb:2");
 });

--- a/packages/app/e2e/note-lifecycle.spec.ts
+++ b/packages/app/e2e/note-lifecycle.spec.ts
@@ -2,6 +2,40 @@ import { test, expect } from "./fixtures/test.js";
 import { McpDriver } from "./drivers/mcp.js";
 import { ReviewDriver } from "./drivers/review.js";
 
+test("keeps the code and target visible while composing a note", async ({ world }) => {
+  const repository = await world.addRepository({ repoId: "acme/inline-note-composer" });
+  const otherRepository = await world.addRepository({ repoId: "acme/other-review" });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+
+  await review.open(repository.title);
+  await review.selectFile("a.rb");
+  await app.page.getByRole("button", { name: "Add note (N)" }).click();
+
+  const drawer = app.page.getByRole("complementary", { name: "Notes" });
+  const composer = drawer.getByRole("form", { name: "New note" });
+  const input = composer.getByRole("textbox", { name: "Note text" });
+  await expect(drawer).toBeVisible();
+  await expect(composer).toContainText("a.rb:1");
+  await expect(app.page.locator(".monaco-editor:visible").first()).toBeVisible();
+  await expect(app.page.getByRole("dialog")).toHaveCount(0);
+  await drawer.getByRole("button", { name: "Dock notes below the diff" }).click();
+
+  await input.fill("Preserve this unfinished thought");
+  await drawer.getByRole("button", { name: "Close notes" }).click();
+  await expect(drawer).toHaveCount(0);
+  await expect(app.page.locator(".monaco-editor:visible").first()).toBeVisible();
+
+  await review.openNotes();
+  await expect(input).toBeFocused();
+  await expect(input).toHaveValue("Preserve this unfinished thought");
+
+  await review.workbench.selectRepository(otherRepository.repoId);
+  await expect(app.page.locator(".context-title strong")).toHaveText("other-review");
+  await review.open(otherRepository.title);
+  await expect(composer).toHaveCount(0);
+});
+
 test("carries a reviewer note through MCP addressing and reviewer resolution", async ({ world }) => {
   const repository = await world.addRepository({ repoId: "acme/note-lifecycle" });
   const app = await world.launch();

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -16,7 +16,6 @@ import ActivityRail from "./components/ActivityRail.vue";
 import ConfirmDialog from "./components/ConfirmDialog.vue";
 import KeymapHelp from "./components/KeymapHelp.vue";
 import LocalSurface from "./components/LocalSurface.vue";
-import NoteCapture from "./components/NoteCapture.vue";
 import ReviewSurface from "./components/ReviewSurface.vue";
 import SettingsPane from "./components/SettingsPane.vue";
 import StatusBar from "./components/StatusBar.vue";
@@ -34,6 +33,8 @@ const { level: zoomLevel, change: changeZoom } = useWindowZoom(api);
 const integratedTitleBar = api.initialWindowState.windowStyle === "integrated-titlebar";
 
 const noteTarget = shallowRef<NoteTarget | null>(null);
+const noteDraft = shallowRef("");
+const noteFocusRequest = shallowRef(0);
 const drawerOpen = ref(false);
 const treeVisible = ref(true);
 const helpOpen = ref(false);
@@ -61,16 +62,33 @@ onMounted(() => { void editorSettings.load(); });
 watch(activeMode, (mode) => {
   if (mode === "pulls") return;
   drawerOpen.value = false;
-  noteTarget.value = null;
+  closeNote();
+});
+
+watch(() => [store.targetRepoId, store.selectedPrNumber] as const, ([repoId, prNumber], previous) => {
+  if (repoId === previous[0] && prNumber === previous[1]) return;
+  // A draft belongs to the review where it began. The pane no longer blocks navigation,
+  // so switching reviews must not carry that target into a different pull request.
+  closeNote();
 });
 
 /** Opens the note editor. Without a target, the note lands on wherever the reviewer is. */
 function openNote(target?: NoteTarget): void {
   if (!store.view || activeMode.value !== "pulls") return;
+  drawerOpen.value = true;
+  noteFocusRequest.value += 1;
+  // One draft has one stable target. Repeating the shortcut focuses it instead of
+  // silently moving an unfinished note to whichever file the reviewer visits next.
+  if (noteTarget.value !== null) return;
   noteTarget.value = target ?? {
     path: store.selectedPath,
     line: store.selectedPath === null ? null : currentLine.value,
   };
+}
+
+function closeNote(): void {
+  noteTarget.value = null;
+  noteDraft.value = "";
 }
 
 async function confirmRemoveRepo(): Promise<void> {
@@ -139,11 +157,15 @@ async function confirmRemoveRepo(): Promise<void> {
           v-else
           ref="reviewSurface"
           v-model:drawer-open="drawerOpen"
+          v-model:note-draft="noteDraft"
           :store="store"
           :editor-settings="editorSettings.settings.editor"
           :repo-name="repoName"
+          :note-target="noteTarget"
+          :note-focus-request="noteFocusRequest"
           @choose-repo="chooseRepo()"
           @add-note="openNote"
+          @close-note="closeNote"
         />
       </div>
     </main>
@@ -158,7 +180,6 @@ async function confirmRemoveRepo(): Promise<void> {
       @change-zoom="changeZoom"
       @open-zoom-settings="openSettings('workbench')"
     />
-    <NoteCapture :store="store" :target="noteTarget" @close="noteTarget = null" />
     <KeymapHelp v-if="helpOpen" @close="helpOpen = false" />
     <ConfirmDialog
       :open="repoPendingRemoval !== null"

--- a/packages/app/src/renderer/src/components/NoteCapture.test.ts
+++ b/packages/app/src/renderer/src/components/NoteCapture.test.ts
@@ -5,7 +5,7 @@ import type { Store } from "../store.js";
 import NoteCapture from "./NoteCapture.vue";
 
 describe("NoteCapture", () => {
-  it("opens as a substantial, described writing surface", () => {
+  it("opens as a compact, non-modal writing surface with a visible target", () => {
     const store = {
       selectedPath: "src/review.ts",
       addNote: vi.fn(),
@@ -15,9 +15,13 @@ describe("NoteCapture", () => {
     });
 
     const note = wrapper.get("textarea");
-    expect(note.attributes("rows")).toBe("12");
+    expect(note.attributes("rows")).toBe("4");
+    expect(note.attributes("aria-label")).toBe("Note text");
     expect(note.attributes("aria-describedby")).toBe("note-capture-hint");
-    expect(wrapper.get("label").attributes("for")).toBe(note.attributes("id"));
+    expect(wrapper.get("form").attributes("role")).toBe("form");
+    expect(wrapper.find("[role='dialog']").exists()).toBe(false);
+    expect(wrapper.get("button.target").text()).toBe("review.ts:12");
+    expect(wrapper.text()).toContain("src/review.ts");
 
     wrapper.unmount();
   });
@@ -35,7 +39,7 @@ describe("NoteCapture", () => {
       },
     });
 
-    expect(wrapper.get("label").text()).toContain("reviewed-file.ts · line 17");
+    expect(wrapper.get("button.target").text()).toBe("reviewed-file.ts:17");
     await wrapper.get("textarea").setValue("Keep this anchor");
     await wrapper.get("form").trigger("submit");
 
@@ -84,5 +88,17 @@ describe("NoteCapture", () => {
     await wrapper.get("form").trigger("submit");
 
     expect(addNote).toHaveBeenCalledWith("Across the whole PR", null, null);
+  });
+
+  it("returns to its frozen file and line without changing the draft", async () => {
+    const store = { addNote: vi.fn() } as unknown as Store;
+    const target = { path: "src/review.ts", line: 12 };
+    const wrapper = mount(NoteCapture, { props: { store, target } });
+
+    await wrapper.get("textarea").setValue("Keep this draft");
+    await wrapper.get("button.target").trigger("click");
+
+    expect(wrapper.emitted("navigate")).toEqual([[target]]);
+    expect((wrapper.get("textarea").element as HTMLTextAreaElement).value).toBe("Keep this draft");
   });
 });

--- a/packages/app/src/renderer/src/components/NoteCapture.vue
+++ b/packages/app/src/renderer/src/components/NoteCapture.vue
@@ -1,22 +1,33 @@
 <script setup lang="ts">
 import { computed, nextTick, shallowRef, useTemplateRef, watch } from "vue";
 import type { Store } from "../store.js";
+import { basename } from "../paths.js";
 import type { NoteTarget } from "../selection.js";
 
-const props = defineProps<{ store: Store; target: NoteTarget | null }>();
-const emit = defineEmits<{ close: [] }>();
+const props = withDefaults(defineProps<{
+  store: Store;
+  target: NoteTarget;
+  dock?: "right" | "bottom";
+  focusRequest?: number;
+}>(), {
+  dock: "right",
+  focusRequest: 0,
+});
+const emit = defineEmits<{ close: []; navigate: [target: NoteTarget] }>();
+const text = defineModel<string>({ default: "" });
 
-const text = shallowRef("");
 const saving = shallowRef(false);
 const canSave = computed(() => text.value.trim().length > 0 && !saving.value);
+const targetName = computed(() => props.target.path === null ? "This pull request" : basename(props.target.path));
+const targetLocation = computed(() => props.target.line === null ? targetName.value : `${targetName.value}:${props.target.line}`);
+const targetDetail = computed(() => props.target.path ?? "Applies to the entire pull request");
+const showTargetDetail = computed(() => props.target.path === null || props.target.path !== targetName.value);
 const box = useTemplateRef<HTMLTextAreaElement>("box");
 
-watch(() => props.target, async (target) => {
-  if (target === null) return;
-  text.value = "";
+watch(() => props.focusRequest, async () => {
   await nextTick();
   box.value?.focus();
-});
+}, { immediate: true });
 
 async function submit(): Promise<void> {
   if (!canSave.value) return;
@@ -25,7 +36,7 @@ async function submit(): Promise<void> {
   // must keep the line it named even if Monaco's cursor or the selected file moves.
   saving.value = true;
   try {
-    await props.store.addNote(body, props.target?.path ?? null, props.target?.line ?? null);
+    await props.store.addNote(body, props.target.path, props.target.line);
     emit("close");
   } finally {
     saving.value = false;
@@ -34,59 +45,73 @@ async function submit(): Promise<void> {
 </script>
 
 <template>
-  <div v-if="target" class="capture" @click.self="$emit('close')">
-    <form class="panel" role="dialog" aria-modal="true" aria-labelledby="note-target" @submit.prevent="submit">
-      <label id="note-target" class="context" for="note-text">
-        Note on
-        <b>{{ target.path ?? "this pull request" }}</b>
-        <template v-if="target.line !== null"> · line {{ target.line }}</template>
-      </label>
+  <form class="capture" :class="dock" role="form" aria-labelledby="note-composer-title" @submit.prevent="submit">
+    <div class="context">
+      <h3 id="note-composer-title">New note</h3>
+      <button
+        v-if="target.path"
+        type="button"
+        class="target"
+        :title="`Return to ${target.path}${target.line === null ? '' : `:${target.line}`}`"
+        @click="emit('navigate', target)"
+      >
+        {{ targetLocation }}
+      </button>
+      <span v-else class="target-label">{{ targetLocation }}</span>
+      <span v-if="showTargetDetail" class="path" :title="targetDetail">{{ targetDetail }}</span>
+    </div>
+    <div class="writing">
       <!-- Enter submits, Shift+Enter breaks the line: capture must cost one keystroke. -->
       <textarea
         ref="box"
         id="note-text"
         v-model="text"
         class="note"
-        rows="12"
+        rows="4"
+        aria-label="Note text"
         aria-describedby="note-capture-hint"
         placeholder="What needs answering or changing here?"
         @keydown.enter.exact.prevent="submit"
         @keydown.esc.prevent="$emit('close')"
       />
-      <div class="footer">
-        <div id="note-capture-hint" class="hint">
-          <kbd>Enter</kbd> to save · <kbd>Shift</kbd>+<kbd>Enter</kbd> for a new line · <kbd>Esc</kbd> to cancel
-        </div>
-        <div class="actions">
-          <button type="button" class="cancel" @click="$emit('close')">Cancel</button>
-          <button type="submit" class="save" :disabled="!canSave">
-            {{ saving ? "Saving…" : "Save" }}
-          </button>
-        </div>
+      <div id="note-capture-hint" class="hint">
+        <kbd>Enter</kbd> save · <kbd>⇧ Enter</kbd> new line · <kbd>Esc</kbd> cancel
       </div>
-    </form>
-  </div>
+    </div>
+    <div class="actions">
+      <button type="button" class="cancel" @click="emit('close')">Cancel</button>
+      <button type="submit" class="save" :disabled="!canSave">
+        {{ saving ? "Saving…" : "Save" }}
+      </button>
+    </div>
+  </form>
 </template>
 
 <style scoped>
-.capture { position: fixed; inset: 0; background: var(--overlay-background); display: flex; align-items: center; justify-content: center; padding: clamp(16px, 8vh, 72px) clamp(16px, 5vw, 72px); z-index: 50; }
-.panel { width: min(960px, 100%); max-height: 100%; background: var(--panel-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-lg); padding: 20px; display: flex; flex-direction: column; gap: 14px; box-shadow: 0 18px 50px var(--workbench-shadow); }
-.context { font-size: 13px; color: var(--faint-foreground); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.context b { color: var(--workbench-foreground); font-weight: 600; }
-.note { width: 100%; height: clamp(180px, 42vh, 420px); min-height: 120px; max-height: calc(100vh - 160px); background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-md); color: var(--workbench-foreground); caret-color: var(--accent); font: inherit; font-size: 14px; line-height: 1.6; padding: 14px 16px; resize: vertical; }
+.capture { display: flex; flex: none; flex-direction: column; gap: 9px; padding: 11px 10px 10px; border-bottom: 1px solid var(--workbench-border); background: color-mix(in srgb, var(--accent) 4%, var(--panel-background)); }
+.context { display: grid; min-width: 0; grid-template-columns: minmax(0, auto) 1fr; align-items: baseline; gap: 4px 8px; }
+.context h3 { grid-column: 1 / -1; margin: 0; color: var(--workbench-foreground); font-size: 12px; font-weight: 650; }
+.target, .target-label { min-width: 0; color: var(--accent); font: 600 11.5px var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.target { width: fit-content; max-width: 100%; padding: 0; border: 0; background: none; cursor: pointer; text-align: left; }
+.target:hover { text-decoration: underline; text-underline-offset: 3px; }
+.path { min-width: 0; overflow: hidden; color: var(--faint-foreground); font: 10.5px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.writing { min-width: 0; }
+.note { box-sizing: border-box; width: 100%; min-height: 82px; max-height: 180px; background: var(--input-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-md); color: var(--workbench-foreground); caret-color: var(--accent); font: inherit; font-size: 12.5px; line-height: 1.5; padding: 8px 9px; resize: vertical; }
 .note::selection { background: var(--selection-background); }
 .note:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
-.footer { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-.hint { font-size: 11px; color: var(--faint-foreground); }
-kbd { font: 10.5px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 1px 5px; }
+.hint { margin-top: 5px; color: var(--faint-foreground); font-size: 9.5px; line-height: 1.4; }
+kbd { font: 9px var(--mono); background: var(--badge-background); border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); padding: 1px 3px; }
 .actions { display: flex; flex: none; gap: 8px; }
-button { height: 30px; padding: 0 14px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 12px; cursor: pointer; }
-button:hover:not(:disabled) { border-color: var(--accent); }
-button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
-button:disabled { opacity: .55; cursor: default; }
+.actions button { height: 28px; padding: 0 11px; border: 1px solid var(--workbench-border); border-radius: var(--radius-md); background: var(--input-background); color: var(--workbench-foreground); font: inherit; font-size: 11px; cursor: pointer; }
+.actions button:hover:not(:disabled) { border-color: var(--accent); }
+.target:focus-visible, .actions button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.actions button:disabled { opacity: .55; cursor: default; }
 .save { border-color: var(--accent); background: var(--accent); color: var(--accent-foreground); font-weight: 600; }
 
-@media (max-width: 620px) {
-  .footer { align-items: flex-end; flex-direction: column; }
+@container notes (min-width: 620px) {
+  .capture.bottom { display: grid; grid-template-columns: minmax(150px, .32fr) minmax(260px, 1fr) auto; align-items: end; gap: 10px; }
+  .capture.bottom .context { display: flex; flex-direction: column; align-self: stretch; justify-content: center; gap: 4px; }
+  .capture.bottom .context h3 { margin-bottom: 2px; }
+  .capture.bottom .note { min-height: 64px; height: 64px; resize: none; }
 }
 </style>

--- a/packages/app/src/renderer/src/components/NotesDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/NotesDrawer.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrView } from "@gander/shared";
 import type { Store } from "../store.js";
@@ -84,6 +84,32 @@ describe("NotesDrawer", () => {
     await actions[1]!.trigger("click");
 
     expect(wrapper.emitted("addNote")).toHaveLength(1);
+  });
+
+  it("embeds the active composer above the note controls", async () => {
+    const addNote = vi.fn(async () => {});
+    const wrapper = mount(NotesDrawer, {
+      props: {
+        store: store([], { addNote }),
+        dock: "right",
+        noteTarget: { path: "src/review.ts", line: 12 },
+        noteFocusRequest: 1,
+        noteDraft: "Keep the code visible",
+      },
+    });
+
+    const composer = wrapper.get("[role='form'][aria-labelledby='note-composer-title']");
+    expect(composer.find("[role='dialog']").exists()).toBe(false);
+    expect(composer.text()).toContain("review.ts:12");
+    expect(wrapper.find(".notes-toolbar").exists()).toBe(true);
+    expect(wrapper.find(".empty").exists()).toBe(false);
+
+    expect((composer.get("textarea").element as HTMLTextAreaElement).value).toBe("Keep the code visible");
+    await composer.trigger("submit");
+    await flushPromises();
+
+    expect(addNote).toHaveBeenCalledWith("Keep the code visible", "src/review.ts", 12);
+    expect(wrapper.emitted("closeNote")).toHaveLength(1);
   });
 
   it("keeps the header add action when notes are populated", async () => {

--- a/packages/app/src/renderer/src/components/NotesDrawer.vue
+++ b/packages/app/src/renderer/src/components/NotesDrawer.vue
@@ -3,13 +3,24 @@ import { computed, shallowRef } from "vue";
 import type { Note, NoteState } from "@gander/shared";
 import { MessageSquare, PanelBottom, PanelRight, Plus, X } from "@lucide/vue";
 import type { Store } from "../store.js";
+import type { NoteTarget } from "../selection.js";
 import { revealLine } from "../selection.js";
 import { revealReviewFile } from "../tree-nav.js";
+import NoteCapture from "./NoteCapture.vue";
 import NoteItem from "./NoteItem.vue";
 import NotesToolbar, { type NoteStatusFilter } from "./NotesToolbar.vue";
 
-const props = defineProps<{ store: Store; dock: "right" | "bottom" }>();
-const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addNote: [] }>();
+const props = withDefaults(defineProps<{
+  store: Store;
+  dock: "right" | "bottom";
+  noteTarget?: NoteTarget | null;
+  noteFocusRequest?: number;
+}>(), {
+  noteTarget: null,
+  noteFocusRequest: 0,
+});
+const noteDraft = defineModel<string>("noteDraft", { default: "" });
+const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addNote: []; closeNote: [] }>();
 
 const notes = computed(() => props.store.view?.notes ?? []);
 const statusFilter = shallowRef<NoteStatusFilter>("all");
@@ -114,6 +125,17 @@ async function copyAll(): Promise<void> {
       </button>
     </header>
 
+    <NoteCapture
+      v-if="noteTarget"
+      v-model="noteDraft"
+      :store="store"
+      :target="noteTarget"
+      :dock="dock"
+      :focus-request="noteFocusRequest"
+      @navigate="goTo"
+      @close="emit('closeNote')"
+    />
+
     <NotesToolbar
       v-model="statusFilter"
       :counts="statusCounts"
@@ -122,7 +144,7 @@ async function copyAll(): Promise<void> {
       @add-note="emit('addNote')"
     />
 
-    <div v-if="notes.length === 0" class="empty">
+    <div v-if="notes.length === 0 && !noteTarget" class="empty">
       <p>Capture a note about the selected file or line.</p>
       <button type="button" @click="emit('addNote')">
         <Plus :size="14" aria-hidden="true" />
@@ -130,12 +152,12 @@ async function copyAll(): Promise<void> {
       </button>
     </div>
 
-    <div v-else-if="visibleNotes.length === 0" class="empty filtered-empty">
+    <div v-else-if="notes.length > 0 && visibleNotes.length === 0" class="empty filtered-empty">
       <p>No notes have this status.</p>
       <button type="button" @click="statusFilter = 'all'">Show all notes</button>
     </div>
 
-    <ul v-else aria-label="Review notes">
+    <ul v-else-if="notes.length > 0" aria-label="Review notes">
       <template v-for="row in noteRows" :key="row.key">
         <li v-if="row.kind === 'heading'" class="group-heading" role="presentation">{{ row.label }} <span>{{ row.count }}</span></li>
         <NoteItem

--- a/packages/app/src/renderer/src/components/ReviewSurface.vue
+++ b/packages/app/src/renderer/src/components/ReviewSurface.vue
@@ -17,10 +17,14 @@ const props = defineProps<{
   editorSettings: EditorSettings;
   repoName: string;
   drawerOpen: boolean;
+  noteTarget: NoteTarget | null;
+  noteFocusRequest: number;
 }>();
+const noteDraft = defineModel<string>("noteDraft", { required: true });
 const emit = defineEmits<{
   chooseRepo: [];
   addNote: [target?: NoteTarget];
+  closeNote: [];
   "update:drawerOpen": [open: boolean];
 }>();
 
@@ -76,13 +80,17 @@ defineExpose({
       <template v-if="drawerOpen">
         <Splitter v-model="notesSize" :orientation="notesDock === 'right' ? 'vertical' : 'horizontal'" :min="notesDock === 'right' ? 220 : 120" :max="700" inverted />
         <NotesDrawer
+          v-model:note-draft="noteDraft"
           :store="store"
           class="drawer"
           :dock="notesDock"
+          :note-target="noteTarget"
+          :note-focus-request="noteFocusRequest"
           :style="notesDock === 'right' ? { width: `${notesWidth}px` } : { height: `${notesHeight}px` }"
           @dock="notesDock = $event"
           @close="emit('update:drawerOpen', false)"
           @add-note="emit('addNote')"
+          @close-note="emit('closeNote')"
         />
       </template>
     </div>


### PR DESCRIPTION
## Summary
- replace the blocking note modal with a compact composer inside the Notes pane
- keep code, the frozen file and line target, and unfinished drafts visible while reviewing
- support both right and bottom docking and clear drafts when the reviewer changes reviews

## Verification
- pnpm typecheck
- pnpm test (61 files, 412 tests)
- pnpm test:e2e (19 passed before the corrected keyboard expectation; that test then passed focused)
- focused note and keyboard Electron pass (5 tests, with the new cross-review assertion rerun green)
- visual verification in right and bottom dock positions
- Impeccable detector: no findings