### PR TITLE
Add Cmd+P quick file jump

### DIFF
--- a/packages/app/e2e/quick-file-jump.spec.ts
+++ b/packages/app/e2e/quick-file-jump.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "./fixtures/test.js";
+import { ReviewDriver } from "./drivers/review.js";
+
+test("finds and reveals a pull-request file with Cmd+P", async ({ world }) => {
+  const target = "packages/app/src/components/QuickFilePicker.vue";
+  const repository = await world.addRepository({
+    repoId: "acme/quick-file-jump",
+    featureFiles: {
+      [target]: "export const picker = true;\n",
+      "packages/service/src/server.ts": "export const server = true;\n",
+      "docs/quick-open.md": "# Quick Open\n",
+    },
+  });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+  await review.open(repository.title);
+
+  await app.page.locator(".tnode.isdir").filter({ hasText: "packages" }).click();
+  await expect(review.file(target)).toHaveCount(0);
+  await expect(review.file("a.rb")).toHaveClass(/sel/);
+
+  const shortcut = process.platform === "darwin" ? "Meta+p" : "Control+p";
+  await app.page.keyboard.press(shortcut);
+  const picker = app.page.getByRole("dialog", { name: "Quick file jump" });
+  const search = app.page.getByRole("combobox", { name: "Search files in this pull request" });
+  await expect(picker).toBeVisible();
+  await expect(search).toBeFocused();
+  await search.fill("qfp");
+  await expect(picker.getByRole("option")).toHaveCount(1);
+  await search.press("Escape");
+  await expect(picker).toHaveCount(0);
+  await expect(review.file("a.rb")).toHaveClass(/sel/);
+
+  await app.page.keyboard.press(shortcut);
+  await search.fill("qfp");
+  await search.press("Enter");
+
+  await expect(picker).toHaveCount(0);
+  await expect(review.file(target)).toBeVisible();
+  await expect(review.file(target)).toHaveClass(/sel/);
+  await expect(review.file(target)).toHaveClass(/cur/);
+
+  await app.page.keyboard.press("?");
+  const shortcutLabel = process.platform === "darwin" ? "⌘P" : "Ctrl+P";
+  await expect(app.page.getByRole("dialog", { name: "Keyboard shortcuts" })).toContainText(shortcutLabel);
+  await expect(app.page.getByRole("dialog", { name: "Keyboard shortcuts" })).toContainText("Open a file in this pull request");
+});

--- a/packages/app/src/renderer/src/App.vue
+++ b/packages/app/src/renderer/src/App.vue
@@ -21,6 +21,8 @@ import SettingsPane from "./components/SettingsPane.vue";
 import StatusBar from "./components/StatusBar.vue";
 import TargetBar from "./components/TargetBar.vue";
 import WorkbenchSidebar from "./components/WorkbenchSidebar.vue";
+import QuickFilePicker from "./components/QuickFilePicker.vue";
+import { revealReviewFile } from "./tree-nav.js";
 
 const store = createStore(api);
 const editorSettings = createEditorSettingsStore(api, api.initialWindowState.colorTheme);
@@ -38,6 +40,7 @@ const noteFocusRequest = shallowRef(0);
 const drawerOpen = ref(false);
 const treeVisible = ref(true);
 const helpOpen = ref(false);
+const quickFileOpen = shallowRef(false);
 const repoPendingRemoval = ref<string | null>(null);
 const reviewSurface = ref<InstanceType<typeof ReviewSurface> | null>(null);
 
@@ -52,6 +55,7 @@ const treeJump = useReviewKeyboard({
   helpOpen,
   diff: () => reviewSurface.value,
   captureNote: () => openNote(),
+  openQuickFile,
 });
 
 useBackgroundRefresh(store, () => store.view !== null || store.localView !== null);
@@ -65,6 +69,7 @@ onMounted(() => {
 watch(activeMode, (mode) => {
   if (mode === "pulls") return;
   drawerOpen.value = false;
+  quickFileOpen.value = false;
   closeNote();
 });
 
@@ -72,6 +77,7 @@ watch(() => [store.targetRepoId, store.selectedPrNumber] as const, ([repoId, prN
   if (repoId === previous[0] && prNumber === previous[1]) return;
   // A draft belongs to the review where it began. The pane no longer blocks navigation,
   // so switching reviews must not carry that target into a different pull request.
+  quickFileOpen.value = false;
   closeNote();
 });
 
@@ -92,6 +98,18 @@ function openNote(target?: NoteTarget): void {
 function closeNote(): void {
   noteTarget.value = null;
   noteDraft.value = "";
+}
+
+function openQuickFile(): void {
+  if (!store.view || activeMode.value !== "pulls") return;
+  helpOpen.value = false;
+  quickFileOpen.value = true;
+}
+
+function selectQuickFile(path: string): void {
+  revealReviewFile(path);
+  store.select(path);
+  quickFileOpen.value = false;
 }
 
 async function confirmRemoveRepo(): Promise<void> {
@@ -184,6 +202,14 @@ async function confirmRemoveRepo(): Promise<void> {
       @open-zoom-settings="openSettings('workbench')"
     />
     <KeymapHelp v-if="helpOpen" @close="helpOpen = false" />
+    <QuickFilePicker
+      v-if="quickFileOpen && store.view"
+      :files="store.view.files"
+      :selected-path="store.selectedPath"
+      :icon-theme="editorSettings.settings.workbench.iconTheme"
+      @select="selectQuickFile"
+      @close="quickFileOpen = false"
+    />
     <ConfirmDialog
       :open="repoPendingRemoval !== null"
       title="Remove repository?"

--- a/packages/app/src/renderer/src/components/KeymapHelp.vue
+++ b/packages/app/src/renderer/src/components/KeymapHelp.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BINDINGS, GROUPS } from "../keymap.js";
+import { BINDINGS, GROUPS, bindingLabel } from "../keymap.js";
 
 defineEmits<{ close: [] }>();
 
@@ -20,7 +20,7 @@ const inGroup = (group: string) => BINDINGS.filter((binding) => binding.group ==
           <h3>{{ group }}</h3>
           <dl>
             <template v-for="binding in inGroup(group)" :key="binding.command">
-              <dt><kbd>{{ binding.label }}</kbd></dt>
+              <dt><kbd>{{ bindingLabel(binding.command) }}</kbd></dt>
               <dd>{{ binding.description }}</dd>
             </template>
           </dl>

--- a/packages/app/src/renderer/src/components/QuickFilePicker.test.ts
+++ b/packages/app/src/renderer/src/components/QuickFilePicker.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { describe, expect, it } from "vitest";
+import type { PrFile } from "@gander/shared";
+import QuickFilePicker from "./QuickFilePicker.vue";
+
+if (typeof HTMLDialogElement !== "undefined" && !HTMLDialogElement.prototype.showModal) {
+  HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
+    this.open = true;
+  };
+}
+if (typeof HTMLDialogElement !== "undefined" && !HTMLDialogElement.prototype.close) {
+  HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+    this.open = false;
+  };
+}
+
+const file = (path: string, status: PrFile["status"] = "M"): PrFile => ({
+  path,
+  status,
+  baseContent: "old",
+  headContent: "new",
+  baseHash: "base",
+  headHash: "head",
+  checked: false,
+  changedSince: false,
+});
+
+const files = [
+  file("README.md"),
+  file("packages/app/src/components/QuickFilePicker.vue", "A"),
+  file("packages/service/src/server.ts"),
+];
+
+describe("QuickFilePicker", () => {
+  it("filters paths fuzzily and opens the active result", async () => {
+    const wrapper = mount(QuickFilePicker, {
+      attachTo: document.body,
+      props: { files, selectedPath: "README.md", iconTheme: "catppuccin-mocha" },
+    });
+    const input = wrapper.get("input");
+
+    await nextTick();
+    expect(document.activeElement).toBe(input.element);
+    await input.setValue("qfp");
+    expect(wrapper.findAll("[role='option']")).toHaveLength(1);
+    expect(wrapper.get("[role='option']").text()).toContain("QuickFilePicker.vue");
+    expect(wrapper.findAll("mark.match").map((part) => part.text()).join("")).toBe("QFP");
+
+    await input.trigger("keydown", { key: "Enter" });
+    expect(wrapper.emitted("select")).toEqual([["packages/app/src/components/QuickFilePicker.vue"]]);
+    wrapper.unmount();
+  });
+
+  it("moves through results and Escape closes without selecting", async () => {
+    const returnTarget = document.createElement("button");
+    document.body.append(returnTarget);
+    returnTarget.focus();
+    const wrapper = mount(QuickFilePicker, {
+      attachTo: document.body,
+      props: { files, selectedPath: "README.md", iconTheme: "catppuccin-mocha" },
+    });
+    const input = wrapper.get("input");
+
+    expect(wrapper.get("[role='option'][aria-selected='true']").text()).toContain("README.md");
+    await input.trigger("keydown", { key: "ArrowDown" });
+    expect(wrapper.get("[role='option'][aria-selected='true']").text()).toContain("QuickFilePicker.vue");
+    await input.trigger("keydown", { key: "Escape" });
+    await nextTick();
+
+    expect(wrapper.emitted("close")).toHaveLength(1);
+    expect(wrapper.emitted("select")).toBeUndefined();
+    expect(document.activeElement).toBe(returnTarget);
+    wrapper.unmount();
+    returnTarget.remove();
+  });
+
+  it("shows a clear empty result state", async () => {
+    const wrapper = mount(QuickFilePicker, {
+      props: { files, selectedPath: null, iconTheme: "catppuccin-mocha" },
+    });
+
+    await wrapper.get("input").setValue("does-not-exist");
+    expect(wrapper.get(".empty").text()).toBe("No matching files");
+    expect(wrapper.findAll("[role='option']")).toHaveLength(0);
+  });
+});

--- a/packages/app/src/renderer/src/components/QuickFilePicker.vue
+++ b/packages/app/src/renderer/src/components/QuickFilePicker.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, shallowRef, useTemplateRef, watch } from "vue";
+import { Search } from "@lucide/vue";
+import type { PrFile } from "@gander/shared";
+import type { FileIconThemeId } from "../../../file-icon-themes.js";
+import { bindingLabel } from "../keymap.js";
+import { quickFileMatches } from "../quick-file.js";
+import { useTreeIcons } from "../composables/use-tree-icons.js";
+import FileIcon from "./FileIcon.vue";
+
+const props = defineProps<{
+  files: PrFile[];
+  selectedPath: string | null;
+  iconTheme: FileIconThemeId;
+}>();
+const emit = defineEmits<{ close: []; select: [path: string] }>();
+
+const dialog = useTemplateRef<HTMLDialogElement>("dialog");
+const input = useTemplateRef<HTMLInputElement>("input");
+const query = shallowRef("");
+const initiallySelected = props.files.findIndex((file) => file.path === props.selectedPath);
+const activeIndex = shallowRef(Math.max(0, initiallySelected));
+const matches = computed(() => quickFileMatches(props.files.map((file) => file.path), query.value));
+const activeId = computed(() => matches.value[activeIndex.value] === undefined
+  ? undefined
+  : `quick-file-option-${activeIndex.value}`);
+const filesByPath = computed(() => new Map(props.files.map((file) => [file.path, file])));
+const { fileIcon } = useTreeIcons(() => props.iconTheme);
+const shortcutLabel = bindingLabel("quick-file");
+let returnFocus: HTMLElement | null = null;
+
+onMounted(async () => {
+  returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  dialog.value?.showModal();
+  await nextTick();
+  input.value?.focus();
+  input.value?.select();
+});
+
+watch(query, () => { activeIndex.value = 0; });
+watch(matches, (next) => {
+  if (activeIndex.value >= next.length) activeIndex.value = Math.max(0, next.length - 1);
+});
+watch(activeIndex, async (index) => {
+  await nextTick();
+  dialog.value?.querySelector(`#quick-file-option-${index}`)?.scrollIntoView?.({ block: "nearest" });
+});
+
+function move(delta: 1 | -1): void {
+  if (matches.value.length === 0) return;
+  activeIndex.value = (activeIndex.value + delta + matches.value.length) % matches.value.length;
+}
+
+function choose(path = matches.value[activeIndex.value]?.path): void {
+  if (path !== undefined) finish("select", path);
+}
+
+async function finish(action: "close" | "select", path?: string): Promise<void> {
+  dialog.value?.close();
+  if (action === "select" && path !== undefined) emit("select", path);
+  else emit("close");
+  await nextTick();
+  if (returnFocus?.isConnected) returnFocus.focus();
+}
+
+function closeFromBackdrop(event: MouseEvent): void {
+  if (event.target === event.currentTarget) void finish("close");
+}
+
+function pathParts(path: string, matchIndices: number[]): Array<{ text: string; matched: boolean }> {
+  const matched = new Set(matchIndices);
+  return [...path].map((text, index) => ({ text, matched: matched.has(index) }));
+}
+</script>
+
+<template>
+  <dialog
+    ref="dialog"
+    class="quick-file"
+    aria-label="Quick file jump"
+    @cancel.prevent="finish('close')"
+    @click="closeFromBackdrop"
+  >
+    <div class="picker">
+      <label class="search-field">
+        <Search :size="16" aria-hidden="true" />
+        <input
+          ref="input"
+          v-model="query"
+          autofocus
+          type="text"
+          role="combobox"
+          aria-label="Search files in this pull request"
+          aria-autocomplete="list"
+          aria-controls="quick-file-results"
+          :aria-activedescendant="activeId"
+          aria-expanded="true"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="Search files by path"
+          @keydown.down.prevent="move(1)"
+          @keydown.up.prevent="move(-1)"
+          @keydown.enter.prevent="choose()"
+          @keydown.escape.prevent="finish('close')"
+        >
+        <kbd>{{ shortcutLabel }}</kbd>
+      </label>
+
+      <div id="quick-file-results" class="results" role="listbox" aria-label="Matching files">
+        <button
+          v-for="(match, index) in matches"
+          :id="`quick-file-option-${index}`"
+          :key="match.path"
+          type="button"
+          class="result"
+          :class="{ active: index === activeIndex }"
+          role="option"
+          :aria-selected="index === activeIndex"
+          @mousemove="activeIndex = index"
+          @click="choose(match.path)"
+        >
+          <FileIcon :icon="fileIcon(match.path)" />
+          <span class="path">
+            <template v-for="(part, partIndex) in pathParts(match.path, match.matchIndices)" :key="partIndex">
+              <mark v-if="part.matched" class="match">{{ part.text }}</mark>
+              <template v-else>{{ part.text }}</template>
+            </template>
+          </span>
+          <span class="status" :class="filesByPath.get(match.path)?.status">
+            {{ filesByPath.get(match.path)?.status }}
+          </span>
+        </button>
+        <p v-if="matches.length === 0" class="empty">No matching files</p>
+      </div>
+
+      <footer class="hints" aria-hidden="true">
+        <span><kbd>↑↓</kbd> Navigate</span>
+        <span><kbd>↵</kbd> Open</span>
+        <span><kbd>Esc</kbd> Close</span>
+      </footer>
+    </div>
+  </dialog>
+</template>
+
+<style scoped>
+.quick-file {
+  width: min(640px, calc(100vw - 48px)); max-height: min(520px, calc(100vh - 80px));
+  margin: 58px auto auto; padding: 0; overflow: hidden;
+  border: 1px solid var(--workbench-border); border-radius: var(--radius-lg);
+  background: var(--panel-background); color: var(--workbench-foreground);
+  box-shadow: 0 18px 48px var(--workbench-shadow);
+}
+.quick-file::backdrop { background: var(--overlay-background); }
+.picker { display: flex; max-height: min(520px, calc(100vh - 80px)); flex-direction: column; }
+.search-field { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 10px; padding: 10px 12px; border-bottom: 1px solid var(--workbench-border); color: var(--faint-foreground); }
+.search-field:focus-within { color: var(--accent); box-shadow: inset 0 -1px 0 var(--accent); }
+.search-field input { width: 100%; border: 0; outline: 0; background: transparent; color: var(--workbench-foreground); font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; caret-color: var(--accent); }
+.search-field input::placeholder { color: var(--faint-foreground); }
+kbd { display: inline-flex; min-width: 24px; height: 20px; align-items: center; justify-content: center; padding: 0 5px; border: 1px solid var(--workbench-border); border-radius: var(--radius-sm); background: var(--input-background); color: var(--muted-foreground); font: 10px/1 var(--mono); }
+.results { min-height: 42px; overflow-y: auto; padding: 6px; }
+.result { display: grid; width: 100%; grid-template-columns: 16px minmax(0, 1fr) auto; align-items: center; gap: 8px; min-height: 30px; padding: 4px 8px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--workbench-foreground); text-align: left; cursor: pointer; }
+.result.active { background: var(--selection-background); }
+.result:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.path { overflow: hidden; font: 12.5px/1.4 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.match { padding: 0; background: transparent; color: var(--accent); font-weight: 750; }
+.status { color: var(--faint-foreground); font: 11px/1 var(--mono); }
+.status.M { color: var(--warning); }
+.status.A { color: var(--success); }
+.status.D { color: var(--danger); }
+.status.R { color: var(--info); }
+.empty { padding: 16px 10px; color: var(--faint-foreground); text-align: center; }
+.hints { display: flex; justify-content: flex-end; gap: 14px; padding: 6px 10px; border-top: 1px solid var(--workbench-border); color: var(--faint-foreground); font-size: 10.5px; }
+.hints span { display: inline-flex; align-items: center; gap: 5px; }
+</style>

--- a/packages/app/src/renderer/src/composables/use-review-keyboard.ts
+++ b/packages/app/src/renderer/src/composables/use-review-keyboard.ts
@@ -22,6 +22,7 @@ export interface KeyboardSurface {
   /** Null until the review surface has mounted its diff. */
   diff: () => DiffCommands | null;
   captureNote: () => void;
+  openQuickFile: () => void;
 }
 
 /**
@@ -63,6 +64,9 @@ export function useReviewKeyboard(surface: KeyboardSurface): TreeJump {
         return moveTo(edge(files, command === "first-file" ? "first" : "last"));
       case "jump-row":
         return surface.treeVisible.value && store.currentRepoId === store.targetRepoId && treeJump.start();
+      case "quick-file":
+        surface.openQuickFile();
+        return true;
       case "toggle-directory": {
         if (at === null) return true;
         // Opening a directory is how a reviewer says "let me look in here", so the cursor

--- a/packages/app/src/renderer/src/keymap.test.ts
+++ b/packages/app/src/renderer/src/keymap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BINDINGS, GROUPS, bindingFor, isPrefix } from "./keymap.js";
+import { BINDINGS, GROUPS, bindingFor, bindingLabel, isPrefix } from "./keymap.js";
 
 const press = (key: string, modifiers: Partial<KeyboardEvent> = {}): KeyboardEvent =>
   ({ key, metaKey: false, ctrlKey: false, altKey: false, ...modifiers }) as KeyboardEvent;
@@ -35,6 +35,18 @@ describe("keymap", () => {
 
   it("starts the visible-row jump with f", () => {
     expect(bindingFor(press("f"))?.command).toBe("jump-row");
+  });
+
+  it("opens the pull-request file picker with Command or Control P", () => {
+    expect(bindingFor(press("p", { metaKey: true }))?.command).toBe("quick-file");
+    expect(bindingFor(press("p", { ctrlKey: true }))?.command).toBe("quick-file");
+    expect(bindingFor(press("p"))).toBeNull();
+  });
+
+  it("prints the platform modifier used by modified bindings", () => {
+    expect(bindingLabel("quick-file", true)).toBe("⌘P");
+    expect(bindingLabel("quick-file", false)).toBe("Ctrl+P");
+    expect(bindingLabel("next-file", false)).toBe("j / ↓");
   });
 
   // The `?` sheet renders from this table, so a binding outside the printed groups would

--- a/packages/app/src/renderer/src/keymap.ts
+++ b/packages/app/src/renderer/src/keymap.ts
@@ -15,6 +15,7 @@ export type Command =
   | "first-file"
   | "last-file"
   | "jump-row"
+  | "quick-file"
   | "toggle-directory"
   | "dismiss"
   | "toggle-checked"
@@ -48,6 +49,7 @@ export const BINDINGS: Binding[] = [
   { command: "first-file", keys: ["g"], prefix: "g", label: "gg", description: "First row", group: "Move" },
   { command: "last-file", keys: ["G"], label: "⇧G", description: "Last row", group: "Move" },
   { command: "jump-row", keys: ["f"], label: "f", description: "Jump to a visible row by name", group: "Move" },
+  { command: "quick-file", keys: ["p"], label: "⌘P", description: "Open a file in this pull request", group: "Move", meta: true },
   { command: "toggle-directory", keys: ["o"], label: "o", description: "Open the directory and step in, or close the one you are in", group: "Move" },
   { command: "dismiss", keys: ["Escape"], label: "Esc", description: "Close what is open on top", group: "Move" },
 
@@ -66,6 +68,12 @@ export const BINDINGS: Binding[] = [
 ];
 
 export const GROUPS: Binding["group"][] = ["Move", "Review", "Read", "Panels"];
+
+export function bindingLabel(command: Command, isMac = /Mac/.test(globalThis.navigator?.platform ?? "")): string {
+  const binding = BINDINGS.find((candidate) => candidate.command === command);
+  if (!binding) return "";
+  return binding.meta === true && !isMac ? binding.label.replace("⌘", "Ctrl+") : binding.label;
+}
 
 /**
  * `pending` is the prefix key already pressed, if any. A binding with a prefix is reachable

--- a/packages/app/src/renderer/src/quick-file.test.ts
+++ b/packages/app/src/renderer/src/quick-file.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { matchQuickFile, quickFileMatches } from "./quick-file.js";
+
+describe("quick file matching", () => {
+  it("matches a case-insensitive fuzzy subsequence", () => {
+    expect(matchQuickFile("packages/app/src/QuickFilePicker.vue", "qfp")?.matchIndices)
+      .toEqual([17, 22, 26]);
+    expect(matchQuickFile("packages/app/src/QuickFilePicker.vue", "missing")).toBeNull();
+  });
+
+  it("ranks a filename match above the same text in a directory", () => {
+    expect(quickFileMatches([
+      "review/picker/helpers.ts",
+      "review/file-picker.ts",
+      "picker/review.ts",
+    ], "picker").map(({ path }) => path)).toEqual([
+      "review/file-picker.ts",
+      "picker/review.ts",
+      "review/picker/helpers.ts",
+    ]);
+  });
+
+  it("keeps pull-request order when the query is empty", () => {
+    expect(quickFileMatches(["z.ts", "a.ts"], "").map(({ path }) => path)).toEqual(["z.ts", "a.ts"]);
+  });
+});

--- a/packages/app/src/renderer/src/quick-file.ts
+++ b/packages/app/src/renderer/src/quick-file.ts
@@ -1,0 +1,50 @@
+export interface QuickFileMatch {
+  path: string;
+  matchIndices: number[];
+  score: number;
+}
+
+function boundary(path: string, index: number): boolean {
+  if (index === 0) return true;
+  return "/._-".includes(path[index - 1] ?? "");
+}
+
+/**
+ * Scores a case-insensitive subsequence match while favoring the filename, word
+ * boundaries, and consecutive characters. The original path is retained for display.
+ */
+export function matchQuickFile(path: string, query: string): QuickFileMatch | null {
+  const needle = query.trim().toLocaleLowerCase();
+  if (needle === "") return { path, matchIndices: [], score: 0 };
+
+  const haystack = path.toLocaleLowerCase();
+  const basenameAt = haystack.lastIndexOf("/") + 1;
+  const matchIndices: number[] = [];
+  let from = 0;
+  let score = 0;
+
+  for (const character of needle) {
+    const index = haystack.indexOf(character, from);
+    if (index === -1) return null;
+    const previous = matchIndices.at(-1);
+    score += index >= basenameAt ? 8 : 2;
+    if (boundary(haystack, index)) score += 10;
+    if (previous !== undefined && index === previous + 1) score += 12;
+    score -= Math.max(0, index - from);
+    matchIndices.push(index);
+    from = index + 1;
+  }
+
+  const contiguousAt = haystack.indexOf(needle);
+  if (contiguousAt !== -1) score += contiguousAt >= basenameAt ? 80 : 40;
+  score -= path.length / 100;
+  return { path, matchIndices, score };
+}
+
+export function quickFileMatches(paths: string[], query: string): QuickFileMatch[] {
+  return paths
+    .map((path, order) => ({ match: matchQuickFile(path, query), order }))
+    .filter((entry): entry is { match: QuickFileMatch; order: number } => entry.match !== null)
+    .sort((left, right) => right.match.score - left.match.score || left.order - right.order)
+    .map(({ match }) => match);
+}


### PR DESCRIPTION
## Summary
- add a fuzzy file picker for the current pull request
- reveal collapsed directories and move selection when a result opens
- keep the shortcut table and platform-specific help labels in sync

## Verification
- pnpm typecheck
- pnpm test (449 tests)
- pnpm test:e2e:run (23 tests)

Closes #93