### PR TITLE
Open Pull Requests by default at startup

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -87,6 +87,10 @@ picker. The target switcher remembers it and discovers its linked worktrees with
 workspace; the activity bar switches among Explorer, Current Diff, and Pull Requests
 without changing what those modes mean.
 
+On a normal launch, Pull Requests is selected and the initial repository's pull request
+list loads. This also applies after closing the app from another view. An explicit
+command-line target still opens the requested review or local checkout.
+
 Every registered repository has a local checkout. Gander derives its repository ID and
 remote URL from Git; URL-only registration and command-line auto-registration are not
 supported. If the checkout moves, the target switcher can locate a replacement checkout

--- a/packages/app/e2e/activity-rail.spec.ts
+++ b/packages/app/e2e/activity-rail.spec.ts
@@ -1,5 +1,26 @@
 import { test, expect } from "./fixtures/test.js";
 
+test("opens Pull Requests on launch and after using another view", async ({ world }) => {
+  const title = "Startup review";
+  await world.addLocalRepository({ repoId: "acme/startup", title });
+  const app = await world.launch();
+
+  async function expectPullRequests(): Promise<void> {
+    const rail = app.page.getByRole("navigation", { name: "Workspace views" });
+    await expect(rail.getByRole("button", { name: "Pull Requests" })).toHaveClass(/active/);
+    await expect(app.page.getByRole("option").filter({ hasText: title })).toBeVisible();
+  }
+
+  await expectPullRequests();
+  for (const name of ["Explorer", "Current Diff"]) {
+    const button = app.page.getByRole("navigation", { name: "Workspace views" }).getByRole("button", { name });
+    await button.click();
+    await expect(button).toHaveClass(/active/);
+    await app.restart();
+    await expectPullRequests();
+  }
+});
+
 test("reorders workspace views by dragging and remembers the order", async ({ world }) => {
   await world.addLocalRepository({ repoId: "acme/activity-rail" });
   const app = await world.launch();

--- a/packages/app/e2e/drivers/workbench.ts
+++ b/packages/app/e2e/drivers/workbench.ts
@@ -11,9 +11,8 @@ export class WorkbenchDriver {
   }
 
   async selectWorktree(branch: string): Promise<void> {
-    // Launch selects the registered checkout asynchronously. Wait for that first local
-    // view before replacing it, or its late completion can win this interaction race.
-    await expect(this.page.locator(".local-progress")).toBeVisible();
+    // Explorer becomes available once startup has loaded the repository's worktrees.
+    await expect(this.page.getByRole("button", { name: "Explorer", exact: true })).toBeEnabled();
     const trigger = this.page.locator('button[aria-controls="target-picker"]');
     await trigger.click();
     await this.page.locator(".worktree-row").filter({ hasText: branch }).click();

--- a/packages/app/src/renderer/src/composables/use-workbench.ts
+++ b/packages/app/src/renderer/src/composables/use-workbench.ts
@@ -25,7 +25,7 @@ export interface Workbench {
   openExternalTarget(target: OpenTarget): Promise<void>;
   chooseRepo(repoId?: string): Promise<void>;
   removeRepo(repoId: string): Promise<void>;
-  selectRepo(repoId: string, options?: { keepChosenMode?: boolean }): Promise<void>;
+  selectRepo(repoId: string): Promise<void>;
   selectWorktree(path: string): Promise<void>;
   selectMode(mode: WorkbenchMode): Promise<void>;
   openPr(prNumber: number): Promise<void>;
@@ -38,8 +38,8 @@ export interface Workbench {
  * the reviewer's own navigation always wins over a load that is still in flight.
  */
 export function useWorkbench(store: Store, api: GanderApi): Workbench {
-  const activeMode = shallowRef<WorkbenchMode>("explorer");
-  const modeBeforeSettings = shallowRef<Exclude<WorkbenchMode, "settings">>("explorer");
+  const activeMode = shallowRef<WorkbenchMode>("pulls");
+  const modeBeforeSettings = shallowRef<Exclude<WorkbenchMode, "settings">>("pulls");
   const settingsCategory = shallowRef<SettingsCategory>("workbench");
   const unconfigured = shallowRef(false);
 
@@ -68,21 +68,10 @@ export function useWorkbench(store: Store, api: GanderApi): Workbench {
     await store.loadRepos();
   }
 
-  function landIn(mode: LocalMode, keepChosenMode: boolean): void {
-    // The reviewer went somewhere else while the load was in flight: remember where this
-    // target landed, so closing Settings returns to it, and leave them where they are.
-    if (keepChosenMode && activeMode.value !== "explorer") {
-      modeBeforeSettings.value = mode;
-      return;
-    }
-    activeMode.value = mode;
-  }
-
   async function openLocalTarget(
     path: string,
     mode: LocalMode,
     contextError: string | null,
-    keepChosenMode = false,
   ): Promise<void> {
     await store.openLocal(path);
     const localError = store.error;
@@ -90,7 +79,7 @@ export function useWorkbench(store: Store, api: GanderApi): Workbench {
     store.error = errors.length ? errors.join("\n") : null;
     if (localError) return;
     store.showLocalSurface(mode);
-    landIn(mode, keepChosenMode);
+    activeMode.value = mode;
   }
 
   async function openExternalTarget(target: OpenTarget): Promise<void> {
@@ -110,19 +99,14 @@ export function useWorkbench(store: Store, api: GanderApi): Workbench {
     } else activeMode.value = "pulls";
   }
 
-  /**
-   * `keepChosenMode` is for the repository opened at launch: that load finishes long after
-   * the window is usable, and it must not drag the reviewer out of a view they opened
-   * while it was still working.
-   */
-  async function selectRepo(repoId: string, { keepChosenMode = false } = {}): Promise<void> {
+  async function selectRepo(repoId: string): Promise<void> {
     await store.selectRepo(repoId);
     const contextError = store.error;
     if (!store.targetWorktreePath) {
-      landIn("explorer", keepChosenMode);
+      activeMode.value = "explorer";
       return;
     }
-    await openLocalTarget(store.targetWorktreePath, "explorer", contextError, keepChosenMode);
+    await openLocalTarget(store.targetWorktreePath, "explorer", contextError);
   }
 
   /** Register a repository from a folder on disk, and open its checkout. `repoId` names the one the reviewer is being asked to locate. */
@@ -188,7 +172,9 @@ export function useWorkbench(store: Store, api: GanderApi): Workbench {
     }
 
     const firstRepo = store.repos[0];
-    if (firstRepo) await selectRepo(firstRepo.repoId, { keepChosenMode: true });
+    // Loading the initial repository must not switch away from Pull Requests or from
+    // a view the reviewer selected while startup was still in flight.
+    if (firstRepo) await store.selectRepo(firstRepo.repoId);
   }
 
   // The main process can name a target at any time — at launch, and again whenever


### PR DESCRIPTION
Gander now opens with Pull Requests selected and loads the initial repository's PR list, including after closing the app from Explorer or Current Diff. Explicit CLI targets still open the requested review or checkout.

Startup no longer opens a local Explorer surface in the background. Removed the obsolete startup mode-preservation option and updated the worktree test helper to wait for repository context.

Validation: typecheck, 449 unit tests, and 24 Electron end-to-end tests. The new startup regression test failed against the old behavior and covers fresh launch plus reopening after both other views. Updated docs/STATE.md.
