### PR TITLE
Allow addressed note outcome corrections

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -64,8 +64,10 @@ for registration.
 
 Agents discuss notes with the reviewer in their active session. Once the work is
 complete, they record the durable outcome through MCP with a summary and an
-optional commit ref. Notes also carry immutable source context from the head
-revision at capture time, and agents can fetch only notes after a last-seen id.
+optional commit ref. They can correct that recorded outcome while the note remains
+addressed; reviewer resolution makes it final. Notes also carry immutable source
+context from the head revision at capture time, and agents can fetch only notes
+after a last-seen id.
 
 Each opened pull request records its own branch, which is how the service maps an
 agent's working branch to a pull request without holding GitHub credentials.

--- a/packages/service/contract.json
+++ b/packages/service/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0",
+  "version": "0.8.1",
   "routes": [
     "DELETE /api/reviews/:repoId/:prNumber/notes/:id",
     "DELETE /mcp",
@@ -713,7 +713,7 @@
     },
     {
       "name": "mark_note_addressed",
-      "description": "Record the outcome after an open or in-progress note has been acted on. A code change can name its commit; an answered question has no commit. This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
+      "description": "Record the outcome after an open or in-progress note has been acted on, or correct the outcome while it remains addressed. A code change can name its commit; an answered question has no commit. This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/packages/service/src/mcp.test.ts
+++ b/packages/service/src/mcp.test.ts
@@ -153,6 +153,26 @@ describe("MCP endpoint", () => {
     await client.close();
   });
 
+  it("updates an addressed note's outcome until the reviewer resolves it", async () => {
+    const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why?", headSha: null, sourceContext: null });
+    storage.markNoteAddressed(note.id, { commitRef: "abc1234", summary: "Dropped the retry" });
+
+    const client = await connect();
+    const result = await client.callTool({
+      name: "mark_note_addressed",
+      arguments: { id: note.id, commitRef: "def5678", summary: "Restored the retry with a limit" },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result as { content?: unknown })).toBe("Note 1 marked addressed.");
+    expect(storage.getNote(note.id)).toMatchObject({
+      state: "addressed",
+      commitRef: "def5678",
+      summary: "Restored the retry with a limit",
+    });
+    await client.close();
+  });
+
   it("claims a note, exposes a reviewer blocker, and addresses a question without a commit", async () => {
     storage.setPrContext("acme/atlas", 7, { headRef: "feat/thing", title: "Feature", headSha: "sha-1", stackId: null, stackSize: null, stackPosition: null });
     const q = storage.addNote("acme/atlas", 7, {
@@ -208,9 +228,7 @@ describe("MCP endpoint", () => {
     await client.close();
   });
 
-  it("distinguishes missing, addressed, and resolved notes when addressing fails", async () => {
-    const addressed = storage.addNote("acme/atlas", 7, { path: "addressed.rb", line: null, text: "Address me", headSha: null, sourceContext: null });
-    storage.markNoteAddressed(addressed.id, { commitRef: null, summary: "Done" });
+  it("distinguishes missing and resolved notes when addressing fails", async () => {
     const resolved = storage.addNote("acme/atlas", 7, { path: "resolved.rb", line: null, text: "Resolve me", headSha: null, sourceContext: null });
     storage.markNoteAddressed(resolved.id, { commitRef: null, summary: "Done" });
     storage.putFileState("acme/atlas", 7, {
@@ -221,7 +239,6 @@ describe("MCP endpoint", () => {
     const client = await connect();
     for (const [id, message] of [
       [999, "Note id 999 does not exist."],
-      [addressed.id, `Note ${addressed.number} is already addressed.`],
       [resolved.id, `Note ${resolved.number} is already resolved.`],
     ] as const) {
       const result = await client.callTool({ name: "mark_note_addressed", arguments: { id, summary: "Nothing to change" } });

--- a/packages/service/src/mcp.ts
+++ b/packages/service/src/mcp.ts
@@ -168,7 +168,7 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
     {
       title: "Mark a review note addressed",
       description:
-        "Record the outcome after an open or in-progress note has been acted on. A code change can name its commit; an answered question has no commit. " +
+        "Record the outcome after an open or in-progress note has been acted on, or correct the outcome while it remains addressed. A code change can name its commit; an answered question has no commit. " +
         "This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
       inputSchema: {
         id: z.number().int().positive().describe("Global note id from get_review_notes. Use its number when discussing the note with the reviewer."),

--- a/packages/service/src/storage.test.ts
+++ b/packages/service/src/storage.test.ts
@@ -146,6 +146,23 @@ describe("storage", () => {
       expect(storage.getNote(999)).toBeNull();
     });
 
+    it("lets an agent correct an addressed outcome until the reviewer resolves it", () => {
+      const note = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Why the retry?", headSha: null, sourceContext: null });
+      storage.markNoteAddressed(note.id, { commitRef: "abc1234", summary: "Dropped the retry" });
+
+      expect(storage.markNoteAddressed(note.id, { commitRef: "def5678", summary: "Restored the retry with a limit" })).toMatchObject({
+        state: "addressed",
+        commitRef: "def5678",
+        summary: "Restored the retry with a limit",
+      });
+
+      storage.putFileState("acme/atlas", 7, {
+        checked: true, path: "a.rb", baseHash: "b", headHash: "h",
+        baseContent: "old", headContent: "new", machine: "test",
+      });
+      expect(storage.markNoteAddressed(note.id, { commitRef: "ghi9012", summary: "Too late" })).toBeNull();
+    });
+
     it("claims a note, records why it is waiting, then addresses it without a commit", () => {
       const q = storage.addNote("acme/atlas", 7, { path: "a.rb", line: null, text: "Which behavior?", headSha: null, sourceContext: null });
 

--- a/packages/service/src/storage.ts
+++ b/packages/service/src/storage.ts
@@ -220,11 +220,12 @@ export function openStorage(dbPath: string): Storage {
 
     markNoteAddressed(id, input) {
       // Claiming is useful for work that spans time, but a note handled in one exchange
-      // can go straight from open to addressed. Neither path may undo reviewer resolution.
+      // can go straight from open to addressed. Agents can correct the recorded outcome
+      // until the reviewer resolves it; neither path may undo reviewer resolution.
       const changed = db.prepare(`
         UPDATE notes
         SET state = 'addressed', in_progress_note = NULL, commit_ref = ?, summary = ?, addressed_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-        WHERE id = ? AND state IN ('open', 'in_progress')
+        WHERE id = ? AND state IN ('open', 'in_progress', 'addressed')
       `).run(input.commitRef, input.summary, id).changes;
       if (changed === 0) return null;
       return rowToNote(db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(id) as NoteRow);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
  *
  * Not the app's release version: releases happen far more often than the contract moves.
  */
-export const SERVICE_VERSION = "0.8.0";
+export const SERVICE_VERSION = "0.8.1";
 
 export const FileStatusSchema = z.enum(["A", "M", "D", "R"]);
 export type FileStatus = z.infer<typeof FileStatusSchema>;


### PR DESCRIPTION
## Summary

- let agents replace the summary and commit on an addressed note until reviewer resolution
- keep resolved notes protected
- bump the service contract to 0.8.1 and document the behavior

## Verification

- pnpm typecheck
- pnpm test (62 files, 419 tests)
- pnpm test:e2e (21 tests)