### PR TITLE
Add expand and collapse all notes button

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -59,6 +59,9 @@ blockers from active work. Work completed in one exchange can move directly
 from `open` to `addressed`.
 The notes drawer lets the reviewer correct note text or explicitly change a
 note's state when the recorded workflow state needs correcting.
+Its toolbar can expand or collapse all notes, including notes hidden by the status
+filter. Individual disclosure choices survive refreshes and status changes while
+the drawer stays open.
 Each note also has an immutable number scoped to its pull request, shown in the
 drawer and returned over MCP so the reviewer and agent can both refer to "Note
 4". The service keeps a separate global id for writes and incremental cursors.

--- a/packages/app/e2e/note-lifecycle.spec.ts
+++ b/packages/app/e2e/note-lifecycle.spec.ts
@@ -136,6 +136,32 @@ test("lets the reviewer edit a note and change its status", async ({ world }) =>
   }
 });
 
+test("expands and collapses all notes from either dock", async ({ world }) => {
+  const repository = await world.addRepository({ repoId: "acme/note-disclosure" });
+  const app = await world.launch();
+  const review = new ReviewDriver(app.page);
+  await review.open(repository.title);
+  await review.addNote("QA: first disclosure note");
+  await app.page.getByRole("complementary", { name: "Notes" }).getByRole("button", { name: "Add note (N)" }).click();
+  const input = app.page.getByPlaceholder("What needs answering or changing here?");
+  await input.fill("QA: second disclosure note");
+  await input.press("Enter");
+  await expect(input).toHaveCount(0);
+  await review.openNotes();
+  const drawer = app.page.getByRole("complementary", { name: "Notes" });
+  const bodies = drawer.locator("[data-note-body]");
+  await expect(bodies).toHaveCount(2);
+  for (const dock of ["right", "bottom"]) {
+    if (dock === "bottom") await drawer.getByRole("button", { name: "Dock notes below the diff" }).click();
+    await drawer.getByRole("button", { name: "Collapse all notes" }).click();
+    for (const body of await bodies.all()) await expect(body).toBeHidden();
+    const expand = drawer.getByRole("button", { name: "Expand all notes" });
+    await expand.focus();
+    await expand.press("Enter");
+    for (const body of await bodies.all()) await expect(body).toBeVisible();
+  }
+});
+
 test("keeps note controls fixed and reveals a note's reviewed file in the tree", async ({ world }) => {
   const repository = await world.addRepository({
     repoId: "acme/note-navigation",

--- a/packages/app/src/renderer/src/components/NoteItem.vue
+++ b/packages/app/src/renderer/src/components/NoteItem.vue
@@ -36,9 +36,7 @@ const editInput = useTemplateRef<HTMLTextAreaElement>("editInput");
 
 const deleteDetail = "The note will be removed from the review. This cannot be undone.";
 
-// A keyed note instance survives service refreshes, so a reviewer's disclosure
-// choice remains stable when the Note object is replaced.
-const expanded = shallowRef(props.note.state === "open" || props.note.state === "in_progress");
+const expanded = defineModel<boolean>("expanded", { required: true });
 const bodyId = computed(() => `note-body-${props.note.id}`);
 const numberId = computed(() => `note-number-${props.note.id}`);
 const titleId = computed(() => `note-title-${props.note.id}`);

--- a/packages/app/src/renderer/src/components/NotesDrawer.test.ts
+++ b/packages/app/src/renderer/src/components/NotesDrawer.test.ts
@@ -76,6 +76,31 @@ describe("NotesDrawer", () => {
     collapsedDirs.clear();
   });
 
+  it("toggles all notes, including filtered notes, and follows individual disclosure", async () => {
+    const wrapper = mount(NotesDrawer, { props: { store: store(notes), dock: "right" } });
+    await wrapper.get("button[aria-label='Collapse all notes']").trigger("click");
+    expect(wrapper.findAll("[data-note-id] button[aria-expanded]").map((button) => button.attributes("aria-expanded")))
+      .toEqual(["false", "false"]);
+
+    await wrapper.get("select").setValue("addressed");
+    await wrapper.get("button[aria-label='Expand all notes']").trigger("click");
+    await wrapper.get("select").setValue("all");
+    expect(wrapper.findAll("[data-note-id] button[aria-expanded]").map((button) => button.attributes("aria-expanded")))
+      .toEqual(["true", "true"]);
+
+    await wrapper.get("button[aria-label='Collapse note 1']").trigger("click");
+    await wrapper.get("button[aria-label='Collapse note 2']").trigger("click");
+    expect(wrapper.find("button[aria-label='Expand all notes']").exists()).toBe(true);
+    await wrapper.get("button[aria-label='Expand note 1']").trigger("click");
+    expect(wrapper.find("button[aria-label='Collapse all notes']").exists()).toBe(true);
+
+    await wrapper.setProps({ store: store(notes.map((note) => ({ ...note }))) });
+    expect(wrapper.get("button[aria-label='Expand note 2']").attributes("aria-expanded")).toBe("false");
+    await wrapper.setProps({ store: store([]) });
+    expect(wrapper.find("button[aria-label='Collapse all notes']").exists()).toBe(false);
+    expect(wrapper.find("button[aria-label='Expand all notes']").exists()).toBe(false);
+  });
+
   it("offers add actions in the empty state", async () => {
     const wrapper = mount(NotesDrawer, { props: { store: store([]), dock: "right" } });
 

--- a/packages/app/src/renderer/src/components/NotesDrawer.vue
+++ b/packages/app/src/renderer/src/components/NotesDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, shallowRef } from "vue";
+import { computed, reactive, shallowRef, watch } from "vue";
 import type { Note, NoteState } from "@gander/shared";
 import { MessageSquare, PanelBottom, PanelRight, Plus, X } from "@lucide/vue";
 import type { Store } from "../store.js";
@@ -23,6 +23,26 @@ const noteDraft = defineModel<string>("noteDraft", { default: "" });
 const emit = defineEmits<{ close: []; dock: ["right" | "bottom"]; addNote: []; closeNote: [] }>();
 
 const notes = computed(() => props.store.view?.notes ?? []);
+// Disclosure belongs to the drawer so bulk actions include notes hidden by a filter.
+// Keep each choice stable across status changes and service refreshes.
+const expandedNotes = reactive(new Map<number, boolean>());
+watch(notes, (current) => {
+  const ids = new Set(current.map((note) => note.id));
+  for (const id of expandedNotes.keys()) {
+    if (!ids.has(id)) expandedNotes.delete(id);
+  }
+  for (const note of current) {
+    if (!expandedNotes.has(note.id)) {
+      expandedNotes.set(note.id, note.state === "open" || note.state === "in_progress");
+    }
+  }
+}, { immediate: true });
+const anyExpanded = computed(() => notes.value.some((note) => expandedNotes.get(note.id)));
+function toggleAll(): void {
+  const expanded = !anyExpanded.value;
+  for (const note of notes.value) expandedNotes.set(note.id, expanded);
+}
+
 const statusFilter = shallowRef<NoteStatusFilter>("all");
 const statusCounts = computed<Record<NoteStatusFilter, number>>(() => ({
   all: notes.value.length,
@@ -140,6 +160,8 @@ async function copyAll(): Promise<void> {
       v-model="statusFilter"
       :counts="statusCounts"
       :copied-all="copiedAll"
+      :any-expanded="anyExpanded"
+      @toggle-all="toggleAll"
       @copy-all="copyAll"
       @add-note="emit('addNote')"
     />
@@ -163,6 +185,8 @@ async function copyAll(): Promise<void> {
         <NoteItem
           v-else
           :note="row.note"
+          :expanded="expandedNotes.get(row.note.id) ?? false"
+          @update:expanded="expandedNotes.set(row.note.id, $event)"
           :current="row.note.path === store.selectedPath"
           :copied="copiedNoteId === row.note.id"
           :update-note="store.updateNote"

--- a/packages/app/src/renderer/src/components/NotesToolbar.vue
+++ b/packages/app/src/renderer/src/components/NotesToolbar.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type { NoteState } from "@gander/shared";
-import { ChevronDown, Copy, ListFilter, Plus } from "@lucide/vue";
+import { ChevronDown, ChevronsDownUp, ChevronsUpDown, Copy, ListFilter, Plus } from "@lucide/vue";
 
 export type NoteStatusFilter = "all" | NoteState;
 
 const props = defineProps<{
   counts: Record<NoteStatusFilter, number>;
   copiedAll: boolean;
+  anyExpanded: boolean;
 }>();
 const filter = defineModel<NoteStatusFilter>({ required: true });
-defineEmits<{ addNote: []; copyAll: [] }>();
+defineEmits<{ addNote: []; copyAll: []; toggleAll: [] }>();
 
 const options = computed<{ value: NoteStatusFilter; label: string }[]>(() => [
   { value: "all", label: `All statuses (${props.counts.all})` },
@@ -32,6 +33,15 @@ const options = computed<{ value: NoteStatusFilter; label: string }[]>(() => [
     </label>
 
     <div class="toolbar-actions">
+      <button
+        v-if="counts.all > 0"
+        type="button"
+        :aria-label="anyExpanded ? 'Collapse all notes' : 'Expand all notes'"
+        :title="anyExpanded ? 'Collapse all notes' : 'Expand all notes'"
+        @click="$emit('toggleAll')"
+      >
+        <component :is="anyExpanded ? ChevronsDownUp : ChevronsUpDown" :size="14" aria-hidden="true" />
+      </button>
       <button
         v-if="counts.all > 0"
         type="button"
@@ -88,7 +98,7 @@ const options = computed<{ value: NoteStatusFilter; label: string }[]>(() => [
 }
 .toolbar-actions button:hover { border-color: var(--accent); color: var(--accent); }
 
-@container notes (max-width: 330px) {
+@container notes (max-width: 380px) {
   .toolbar-actions button { width: 26px; justify-content: center; padding: 0; }
   .toolbar-actions span { display: none; }
 }


### PR DESCRIPTION
Adds an Expand all / Collapse all button to the notes toolbar. If any note is expanded, the button collapses every note; otherwise it expands them all, including notes hidden by the status filter. Individual toggles still work, and disclosure choices survive refreshes and status changes while the drawer stays open.

The drawer owns disclosure state and passes it to each note. The compact toolbar keeps its existing accessible button and focus styles, with icon-only actions at narrow widths.

Validation: typecheck and 450 unit tests pass. All 25 Electron scenarios pass across the full run and focused rerun after correcting the new test's Add note locator. Coverage includes both docks, keyboard activation, filtering, mixed disclosure states, and refreshes.
