### PR TITLE
Look for gh in the mise shim directory

### DIFF
--- a/packages/app/src/main/github.test.ts
+++ b/packages/app/src/main/github.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { listOpenPrs, resolveGithubToken } from "./github.js";
 
 const ghPr = {
@@ -117,6 +119,17 @@ describe("resolveGithubToken", () => {
     };
     expect(await resolveGithubToken(undefined, fakeExecFile)).toBe("brew-tok");
     expect(tried).toEqual(["gh", "/opt/homebrew/bin/gh"]);
+  });
+
+  it("finds gh in the mise shim directory when nothing else has it", async () => {
+    // A version-manager install: no package manager put a binary anywhere on the list,
+    // and the GUI launch's PATH cannot see the shim directory either.
+    const shim = join(homedir(), ".local", "share", "mise", "shims", "gh");
+    const fakeExecFile = async (file: string) => {
+      if (file !== shim) throw new Error("command not found");
+      return { stdout: "mise-tok\n" };
+    };
+    expect(await resolveGithubToken(undefined, fakeExecFile)).toBe("mise-tok");
   });
 
   it("says where to put a token when there is none anywhere", async () => {

--- a/packages/app/src/main/github.ts
+++ b/packages/app/src/main/github.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import type { PrSummary } from "@gander/shared";
 
@@ -49,8 +51,18 @@ export async function listOpenPrs(repoId: string, token: string, fetchImpl: type
  * A GUI launch inherits `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — none of the places a
  * package manager installs to — so looking the binary up on PATH finds nothing on a
  * machine where the reviewer's own terminal runs `gh` perfectly well.
+ *
+ * The mise shim comes last: a version manager's `gh` is the reviewer's chosen one, but
+ * the shim re-execs through mise, so it is the slowest of these to answer and only worth
+ * reaching when no package manager put a binary anywhere.
  */
-const GH_PATHS = ["gh", "/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/home/linuxbrew/.linuxbrew/bin/gh"];
+const GH_PATHS = [
+  "gh",
+  "/opt/homebrew/bin/gh",
+  "/usr/local/bin/gh",
+  "/home/linuxbrew/.linuxbrew/bin/gh",
+  join(homedir(), ".local", "share", "mise", "shims", "gh"),
+];
 
 /** Whether a token GitHub will accept, and who it belongs to — for the settings pane. */
 export async function checkGithubToken(token: string, fetchImpl: typeof fetch = fetch): Promise<{ ok: true; login: string } | { ok: false; reason: string }> {


### PR DESCRIPTION
Closes part of #130.

`GH_PATHS` covers PATH plus the Homebrew and Linuxbrew locations. A `gh`
installed by a version manager lives in `~/.local/share/mise/shims/gh`, which a
GUI launch cannot see either, so `resolveGithubToken` fell through every entry
and threw - on a machine whose terminal runs `gh` perfectly well.

The shim goes last. It re-execs through mise, so it is the slowest of these to
answer and is only worth reaching once no package manager has provided a binary.

Built with `join(homedir(), ...)`: `execFile` does not expand `~`.

The new test fails without the change (verified by reverting `github.ts` and
re-running). `pnpm typecheck` and `pnpm test` pass.