### PR TITLE
Make the activity rail order customizable

### DIFF
--- a/packages/app/e2e/activity-rail.spec.ts
+++ b/packages/app/e2e/activity-rail.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "./fixtures/test.js";
+
+test("reorders workspace views by dragging and remembers the order", async ({ world }) => {
+  await world.addLocalRepository({ repoId: "acme/activity-rail" });
+  const app = await world.launch();
+  const rail = app.page.getByRole("navigation", { name: "Workspace views" });
+  const activityLabels = async (): Promise<string[]> => rail.locator(".rail-action").evaluateAll((buttons) => (
+    buttons.map((button) => button.getAttribute("aria-label") ?? "")
+  ));
+
+  await expect.poll(activityLabels).toEqual(["Pull Requests", "Explorer", "Current Diff", "Editor settings"]);
+
+  const pulls = rail.getByRole("button", { name: "Pull Requests" });
+  const explorer = rail.getByRole("button", { name: "Explorer" });
+  await pulls.dragTo(explorer, { targetPosition: { x: 24, y: 36 } });
+  await expect.poll(activityLabels).toEqual(["Explorer", "Pull Requests", "Current Diff", "Editor settings"]);
+
+  await app.restart();
+  const restoredRail = app.page.getByRole("navigation", { name: "Workspace views" });
+  const restoredLabels = async (): Promise<string[]> => restoredRail.locator(".rail-action").evaluateAll((buttons) => (
+    buttons.map((button) => button.getAttribute("aria-label") ?? "")
+  ));
+  await expect.poll(restoredLabels).toEqual(["Explorer", "Pull Requests", "Current Diff", "Editor settings"]);
+
+  const restoredPulls = restoredRail.getByRole("button", { name: "Pull Requests" });
+  await restoredPulls.focus();
+  await restoredPulls.press("Alt+ArrowDown");
+  await expect.poll(restoredLabels).toEqual(["Explorer", "Current Diff", "Pull Requests", "Editor settings"]);
+  await expect(restoredPulls).toBeFocused();
+});

--- a/packages/app/src/renderer/src/components/ActivityRail.test.ts
+++ b/packages/app/src/renderer/src/components/ActivityRail.test.ts
@@ -1,9 +1,24 @@
 // @vitest-environment jsdom
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import ActivityRail from "./ActivityRail.vue";
 
 describe("ActivityRail", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("puts Pull Requests first by default", () => {
+    const wrapper = mount(ActivityRail, {
+      props: { active: "pulls", hasTarget: true },
+    });
+
+    expect(wrapper.findAll(".rail-action").map((button) => button.attributes("aria-label"))).toEqual([
+      "Pull Requests",
+      "Explorer",
+      "Current Diff",
+      "Editor settings",
+    ]);
+  });
+
   it("keeps every repository lens available while a local target is selected", async () => {
     const wrapper = mount(ActivityRail, {
       props: { active: "pulls", hasTarget: true },
@@ -26,5 +41,25 @@ describe("ActivityRail", () => {
     expect(wrapper.get("button[aria-label='Current Diff']").attributes("disabled")).toBeDefined();
     expect(wrapper.get("button[aria-label='Pull Requests']").attributes("disabled")).toBeDefined();
     expect(wrapper.get("button[aria-label='Editor settings']").attributes("disabled")).toBeUndefined();
+  });
+
+  it("moves a focused view with Alt+Arrow and remembers the order", async () => {
+    const wrapper = mount(ActivityRail, {
+      props: { active: "pulls", hasTarget: true },
+    });
+
+    await wrapper.get("button[aria-label='Pull Requests']").trigger("keydown", { altKey: true, key: "ArrowDown" });
+
+    expect(wrapper.findAll(".rail-action").map((button) => button.attributes("aria-label"))).toEqual([
+      "Explorer",
+      "Pull Requests",
+      "Current Diff",
+      "Editor settings",
+    ]);
+    expect(JSON.parse(localStorage.getItem("gander.activityOrder") ?? "null")).toEqual([
+      "explorer",
+      "pulls",
+      "changes",
+    ]);
   });
 });

--- a/packages/app/src/renderer/src/components/ActivityRail.vue
+++ b/packages/app/src/renderer/src/components/ActivityRail.vue
@@ -1,32 +1,112 @@
 <script setup lang="ts">
 import { FileDiff, Files, GitPullRequest, Settings } from "@lucide/vue";
+import { computed, shallowRef, type Component } from "vue";
+import {
+  reorderActivity,
+  useActivityOrder,
+  type ActivityMode,
+  type DropEdge,
+} from "../composables/use-activity-order.js";
 
 defineProps<{ active: "explorer" | "changes" | "pulls" | "settings"; hasTarget: boolean }>();
 const emit = defineEmits<{ select: [value: "explorer" | "changes" | "pulls" | "settings"] }>();
-const actions = [
-  { id: "explorer" as const, label: "Explorer", icon: Files },
-  { id: "changes" as const, label: "Current Diff", icon: FileDiff },
-  { id: "pulls" as const, label: "Pull Requests", icon: GitPullRequest },
-];
+const actionById: Record<ActivityMode, { id: ActivityMode; label: string; icon: Component }> = {
+  pulls: { id: "pulls", label: "Pull Requests", icon: GitPullRequest },
+  explorer: { id: "explorer", label: "Explorer", icon: Files },
+  changes: { id: "changes", label: "Current Diff", icon: FileDiff },
+};
+
+const { order, setOrder, move } = useActivityOrder();
+const actions = computed(() => order.value.map((id) => actionById[id]));
+const dragged = shallowRef<ActivityMode | null>(null);
+const dropTarget = shallowRef<{ id: ActivityMode; edge: DropEdge } | null>(null);
+
+function onDragStart(event: DragEvent, id: ActivityMode): void {
+  dragged.value = id;
+  event.dataTransfer?.setData("text/plain", id);
+  if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+}
+
+function onDragOver(event: DragEvent, id: ActivityMode): void {
+  if (dragged.value === null || dragged.value === id) {
+    dropTarget.value = null;
+    return;
+  }
+  event.preventDefault();
+  if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+  const bounds = (event.currentTarget as HTMLElement).getBoundingClientRect();
+  dropTarget.value = {
+    id,
+    edge: event.clientY < bounds.top + bounds.height / 2 ? "before" : "after",
+  };
+}
+
+function onDrop(event: DragEvent): void {
+  event.preventDefault();
+  if (dragged.value && dropTarget.value) {
+    setOrder(reorderActivity(order.value, dragged.value, dropTarget.value.id, dropTarget.value.edge));
+  }
+  clearDrag();
+}
+
+function clearDrag(): void {
+  dragged.value = null;
+  dropTarget.value = null;
+}
+
+function onKeydown(event: KeyboardEvent, id: ActivityMode): void {
+  if (!event.altKey || (event.key !== "ArrowUp" && event.key !== "ArrowDown")) return;
+  event.preventDefault();
+  event.stopPropagation();
+  move(id, event.key === "ArrowUp" ? -1 : 1);
+}
 </script>
 
 <template>
-  <nav class="rail" aria-label="Workspace views">
-    <button v-for="action in actions" :key="action.id" :class="{ active: active === action.id }" :disabled="!hasTarget" :aria-label="action.label" :title="action.label" @click="emit('select', action.id)">
+  <nav class="rail" aria-label="Workspace views" aria-describedby="activity-order-help">
+    <span id="activity-order-help" class="sr-only">Drag workspace views to reorder them. With a view focused, press Alt and the up or down arrow key to move it.</span>
+    <button
+      v-for="action in actions"
+      :key="action.id"
+      class="rail-action"
+      :class="{
+        active: active === action.id,
+        dragging: dragged === action.id,
+        'drop-before': dropTarget?.id === action.id && dropTarget.edge === 'before',
+        'drop-after': dropTarget?.id === action.id && dropTarget.edge === 'after',
+      }"
+      :disabled="!hasTarget"
+      :aria-label="action.label"
+      aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
+      :title="action.label"
+      draggable="true"
+      @click="emit('select', action.id)"
+      @dragstart="onDragStart($event, action.id)"
+      @dragover="onDragOver($event, action.id)"
+      @drop="onDrop"
+      @dragend="clearDrag"
+      @keydown="onKeydown($event, action.id)"
+    >
       <component :is="action.icon" :size="22" />
     </button>
     <span class="spacer" />
-    <button :class="{ active: active === 'settings' }" aria-label="Editor settings" title="Editor settings" @click="emit('select', 'settings')"><Settings :size="21" /></button>
+    <button class="rail-action settings-action" :class="{ active: active === 'settings' }" aria-label="Editor settings" title="Editor settings" @click="emit('select', 'settings')"><Settings :size="21" /></button>
   </nav>
 </template>
 
 <style scoped>
 .rail { width: 48px; flex: none; display: flex; flex-direction: column; align-items: stretch; background: var(--panel-background); border-right: 1px solid var(--workbench-border); }
-button { position: relative; height: 48px; display: grid; place-items: center; border: 0; background: none; color: var(--faint-foreground); cursor: pointer; }
-button:hover:not(:disabled) { color: var(--workbench-foreground); background: var(--hover-background); }
-button.active { color: var(--workbench-foreground); }
-button.active::before { content: ""; position: absolute; inset-block: 8px; inset-inline-start: 0; width: 2px; background: var(--accent); }
-button:disabled { opacity: .55; cursor: default; }
-button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.rail-action { position: relative; height: 48px; display: grid; place-items: center; border: 0; background: none; color: var(--faint-foreground); cursor: grab; user-select: none; }
+.rail-action:hover:not(:disabled) { color: var(--workbench-foreground); background: var(--hover-background); }
+.rail-action.active { color: var(--workbench-foreground); }
+.rail-action.active::before { content: ""; position: absolute; inset-block: 8px; inset-inline-start: 0; width: 2px; background: var(--accent); }
+.rail-action.dragging { opacity: .4; cursor: grabbing; }
+.rail-action.drop-before::after, .rail-action.drop-after::after { content: ""; position: absolute; inset-inline: 7px; height: 2px; background: var(--accent); pointer-events: none; }
+.rail-action.drop-before::after { inset-block-start: -1px; }
+.rail-action.drop-after::after { inset-block-end: -1px; }
+.rail-action:disabled { opacity: .55; cursor: default; }
+.rail-action:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.settings-action { cursor: pointer; }
 .spacer { flex: 1; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 </style>

--- a/packages/app/src/renderer/src/composables/use-activity-order.test.ts
+++ b/packages/app/src/renderer/src/composables/use-activity-order.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { moveActivity, parseActivityOrder, reorderActivity } from "./use-activity-order.js";
+
+describe("activity order", () => {
+  it("accepts each activity exactly once", () => {
+    expect(parseActivityOrder(["changes", "pulls", "explorer"])).toEqual(["changes", "pulls", "explorer"]);
+    expect(parseActivityOrder(["pulls", "pulls", "changes"])).toBeNull();
+    expect(parseActivityOrder(["pulls", "explorer", "unknown"])).toBeNull();
+  });
+
+  it("places a dragged activity on the requested edge", () => {
+    expect(reorderActivity(["pulls", "explorer", "changes"], "pulls", "explorer", "after")).toEqual([
+      "explorer",
+      "pulls",
+      "changes",
+    ]);
+    expect(reorderActivity(["pulls", "explorer", "changes"], "changes", "pulls", "before")).toEqual([
+      "changes",
+      "pulls",
+      "explorer",
+    ]);
+  });
+
+  it("keeps keyboard moves inside the rail", () => {
+    expect(moveActivity(["pulls", "explorer", "changes"], "pulls", -1)).toEqual(["pulls", "explorer", "changes"]);
+    expect(moveActivity(["pulls", "explorer", "changes"], "explorer", 1)).toEqual(["pulls", "changes", "explorer"]);
+  });
+});

--- a/packages/app/src/renderer/src/composables/use-activity-order.ts
+++ b/packages/app/src/renderer/src/composables/use-activity-order.ts
@@ -1,0 +1,71 @@
+import { readonly, shallowRef, type DeepReadonly, type ShallowRef } from "vue";
+
+export const ACTIVITY_MODES = ["pulls", "explorer", "changes"] as const;
+export type ActivityMode = typeof ACTIVITY_MODES[number];
+export type DropEdge = "before" | "after";
+
+const STORAGE_KEY = "gander.activityOrder";
+const DEFAULT_ORDER: ActivityMode[] = [...ACTIVITY_MODES];
+
+export function parseActivityOrder(value: unknown): ActivityMode[] | null {
+  if (!Array.isArray(value) || value.length !== ACTIVITY_MODES.length) return null;
+  if (!value.every((item): item is ActivityMode => ACTIVITY_MODES.includes(item as ActivityMode))) return null;
+  if (new Set(value).size !== ACTIVITY_MODES.length) return null;
+  return [...value];
+}
+
+export function reorderActivity(
+  order: readonly ActivityMode[],
+  dragged: ActivityMode,
+  target: ActivityMode,
+  edge: DropEdge,
+): ActivityMode[] {
+  if (dragged === target) return [...order];
+  const next = order.filter((item) => item !== dragged);
+  const targetIndex = next.indexOf(target);
+  next.splice(targetIndex + (edge === "after" ? 1 : 0), 0, dragged);
+  return next;
+}
+
+export function moveActivity(order: readonly ActivityMode[], id: ActivityMode, offset: -1 | 1): ActivityMode[] {
+  const from = order.indexOf(id);
+  const to = Math.min(order.length - 1, Math.max(0, from + offset));
+  if (from === to) return [...order];
+  const next = [...order];
+  next.splice(from, 1);
+  next.splice(to, 0, id);
+  return next;
+}
+
+function load(storage: Pick<Storage, "getItem">): ActivityMode[] {
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    return raw === null ? [...DEFAULT_ORDER] : parseActivityOrder(JSON.parse(raw)) ?? [...DEFAULT_ORDER];
+  } catch {
+    return [...DEFAULT_ORDER];
+  }
+}
+
+export interface ActivityOrder {
+  order: DeepReadonly<ShallowRef<ActivityMode[]>>;
+  setOrder(order: readonly ActivityMode[]): void;
+  move(id: ActivityMode, offset: -1 | 1): void;
+}
+
+/** The reviewer's per-machine activity-bar order and the only actions that can change it. */
+export function useActivityOrder(storage: Pick<Storage, "getItem" | "setItem"> = localStorage): ActivityOrder {
+  const order = shallowRef(load(storage));
+
+  function setOrder(next: readonly ActivityMode[]): void {
+    const parsed = parseActivityOrder(next);
+    if (!parsed) return;
+    order.value = parsed;
+    storage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+  }
+
+  function move(id: ActivityMode, offset: -1 | 1): void {
+    setOrder(moveActivity(order.value, id, offset));
+  }
+
+  return { order: readonly(order), setOrder, move };
+}


### PR DESCRIPTION
## Summary
- put Pull Requests first in the activity rail
- let reviewers drag workspace icons into their preferred order
- persist the order locally and support Alt+Arrow reordering from the keyboard

## Verification
- pnpm typecheck
- pnpm test (62 files, 417 tests)
- pnpm test:e2e:run (21 tests)
- focused drag, persistence, and keyboard Electron test
- desktop visual pass