### PR TITLE
Say when the pull request list is empty because the fetch failed

### DIFF
--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -29,6 +29,7 @@ function fakeStore(view: PrView): { store: Store; calls: Calls } {
   const store: Store = reactive({
     repos: [],
     prs: [],
+    prsError: null,
     worktrees: [],
     currentRepoId: "acme/atlas",
     targetRepoId: "acme/atlas",

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.test.ts
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { reactive } from "vue";
+import { describe, expect, it } from "vitest";
+import type { Store } from "../store.js";
+import PullRequestSidebar from "./PullRequestSidebar.vue";
+
+// Only the fields this sidebar reads. A whole store would say nothing more about which
+// of the two empty states it renders.
+function fakeStore(prsError: string | null): Store {
+  return reactive({
+    prs: [],
+    prsError,
+    view: null,
+    currentRepoId: "acme/atlas",
+    targetRepoId: "acme/atlas",
+    selectedPrNumber: null,
+  }) as unknown as Store;
+}
+
+const props = (prsError: string | null) => ({
+  store: fakeStore(prsError),
+  iconTheme: "catppuccin-mocha" as const,
+  typography: { fontFamily: "monospace", fontSize: 13 },
+});
+
+describe("PullRequestSidebar", () => {
+  it("states an empty list as fact only when GitHub actually answered", () => {
+    const wrapper = mount(PullRequestSidebar, { props: props(null) });
+
+    expect(wrapper.get(".empty").text()).toBe("No open pull requests.");
+  });
+
+  it("says the list could not be fetched, and why, when the request failed", () => {
+    // Otherwise a missing token looks like a repository with nothing open, and the
+    // reviewer goes looking in the wrong place.
+    const wrapper = mount(PullRequestSidebar, { props: props("No GitHub token. Add one in Settings") });
+
+    expect(wrapper.get(".empty").text()).toContain("Could not list pull requests");
+    expect(wrapper.get(".empty").text()).toContain("No GitHub token");
+  });
+});

--- a/packages/app/src/renderer/src/components/PullRequestSidebar.vue
+++ b/packages/app/src/renderer/src/components/PullRequestSidebar.vue
@@ -66,6 +66,9 @@ async function reload(): Promise<void> {
         :selected-pr-number="store.selectedPrNumber"
         @select="$emit('selectPr', $event)"
       />
+      <p v-else-if="store.prsError" class="empty failed" role="status">
+        Could not list pull requests. {{ store.prsError }}
+      </p>
       <p v-else class="empty">No open pull requests.</p>
     </section>
     <section v-if="store.view && store.currentRepoId === store.targetRepoId" class="files-section">
@@ -112,6 +115,7 @@ h1, h2 { flex: none; margin: 0; color: var(--muted-foreground); font-size: 10px;
 .reload:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .reload:disabled { opacity: .5; cursor: default; }
 .empty { margin: 0; padding: 12px; color: var(--faint-foreground); font-size: 11px; }
+.empty.failed { color: var(--danger); }
 .remaining-empty { margin: 0; padding: 16px 12px; color: var(--muted-foreground); font-size: 11px; text-align: center; }
 .files-section :deep(.tree.root) { flex: 1; min-height: 0; overflow: auto; scrollbar-gutter: stable; }
 .pull-sidebar :deep(.reviewing-list) { padding: 5px 0 8px; }

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -455,6 +455,25 @@ describe("store", () => {
     expect(store.busy).toBe(false);
   });
 
+  it("says why the pull request list is empty when GitHub could not be asked", async () => {
+    // An empty list reads as "this repository has nothing open". When the fetch failed it
+    // is a lie, and the reviewer goes looking at the repository instead of their token.
+    let fail = true;
+    const store = createStore(fakeApi({
+      listPrs: async () => { if (fail) throw new Error("No GitHub token. Add one in Settings"); return []; },
+    }));
+    await store.loadRepos();
+    await store.selectRepo("acme/atlas");
+
+    expect(store.prs).toEqual([]);
+    expect(store.prsError).toMatch(/No GitHub token/);
+
+    fail = false;
+    await store.refreshPrs();
+
+    expect(store.prsError).toBeNull();
+  });
+
   it("refreshPrs does nothing when no repository is targeted", async () => {
     let calls = 0;
     const store = createStore(fakeApi({ listPrs: async () => { calls += 1; return []; } }));

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -9,6 +9,13 @@ import { parentDirectory } from "./paths.js";
 export interface Store {
   repos: RepoEntry[];
   prs: PrListItem[];
+  /**
+   * Why the pull request list is empty, when it is empty because the fetch failed.
+   *
+   * An empty list is otherwise ambiguous: a repository with nothing open and a repository
+   * GitHub would not answer for look identical, and the sidebar states the first as fact.
+   */
+  prsError: string | null;
   worktrees: LocalWorktree[];
   currentRepoId: string | null;
   /** Repository the workbench modes operate on, independent of whichever view is loaded. */
@@ -104,6 +111,7 @@ export function createStore(api: GanderApi): Store {
   const store: Store = reactive({
     repos: [],
     prs: [],
+    prsError: null,
     worktrees: [],
     currentRepoId: null,
     targetRepoId: null,
@@ -177,6 +185,7 @@ export function createStore(api: GanderApi): Store {
           store.targetWorktreePath = null;
           store.selectedPrNumber = null;
           store.prs = [];
+          store.prsError = null;
           store.worktrees = [];
         }
         store.repos = await api.listRepos();
@@ -437,6 +446,7 @@ export function createStore(api: GanderApi): Store {
     const [prs, worktrees] = await Promise.allSettled([api.listPrs(repoId), api.listWorktrees(repoId)]);
     if (request !== targetContextRequest) return;
     store.prs = prs.status === "fulfilled" ? prs.value : [];
+    store.prsError = prs.status === "rejected" ? readable((prs.reason as Error).message) : null;
     store.worktrees = worktrees.status === "fulfilled" ? worktrees.value : [];
     const errors = [prs, worktrees]
       .filter((result): result is PromiseRejectedResult => result.status === "rejected")


### PR DESCRIPTION
Closes part of #130.

A failed fetch and a repository with nothing open rendered identically: the
sidebar said "No open pull requests." for both. That is the second half of the
GitHub-token problem in #130 - the reviewer sees a fact about the repository and
has no reason to look at their token.

`loadContexts` already empties `store.prs` when `listPrs` rejects; it now records
why in `store.prsError`, and the sidebar renders that instead of the empty state.
Cleared on the next success and when the target repository is dropped.

The existing throw stays, so the error still reaches the banner through `guard`
as before - this adds a channel rather than replacing one.

Both new tests fail without the change (verified by reverting `store.ts` and
`PullRequestSidebar.vue` in turn). `pnpm typecheck` and `pnpm test` pass.

One observation, not addressed here: `guard` sets `store.error` and then awaits
`checkService()`, so when the service is also unhappy the GitHub message can be
replaced in the banner before it is read. That has its own design comment and
felt out of scope.