### PR TITLE
Mirror reviewed files to GitHub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,8 +199,9 @@ reverting the fix.
 - Comments explain *why*, especially where the code looks wrong without the
   reason (Monaco's hidden textarea, retained snapshots, connection-time config).
   Match that density; don't narrate what the code already says.
-- Everything in the app is read-only. There is no editing feature and no GitHub
-  review machinery (comments, approvals, merge) — that's out of scope by design.
+- Everything in the app is read-only with respect to repository content. The only
+  GitHub mutation mirrors Gander checkoffs to the reviewer's per-user Viewed state;
+  comments, approvals, and merges remain out of scope by design.
 - Errors surface: no silent degradation, no write queues, no swallowed git or
   GitHub error text.
 - Icons come from `@lucide/vue`. Panel sizes and docking live in

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ service token. `bin/dev` starts the review service and the app together.
 this checkout's settings; see `DEVSTACK.md` for the setup and precedence rules.
 
 Reviewing a pull request needs `git` and a GitHub API token. The GitHub CLI is
-not a runtime requirement: Gander calls GitHub's REST API directly. Today it
+not a runtime requirement: Gander calls GitHub's REST and GraphQL APIs directly. Today it
 looks for a token in this order:
 
 1. `GANDER_GITHUB_TOKEN`, for development and automation

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -11,7 +11,9 @@ M1 is merged to `master`.
 
 A working Electron app that opens a GitHub PR, shows its files as a tree with
 hierarchical checkoff, renders a unified Monaco diff, and persists review state
-to a local Fastify + SQLite service.
+to a local Fastify + SQLite service. Successful checkoffs also mirror to the
+authenticated reviewer's per-user GitHub Viewed state; Gander remains authoritative
+if that secondary write fails.
 
 | Package | Contents |
 |---|---|
@@ -117,5 +119,5 @@ independent, clean-world scenarios covering persistence, content-based review
 state, notes and MCP, service recovery and compatibility, target isolation,
 keyboard focus, images, local worktrees, the real `bin/gander` command, and clone
 concurrency. The suite uses real Git,
-Fastify, SQLite, IPC, preload, and renderer boundaries; only GitHub's HTTP endpoint
-is represented by a local fake.
+Fastify, SQLite, IPC, preload, and renderer boundaries; only GitHub's REST and
+GraphQL HTTP endpoints are represented by a local fake.

--- a/docs/github-authentication.md
+++ b/docs/github-authentication.md
@@ -7,9 +7,9 @@ Decision date: 2026-08-18
 ## Decision
 
 Gander will add built-in GitHub.com sign-in using a **GitHub App user access
-token obtained through GitHub's device flow**. The GitHub App will request only
-read access to repository metadata and pull requests, use expiring user access
-tokens, and store access and refresh tokens through Electron's OS-backed
+token obtained through GitHub's device flow**. The GitHub App will request read
+access to repository metadata and write access to pull requests, use expiring
+user access tokens, and store access and refresh tokens through Electron's OS-backed
 `safeStorage` API.
 
 This issue is an investigation, not the OAuth implementation. The slices below
@@ -42,17 +42,20 @@ store.
 
 ## Why a GitHub App
 
-A traditional OAuth App is a poor fit for a read-only reviewer. Public data can
-be read with no OAuth scope, but private repository access requires the OAuth
+A traditional OAuth App is a poor fit for a reviewer with one narrow GitHub
+mutation. Public data can be read with no OAuth scope, but private repository
+access requires the OAuth
 `repo` scope. GitHub defines that scope as full read and write access to public
 and private repositories; even `public_repo` includes write capabilities. Gander
-must not ask for mutation privileges it does not use.
+must not ask for mutation privileges beyond mirroring its reviewed-file
+checkoffs to GitHub's per-user Viewed state.
 
 A GitHub App has fine-grained permissions. The endpoints Gander uses accept a
 GitHub App user access token with:
 
 - **Metadata: read**, for `GET /user/repos`
-- **Pull requests: read**, for `GET /repos/{owner}/{repo}/pulls`
+- **Pull requests: write**, for `GET /repos/{owner}/{repo}/pulls` and the
+  `markFileAsViewed` / `unmarkFileAsViewed` GraphQL mutations
 
 No Contents permission, webhook subscription, private key, or installation
 token is required for the current API calls. Repository installation remains
@@ -99,7 +102,7 @@ For GitHub.com, the maintainer will register one public GitHub App owned by the
 project's durable account or organization. Its client ID is public configuration
 and may be compiled into release builds. Registration must enable device flow,
 keep user-to-server token expiration enabled, request only Metadata read and
-Pull requests read, subscribe to no webhooks, and publish the repository URL as
+Pull requests write, subscribe to no webhooks, and publish the repository URL as
 its homepage and support location.
 
 The app must be tested against personal repositories, selected-repository
@@ -180,7 +183,7 @@ never sent to a different origin.
    fake in tests.
 3. **Installation-aware repository discovery.** Handle selected installations,
    organization approval/SSO failures, no-installation UX, and installation
-   management links without adding GitHub write operations.
+   management links without adding GitHub write operations beyond file-viewed mirroring.
 4. **Refresh, sign-out, and revocation UX.** Implement atomic rotation,
    single-flight refresh, restart persistence, local sign-out, remote-revocation
    detection, and the GitHub authorization-management link.
@@ -191,8 +194,9 @@ never sent to a different origin.
    registration, `/api/v3` and web-auth URL derivation, certificate validation
    guidance, host-aware `gh auth token --hostname`, and GHES integration tests.
 
-Each slice must preserve the rule that GitHub integration is read-only and that
-authentication and API failures surface their real, redacted error.
+Each slice must preserve the rule that file-viewed mirroring is Gander's only
+GitHub mutation and that authentication and API failures surface their real,
+redacted error.
 
 ## Primary sources
 

--- a/packages/app/e2e/checkoff-persistence.spec.ts
+++ b/packages/app/e2e/checkoff-persistence.spec.ts
@@ -17,3 +17,16 @@ test("persists a file checkoff across an app restart", async ({ world }) => {
   await expect(review.file("a.rb").getByRole("checkbox")).toHaveAttribute("aria-checked", "true");
   await review.expectProgress(1, 2);
 });
+
+test("mirrors reviewed and unreviewed files to GitHub", async ({ world }) => {
+  const repository = await world.addRepository({ repoId: "acme/viewed-mirror" });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+  await review.open(repository.title);
+
+  await app.page.getByRole("button", { name: "Mark reviewed" }).click();
+  expect(world.github.isViewed(repository.repoId, "a.rb")).toBe(true);
+
+  await app.page.getByRole("button", { name: "Reviewed", exact: true }).click();
+  expect(world.github.isViewed(repository.repoId, "a.rb")).toBe(false);
+});

--- a/packages/app/e2e/fixtures/github-server.ts
+++ b/packages/app/e2e/fixtures/github-server.ts
@@ -13,6 +13,7 @@ type ListHook = (requestCount: number) => Promise<void> | void;
 
 interface RepositoryResponse {
   pullRequests: PullRequestFixture[];
+  viewedFiles: Set<string>;
   onList?: ListHook;
   requestCount: number;
 }
@@ -26,6 +27,23 @@ export class GithubServer {
 
   private constructor() {
     this.server = Fastify({ logger: false });
+    this.server.post<{ Body: { query?: string; variables?: { input?: { pullRequestId?: string; path?: string } } } }>(
+      "/graphql",
+      async (request, reply) => {
+        if (request.headers.authorization !== `Bearer ${this.token}`) {
+          return reply.code(401).send({ message: "Bad credentials" });
+        }
+        const input = request.body.variables?.input;
+        const match = [...this.repositories.entries()].find(([repoId, repository]) =>
+          repository.pullRequests.some((pullRequest) => this.pullRequestId(repoId, pullRequest.number) === input?.pullRequestId));
+        if (!match || !input?.path) return reply.code(200).send({ errors: [{ message: "Pull request or path not found" }] });
+        const [, repository] = match;
+        if (request.body.query?.includes("unmarkFileAsViewed")) repository.viewedFiles.delete(input.path);
+        else if (request.body.query?.includes("markFileAsViewed")) repository.viewedFiles.add(input.path);
+        else return reply.code(200).send({ errors: [{ message: "Unknown mutation" }] });
+        return { data: { mirror: { clientMutationId: null } } };
+      },
+    );
   }
 
   static async start(): Promise<GithubServer> {
@@ -43,6 +61,7 @@ export class GithubServer {
         await repository.onList?.(repository.requestCount);
         if (request.query.page && request.query.page !== "1") return [];
         return repository.pullRequests.map((pullRequest) => ({
+          node_id: github.pullRequestId(repoId, pullRequest.number),
           number: pullRequest.number,
           title: pullRequest.title,
           body: "",
@@ -57,7 +76,7 @@ export class GithubServer {
   }
 
   register(repoId: string, pullRequests: PullRequestFixture[], onList?: ListHook): void {
-    this.repositories.set(repoId, { pullRequests, onList, requestCount: 0 });
+    this.repositories.set(repoId, { pullRequests, viewedFiles: new Set(), onList, requestCount: 0 });
   }
 
   updatePullRequest(repoId: string, pullRequest: PullRequestFixture): void {
@@ -70,6 +89,14 @@ export class GithubServer {
 
   requestsFor(repoId: string): number {
     return this.repositories.get(repoId)?.requestCount ?? 0;
+  }
+
+  isViewed(repoId: string, path: string): boolean {
+    return this.repositories.get(repoId)?.viewedFiles.has(path) ?? false;
+  }
+
+  private pullRequestId(repoId: string, number: number): string {
+    return `PR_${repoId.replaceAll("/", "_")}_${number}`;
   }
 
   async close(): Promise<void> {

--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -4,6 +4,7 @@ import type { ThemeId } from "./themes.js";
 import type { ConnectionCheck, ServiceStatus } from "./main/connection.js";
 import type { ImagePreview } from "./image-preview.js";
 import type { LocalViewUpdate } from "./main/local-viewer.js";
+import type { CheckoffResult } from "./main/review.js";
 
 export type { ImagePreview, ImageSide } from "./image-preview.js";
 
@@ -46,8 +47,8 @@ export interface GanderApi {
   setConnection(url: string, token: string): Promise<ConnectionCheck>;
   serviceStatus(): Promise<ServiceStatus>;
   openPr(repoId: string, prNumber: number): Promise<PrView>;
-  setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<PrView>;
-  setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView>;
+  setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<CheckoffResult>;
+  setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<CheckoffResult>;
   refreshPr(repoId: string, prNumber: number): Promise<PrView>;
   reviewedSnapshot(repoId: string, prNumber: number, path: string): Promise<string | null>;
   imagePreview(repoId: string, prNumber: number, path: string): Promise<ImagePreview>;

--- a/packages/app/src/main/github.test.ts
+++ b/packages/app/src/main/github.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { listOpenPrs, resolveGithubToken } from "./github.js";
+import { listOpenPrs, resolveGithubToken, setFileViewed } from "./github.js";
 
 const ghPr = {
+  node_id: "PR_kwDOExample",
   number: 987, title: "Late-fee automation", body: "Adds calculator", draft: true,
   base: { ref: "main", sha: "aaa111" }, head: { sha: "bbb222" },
 };
@@ -24,7 +25,7 @@ describe("listOpenPrs", () => {
     }) as typeof fetch;
 
     const prs = await listOpenPrs("acme/atlas", "tok", fakeFetch);
-    expect(prs).toEqual([{ number: 987, title: "Late-fee automation", body: "Adds calculator", draft: true, baseRef: "main", baseSha: "aaa111", headSha: "bbb222", stack: null }]);
+    expect(prs).toEqual([{ githubId: "PR_kwDOExample", number: 987, title: "Late-fee automation", body: "Adds calculator", draft: true, baseRef: "main", baseSha: "aaa111", headSha: "bbb222", stack: null }]);
   });
 
   it("surfaces API errors loudly with status and body", async () => {
@@ -78,6 +79,50 @@ describe("listOpenPrs", () => {
 
     expect(prs).toHaveLength(1);
     expect(calls).toBe(1);
+  });
+});
+
+describe("setFileViewed", () => {
+  const originalApiUrl = process.env.GANDER_GITHUB_API_URL;
+  beforeEach(() => { delete process.env.GANDER_GITHUB_API_URL; });
+  afterEach(() => {
+    if (originalApiUrl === undefined) delete process.env.GANDER_GITHUB_API_URL;
+    else process.env.GANDER_GITHUB_API_URL = originalApiUrl;
+  });
+
+  it.each([
+    [true, "markFileAsViewed", "MarkFileAsViewedInput"],
+    [false, "unmarkFileAsViewed", "UnmarkFileAsViewedInput"],
+  ])("mirrors viewed=%s through %s", async (viewed, mutation, inputType) => {
+    const fakeFetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(url)).toBe("https://api.github.com/graphql");
+      expect(init?.method).toBe("POST");
+      expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer tok");
+      const body = JSON.parse(String(init?.body)) as { query: string; variables: unknown };
+      expect(body.query).toContain(`${mutation}(input: $input)`);
+      expect(body.query).toContain(`$input: ${inputType}!`);
+      expect(body.variables).toEqual({ input: { pullRequestId: "PR_123", path: "src/a.ts" } });
+      return new Response(JSON.stringify({ data: { [mutation]: { clientMutationId: null } } }), { status: 200 });
+    }) as typeof fetch;
+
+    await setFileViewed("PR_123", "src/a.ts", viewed, "tok", fakeFetch);
+  });
+
+  it("surfaces GraphQL errors even when the HTTP request succeeds", async () => {
+    const fakeFetch = (async () => new Response(JSON.stringify({
+      errors: [{ message: "Resource not accessible by integration" }],
+    }), { status: 200 })) as typeof fetch;
+
+    await expect(setFileViewed("PR_123", "src/a.ts", true, "tok", fakeFetch)).rejects.toThrow(
+      /Resource not accessible by integration/,
+    );
+  });
+
+  it("surfaces HTTP errors with the response body", async () => {
+    const fakeFetch = (async () => new Response("Bad credentials", { status: 401 })) as typeof fetch;
+    await expect(setFileViewed("PR_123", "src/a.ts", true, "tok", fakeFetch)).rejects.toThrow(
+      /401.*Bad credentials/s,
+    );
   });
 });
 

--- a/packages/app/src/main/github.ts
+++ b/packages/app/src/main/github.ts
@@ -10,6 +10,7 @@ const execFileAsync = promisify(execFile);
 const runGhAuthToken: ExecFileFn = (file, args) => execFileAsync(file, args);
 
 interface GhPr {
+  node_id: string;
   number: number; title: string; body: string | null; draft: boolean;
   base: { ref: string; sha: string }; head: { ref: string; sha: string };
   // Present since GitHub shipped stacked pull requests; absent on a standalone one.
@@ -23,6 +24,36 @@ const apiBase = (): string => (process.env.GANDER_GITHUB_API_URL ?? DEFAULT_API_
 
 function githubHeaders(token: string): Record<string, string> {
   return { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" };
+}
+
+interface GraphqlResponse {
+  errors?: Array<{ message?: unknown }>;
+}
+
+/** Mirror one Gander checkoff to the authenticated reviewer's GitHub Viewed state. */
+export async function setFileViewed(
+  pullRequestId: string,
+  path: string,
+  viewed: boolean,
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const mutation = viewed ? "markFileAsViewed" : "unmarkFileAsViewed";
+  const input = viewed ? "MarkFileAsViewedInput" : "UnmarkFileAsViewedInput";
+  const res = await fetchImpl(`${apiBase()}/graphql`, {
+    method: "POST",
+    headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query: `mutation MirrorFileViewed($input: ${input}!) { ${mutation}(input: $input) { clientMutationId } }`,
+      variables: { input: { pullRequestId, path } },
+    }),
+  });
+  if (!res.ok) throw new Error(`GitHub API ${res.status}: ${await res.text()}`);
+  const body = (await res.json()) as GraphqlResponse;
+  if (body.errors?.length) {
+    const detail = body.errors.map((error) => typeof error.message === "string" ? error.message : "Unknown GraphQL error").join("; ");
+    throw new Error(`GitHub GraphQL: ${detail}`);
+  }
 }
 
 export async function listOpenPrs(repoId: string, token: string, fetchImpl: typeof fetch = fetch): Promise<PrSummary[]> {
@@ -39,7 +70,7 @@ export async function listOpenPrs(repoId: string, token: string, fetchImpl: type
     page += 1;
   }
   return all.map((p) => ({
-    number: p.number, title: p.title, body: p.body ?? "", draft: p.draft,
+    githubId: p.node_id, number: p.number, title: p.title, body: p.body ?? "", draft: p.draft,
     baseRef: p.base.ref, baseSha: p.base.sha, headRef: p.head.ref, headSha: p.head.sha,
     stack: p.stack ?? null,
   }));

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -7,7 +7,7 @@ import { connectionIsFromEnvironment, loadConfig, resolveServiceConnection, save
 import { checkConnection } from "./connection.js";
 import { parseOpenTarget } from "./cli.js";
 import { createGitEngine, type GitEngine } from "./git.js";
-import { checkGithubToken, listOpenPrs, resolveGithubToken } from "./github.js";
+import { checkGithubToken, listOpenPrs, resolveGithubToken, setFileViewed } from "./github.js";
 import { startOpenServer } from "./open-socket.js";
 import { createReviewer } from "./review.js";
 import { createServiceClient } from "./service-client.js";
@@ -77,6 +77,7 @@ async function bootstrap(): Promise<{ cfg: GanderConfig; git: GitEngine }> {
   const reviewer = createReviewer({
     git, service,
     listPrs: async (repoId) => listOpenPrs(repoId, await githubToken()),
+    setFileViewed: async (pullRequestId, path, viewed) => setFileViewed(pullRequestId, path, viewed, await githubToken()),
     repoUrl: (repoId) => requireRepo(repoId).url,
     machine: hostname(),
   });

--- a/packages/app/src/main/review.test.ts
+++ b/packages/app/src/main/review.test.ts
@@ -18,7 +18,7 @@ let storage: Storage; let server: FastifyInstance; let reviewer: Reviewer; let p
 async function currentPr(fx: FixtureRepo): Promise<PrSummary> {
   const headSha = await fx.git(["rev-parse", "refs/pull/1/head"]);
   const baseSha = await fx.git(["rev-parse", "main"]);
-  return { number: 1, title: "Feature", body: "", draft: false, baseRef: "main", baseSha, headRef: "feature", stack: null, headSha };
+  return { githubId: "PR_test_1", number: 1, title: "Feature", body: "", draft: false, baseRef: "main", baseSha, headRef: "feature", stack: null, headSha };
 }
 
 beforeEach(async () => {
@@ -34,6 +34,7 @@ beforeEach(async () => {
     git: createGitEngine(clonesRoot),
     service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
     listPrs: async () => [await currentPr(fixture)],
+    setFileViewed: async () => {},
     repoUrl: () => fixture.dir,
     machine: "test-machine",
   });
@@ -71,6 +72,7 @@ describe("review pipeline", () => {
       git: countingEngine,
       service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
       listPrs: async () => [await currentPr(fixture)],
+      setFileViewed: async () => {},
       repoUrl: () => fixture.dir,
       machine: "test-machine",
     });
@@ -120,7 +122,7 @@ describe("review pipeline", () => {
 
   it("setChecked persists through the service and survives re-open", async () => {
     await reviewer.openPr("acme/atlas", 1);
-    const view = await reviewer.setChecked("acme/atlas", 1, "a.rb", true);
+    const { view } = await reviewer.setChecked("acme/atlas", 1, "a.rb", true);
     expect(view.files.find((f) => f.path === "a.rb")!.checked).toBe(true);
 
     const reopened = await reviewer.openPr("acme/atlas", 1);
@@ -129,10 +131,52 @@ describe("review pipeline", () => {
 
   it("setCheckedMany checks a batch from the cached view and persists it", async () => {
     await reviewer.openPr("acme/atlas", 1);
-    const view = await reviewer.setCheckedMany("acme/atlas", 1, ["a.rb", "b.rb"], true);
+    const { view } = await reviewer.setCheckedMany("acme/atlas", 1, ["a.rb", "b.rb"], true);
     expect(view.files.every((f) => f.checked)).toBe(true);
     const reopened = await reviewer.openPr("acme/atlas", 1);
     expect(reopened.files.every((f) => f.checked)).toBe(true);
+  });
+
+  it("mirrors each saved checkoff to the GitHub pull request", async () => {
+    const calls: Array<[string, string, boolean]> = [];
+    const mirrored = createReviewer({
+      git: createGitEngine(clonesRoot),
+      service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
+      listPrs: async () => [await currentPr(fixture)],
+      setFileViewed: async (...args) => { calls.push(args); },
+      repoUrl: () => fixture.dir,
+      machine: "test-machine",
+    });
+    await mirrored.openPr("acme/atlas", 1);
+
+    const checked = await mirrored.setCheckedMany("acme/atlas", 1, ["a.rb", "b.rb"], true);
+    const unchecked = await mirrored.setChecked("acme/atlas", 1, "a.rb", false);
+
+    expect(checked.githubError).toBeNull();
+    expect(unchecked.githubError).toBeNull();
+    expect(calls).toEqual([
+      ["PR_test_1", "a.rb", true],
+      ["PR_test_1", "b.rb", true],
+      ["PR_test_1", "a.rb", false],
+    ]);
+  });
+
+  it("keeps the Gander checkoff and reports the mismatch when GitHub rejects it", async () => {
+    const mirrored = createReviewer({
+      git: createGitEngine(clonesRoot),
+      service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
+      listPrs: async () => [await currentPr(fixture)],
+      setFileViewed: async () => { throw new Error("GitHub GraphQL: Resource not accessible by integration"); },
+      repoUrl: () => fixture.dir,
+      machine: "test-machine",
+    });
+    await mirrored.openPr("acme/atlas", 1);
+
+    const result = await mirrored.setChecked("acme/atlas", 1, "a.rb", true);
+
+    expect(result.view.files.find((file) => file.path === "a.rb")?.checked).toBe(true);
+    expect(result.githubError).toMatch(/saved as reviewed in Gander.*GitHub.*Resource not accessible/s);
+    expect(storage.getReview("acme/atlas", 1).files.find((file) => file.path === "a.rb")?.checked).toBe(true);
   });
 
   it("setChecked throws if the PR was never opened", async () => {
@@ -151,6 +195,7 @@ describe("review pipeline", () => {
       git: createGitEngine(clonesRoot),
       service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
       listPrs: async () => [await currentPr(moved)],
+      setFileViewed: async () => {},
       repoUrl: () => moved.dir,
       machine: "test-machine",
     });
@@ -240,7 +285,7 @@ describe("review pipeline", () => {
     await fixture.git(["checkout", "main"]);
 
     await reviewer.openPr("acme/atlas", 1);
-    const reChecked = await reviewer.setChecked("acme/atlas", 1, "a.rb", true);
+    const { view: reChecked } = await reviewer.setChecked("acme/atlas", 1, "a.rb", true);
     const a = reChecked.files.find((f) => f.path === "a.rb")!;
     expect(a.checked).toBe(true);
     expect(a.changedSince).toBe(false);
@@ -265,6 +310,7 @@ describe("review pipeline", () => {
       git: countingEngine,
       service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
       listPrs: async () => [await currentPr(fixture)],
+      setFileViewed: async () => {},
       repoUrl: () => fixture.dir,
       machine: "test-machine",
     });
@@ -364,6 +410,7 @@ describe("review pipeline", () => {
       git: createGitEngine(clonesRoot),
       service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
       listPrs: async () => [await currentPr(fixture)],
+      setFileViewed: async () => {},
       repoUrl: () => fixture.dir,
       machine: "test-machine",
     });
@@ -399,6 +446,7 @@ describe("review pipeline", () => {
       git: createGitEngine(clonesRoot),
       service: createServiceClient(() => ({ url: `http://127.0.0.1:${port}`, token: "t" })),
       listPrs: async () => [await currentPr(fixture)],
+      setFileViewed: async () => {},
       repoUrl: () => fixture.dir,
       machine: "test-machine",
     });

--- a/packages/app/src/main/review.ts
+++ b/packages/app/src/main/review.ts
@@ -7,6 +7,7 @@ export interface ReviewerDeps {
   git: GitEngine;
   service: ServiceClient;
   listPrs(repoId: string): Promise<PrSummary[]>;
+  setFileViewed(pullRequestId: string, path: string, viewed: boolean): Promise<void>;
   repoUrl(repoId: string): string;
   machine: string;
 }
@@ -14,14 +15,20 @@ export interface Reviewer {
   listPrsWithProgress(repoId: string): Promise<PrListItem[]>;
   openPr(repoId: string, prNumber: number): Promise<PrView>;
   refreshPr(repoId: string, prNumber: number): Promise<PrView>;
-  setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<PrView>;
-  setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView>;
+  setChecked(repoId: string, prNumber: number, path: string, checked: boolean): Promise<CheckoffResult>;
+  setCheckedMany(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<CheckoffResult>;
   addNote(repoId: string, prNumber: number, input: Omit<NewNote, "headSha" | "sourceContext">): Promise<PrView>;
   updateNote(repoId: string, prNumber: number, id: number, input: UpdateNote): Promise<PrView>;
   deleteNote(repoId: string, prNumber: number, id: number): Promise<PrView>;
   /** The file as it stood when the reviewer last checked it — the base for the delta view. */
   reviewedSnapshot(repoId: string, prNumber: number, path: string): Promise<string | null>;
   imagePreview(repoId: string, prNumber: number, path: string): Promise<ImagePreview>;
+}
+
+export interface CheckoffResult {
+  view: PrView;
+  /** Gander is authoritative, so a GitHub failure is returned beside the saved view. */
+  githubError: string | null;
 }
 
 interface CacheEntry {
@@ -189,12 +196,16 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     return useCachedViewOnConnectionFailure(repoId, prNumber, () => loadRefresh(repoId, prNumber));
   }
 
-  async function applyChecked(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<PrView> {
+  async function applyChecked(repoId: string, prNumber: number, paths: string[], checked: boolean): Promise<CheckoffResult> {
     const entry = requireWritable(repoId, prNumber);
     const { view } = entry;
-    for (const path of paths) {
-      const file = view.files.find((f) => f.path === path);
+    const files = paths.map((path) => {
+      const file = view.files.find((candidate) => candidate.path === path);
       if (!file) throw new Error(`${path} is not part of PR #${prNumber}`);
+      return file;
+    });
+    for (const file of files) {
+      const { path } = file;
       if (checked) {
         await writeServiceState(entry, () => deps.service.putFileState(repoId, prNumber, {
           checked: true, path,
@@ -209,7 +220,22 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
         file.checked = false;
       }
     }
-    return view;
+
+    const failures: string[] = [];
+    for (const { path } of files) {
+      try {
+        await deps.setFileViewed(view.pr.githubId, path, checked);
+      } catch (error) {
+        failures.push(`${path}: ${(error as Error).message}`);
+      }
+    }
+    const action = checked ? "reviewed" : "unreviewed";
+    const saved = files.length === 1 ? files[0]!.path : `${files.length} files`;
+    const failed = failures.length === 1 ? "1 file" : `${failures.length} files`;
+    const githubError = failures.length === 0
+      ? null
+      : `${saved} saved as ${action} in Gander, but GitHub did not mirror ${failed}: ${failures.join("; ")}`;
+    return { view, githubError };
   }
 
   function requireWritable(repoId: string, prNumber: number): CacheEntry {

--- a/packages/app/src/renderer/src/components/FileTree.test.ts
+++ b/packages/app/src/renderer/src/components/FileTree.test.ts
@@ -13,7 +13,7 @@ const file = (path: string, checked = false): PrFile =>
 
 function prView(prNumber: number, files: PrFile[], notes: PrView["notes"] = []): PrView {
   return {
-    pr: { number: prNumber, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" },
+    pr: { githubId: `PR_test_${prNumber}`, number: prNumber, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" },
     files,
     notes,
   };

--- a/packages/app/src/renderer/src/components/NotesDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/NotesDrawer.test.ts
@@ -21,7 +21,7 @@ if (typeof HTMLDialogElement !== "undefined" && !HTMLDialogElement.prototype.sho
 }
 
 const view = (notes: PrView["notes"]): PrView => ({
-  pr: { number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" },
+  pr: { githubId: "PR_test_1", number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" },
   files: [],
   notes,
 });

--- a/packages/app/src/renderer/src/components/TargetBar.test.ts
+++ b/packages/app/src/renderer/src/components/TargetBar.test.ts
@@ -5,7 +5,7 @@ import type { Store } from "../store.js";
 import TargetBar from "./TargetBar.vue";
 
 const pr = (number: number, headRef: string, title: string) => ({
-  number, title, body: "", draft: false, baseRef: "main", baseSha: "a", headRef, headSha: "b",
+  githubId: `PR_test_${number}`, number, title, body: "", draft: false, baseRef: "main", baseSha: "a", headRef, headSha: "b",
   stack: null, reviewProgress: null,
 });
 

--- a/packages/app/src/renderer/src/store.test.ts
+++ b/packages/app/src/renderer/src/store.test.ts
@@ -6,7 +6,7 @@ import { createStore, readable } from "./store.js";
 import { DEFAULT_APP_SETTINGS } from "../../settings.js";
 
 const prView = (checkedPaths: string[] = []): PrView => ({
-  pr: { number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" },
+  pr: { githubId: "PR_test_1", number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b" },
   files: [
     { path: "a.rb", status: "M", baseContent: "o", headContent: "n", baseHash: "b1", headHash: "h1", checked: checkedPaths.includes("a.rb"), changedSince: false },
     { path: "b.rb", status: "A", baseContent: null, headContent: "x", baseHash: null, headHash: "h2", checked: checkedPaths.includes("b.rb"), changedSince: false },
@@ -35,10 +35,10 @@ function fakeApi(overrides: Partial<GanderApi> = {}): GanderApi {
     chooseLocalRepo: async () => null,
     removeRepo: async () => {},
     listWorktrees: async () => [],
-    listPrs: async () => [{ number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b", reviewProgress: null }],
+    listPrs: async () => [{ githubId: "PR_test_1", number: 1, title: "T", body: "", draft: false, baseRef: "main", baseSha: "a", headRef: "feature", stack: null, headSha: "b", reviewProgress: null }],
     openPr: async () => prView(),
-    setChecked: async (_r, _n, path, checked) => prView(checked ? [path] : []),
-    setCheckedMany: async (_r, _n, paths) => prView(paths),
+    setChecked: async (_r, _n, path, checked) => ({ view: prView(checked ? [path] : []), githubError: null }),
+    setCheckedMany: async (_r, _n, paths) => ({ view: prView(paths), githubError: null }),
     refreshPr: async () => prView(),
     lastReview: async () => null,
     initialTarget: async () => null,
@@ -183,6 +183,23 @@ describe("store", () => {
     expect(store.prs[0]?.reviewProgress).toEqual({ done: 1, total: 2 });
     await store.setChecked("a.rb", false);
     expect(store.prs[0]?.reviewProgress).toEqual({ done: 0, total: 2 });
+  });
+
+  it("shows a GitHub mirror failure without losing the saved Gander checkoff", async () => {
+    const store = createStore(fakeApi({
+      setChecked: async (_repoId, _prNumber, path) => ({
+        view: prView([path]),
+        githubError: `${path} saved as reviewed in Gander, but GitHub did not mirror 1 file`,
+      }),
+    }));
+    await store.loadRepos();
+    await store.selectRepo("acme/atlas");
+    await store.openPr(1);
+
+    await store.setChecked("a.rb", true);
+
+    expect(store.view?.files.find((file) => file.path === "a.rb")?.checked).toBe(true);
+    expect(store.error).toMatch(/saved as reviewed in Gander/);
   });
 
   it("registers and selects a repository from a chosen checkout", async () => {

--- a/packages/app/src/renderer/src/store.ts
+++ b/packages/app/src/renderer/src/store.ts
@@ -311,14 +311,18 @@ export function createStore(api: GanderApi): Store {
     async setChecked(path: string, checked: boolean) {
       await guard(async () => {
         const { repoId, prNumber } = requireOpenPr();
-        store.view = await api.setChecked(repoId, prNumber, path, checked);
+        const result = await api.setChecked(repoId, prNumber, path, checked);
+        store.view = result.view;
+        store.error = result.githubError;
         syncCurrentProgress();
       });
     },
     async setCheckedMany(paths: string[], checked: boolean) {
       await guard(async () => {
         const { repoId, prNumber } = requireOpenPr();
-        store.view = await api.setCheckedMany(repoId, prNumber, paths, checked);
+        const result = await api.setCheckedMany(repoId, prNumber, paths, checked);
+        store.view = result.view;
+        store.error = result.githubError;
         syncCurrentProgress();
       });
     },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -128,6 +128,8 @@ export const MarkInProgressSchema = z.object({
 export type MarkInProgress = z.infer<typeof MarkInProgressSchema>;
 
 export interface PrSummary {
+  /** GitHub's global node ID, required by file-viewed GraphQL mutations. */
+  githubId: string;
   number: number;
   title: string;
   body: string;


### PR DESCRIPTION
## Summary
- mirror Gander reviewed and unreviewed checkoffs to GitHub Viewed state
- keep Gander authoritative and surface partial GitHub failures without losing saved review state
- extend the GitHub fake and Electron coverage for mark/unmark behavior
- update authentication guidance for the required pull-request write permission

## Verification
- pnpm test (430 tests)
- pnpm typecheck
- pnpm --filter @gander/app run test:e2e:run (22 tests)