### PR TITLE
Resolve and reopen review notes through MCP

### DIFF
--- a/.agents/skills/review-with-gander/SKILL.md
+++ b/.agents/skills/review-with-gander/SKILL.md
@@ -72,12 +72,26 @@ bin/mcp call mark_note_addressed id=NOTE_ID commitRef=COMMIT_SHA summary="WHAT C
 
 Discuss the note with the reviewer in the active agent session. Only mark it
 addressed after the work is complete, and use `summary` for a concise durable
-record of what changed. Only the reviewer resolves a note after re-reviewing the
-file; the MCP contract has no reply tool.
+record of what changed. Resolution follows the reviewer's decision: they can re-review in the app or
+explicitly ask an agent to resolve the note. On that explicit instruction, use:
+
+```bash
+bin/mcp call resolve_note id=NOTE_ID
+```
+
+To reopen a note on explicit reviewer direction:
+
+```bash
+bin/mcp call reopen_note id=NOTE_ID
+```
+
+Both tools use the global id, preserve text, context, and outcome, and clear the
+in-progress note. Repeated calls succeed. Addressed still records completed work;
+it does not imply reviewer acceptance. The MCP contract has no reply tool.
 
 ## Diagnose the bridge
 
-- `bin/mcp check` verifies health, authentication, MCP negotiation, and the three
+- `bin/mcp check` verifies health, authentication, MCP negotiation, and the five
   required tools.
 - `bin/mcp tools` lists the live contract.
 - `bin/mcp tui` opens MCP Inspector's terminal UI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,10 +148,12 @@ passing over one leaves the reader on the file they were already reading.
 claims work that spans time over MCP) → `addressed` (agent records the outcome,
 with an optional commit ref) → `resolved` (reviewer re-checks the file). Work
 completed in one exchange can move directly from `open` to `addressed`. An
-in-progress note can name the reviewer decision blocking it. Resolution is
-always the reviewer's act; no MCP tool may resolve anything. The MCP contract is
-deliberately three tools —
-`get_review_notes`, `mark_note_in_progress`, and `mark_note_addressed`. Agents
+in-progress note can name the reviewer decision blocking it. Resolution requires
+the reviewer's decision: they can re-check in the app or
+explicitly direct an agent to use `resolve_note`. The agent can also use
+`reopen_note` on explicit reviewer direction. Addressed remains distinct from
+resolved. The MCP contract includes `get_review_notes`, `mark_note_in_progress`,
+`mark_note_addressed`, `resolve_note`, and `reopen_note`. Agents
 discuss notes with the reviewer in their active session; MCP carries the
 reviewer's notes and the durable work state. Agents have `git` and `gh` for code.
 Keep the contract small.

--- a/DEVSTACK.md
+++ b/DEVSTACK.md
@@ -238,18 +238,37 @@ claude mcp add --transport http gander "$GANDER_SERVICE_URL/mcp" \
   --header "Authorization: Bearer $GANDER_TOKEN"
 ```
 
-Run it in the repository being reviewed, not in this one. Three tools appear:
+Run it in the repository being reviewed, not in this one. Five tools appear:
 
 | Tool | Purpose |
 |------|---------|
 | `get_review_notes` | Notes for a repo + branch (or pull request number), with a PR-scoped conversation number, global tool-call id, captured source, and counts for every state; `since` accepts a last-seen global id |
 | `mark_note_in_progress` | Claims a note; its optional note records why work is waiting on the reviewer |
 | `mark_note_addressed` | Records the outcome with a required summary and an optional commit ref |
+| `resolve_note` | Resolves a note by global id on explicit reviewer direction |
+| `reopen_note` | Returns a note to open by global id on explicit reviewer direction |
 
-Discuss notes in the active agent session. Nothing over MCP replies to or resolves
-a note. Refer to the PR-scoped `number` in that discussion; pass the separate
-global `id` to mutation tools. Resolution stays the reviewer's act, made by
-re-reviewing the file in the app.
+Discuss notes in the active agent session. Record an answer durably with
+`mark_note_addressed` and its summary; MCP has no separate reply thread.
+Addressed means work completed. Resolved means the reviewer accepted or closed
+it, either in the app or by explicitly directing an agent to use `resolve_note`.
+Refer to the PR-scoped `number` in discussion; pass the global `id` to mutations.
+Both new tools accept any current state and succeed on repeated calls. They keep
+the text, captured source context, summary, and commit ref, clear the in-progress
+note, and leave file checkoffs alone. Reopening retains the outcome in storage;
+`get_review_notes` exposes outcomes only for addressed and resolved notes.
+
+```bash
+bin/mcp call resolve_note id=NOTE_ID
+bin/mcp call reopen_note id=NOTE_ID
+```
+
+Reading notes (including resolved notes), recording answers, resolving, and
+reopening are available through MCP. Creating, editing the text of, and deleting
+notes remain HTTP/app operations; there is no separate reply endpoint. These
+operations are outside the read/answer/resolve workflow. The MCP tools use the
+existing connection authentication and avoid separate raw API calls for these
+review actions; they do not change authentication prompts at connection startup.
 
 ## Config precedence
 

--- a/bin/mcp
+++ b/bin/mcp
@@ -140,7 +140,7 @@ cmd_check() {
     const fs = require("node:fs");
     const payload = JSON.parse(fs.readFileSync(0, "utf8"));
     const names = (payload.result?.tools ?? []).map((tool) => tool.name).sort();
-    const required = ["get_review_notes", "mark_note_in_progress", "mark_note_addressed"];
+    const required = ["get_review_notes", "mark_note_in_progress", "mark_note_addressed", "resolve_note", "reopen_note"];
     const missing = required.filter((name) => !names.includes(name));
     if (missing.length > 0) {
       console.error("Missing core MCP tools: " + missing.join(", "));

--- a/bin/mcp.test.ts
+++ b/bin/mcp.test.ts
@@ -60,7 +60,7 @@ if [[ " $* " == *" --format json "* ]]; then
   if [[ -n "\${MCP_TEST_TOOLS_RESPONSE:-}" ]]; then
     printf '%s\n' "$MCP_TEST_TOOLS_RESPONSE"
   else
-    printf '%s\n' '{"result":{"tools":[{"name":"mark_note_addressed"},{"name":"mark_note_in_progress"},{"name":"get_review_notes"}]}}'
+    printf '%s\n' '{"result":{"tools":[{"name":"mark_note_addressed"},{"name":"mark_note_in_progress"},{"name":"get_review_notes"},{"name":"resolve_note"},{"name":"reopen_note"}]}}'
   fi
 else
   printf '%s\n' '{"ok":true}'
@@ -83,7 +83,7 @@ describe.skipIf(platform === "win32")("bin/mcp", () => {
 
     expect(result.status, result.output).toBe(0);
     expect(result.output).toContain("MCP OK");
-    expect(result.output).toContain("get_review_notes, mark_note_addressed, mark_note_in_progress");
+    expect(result.output).toContain("get_review_notes, mark_note_addressed, mark_note_in_progress, reopen_note, resolve_note");
     expect(result.output).not.toContain("test-token");
 
     const args = readFileSync(argsFile, "utf8");
@@ -113,7 +113,7 @@ describe.skipIf(platform === "win32")("bin/mcp", () => {
     const result = run("check");
 
     expect(result.status).toBe(1);
-    expect(result.output).toContain("Missing core MCP tools: mark_note_in_progress, mark_note_addressed");
+    expect(result.output).toContain("Missing core MCP tools: mark_note_in_progress, mark_note_addressed, resolve_note, reopen_note");
     expect(result.output).toContain("tool contract is invalid");
   });
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -53,7 +53,9 @@ milestone boundary.
 Pressing `n` over a file captures a note against it, stamped with the line
 being read. Notes carry four states: `open` when captured, `in_progress` when an
 agent claims work that spans time, `addressed` when the agent records its
-outcome, and `resolved` when the reviewer re-checks the file. A claimed note can
+outcome, and `resolved` when the reviewer re-checks the file or explicitly directs
+an agent to resolve it over MCP. An agent can also reopen a note on explicit
+reviewer direction. A claimed note can
 record the reviewer decision blocking it, and the notes drawer separates those
 blockers from active work. Work completed in one exchange can move directly
 from `open` to `addressed`.

--- a/packages/service/contract.json
+++ b/packages/service/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.1",
+  "version": "0.9.0",
   "routes": [
     "DELETE /api/reviews/:repoId/:prNumber/notes/:id",
     "DELETE /mcp",
@@ -713,7 +713,7 @@
     },
     {
       "name": "mark_note_addressed",
-      "description": "Record the outcome after an open or in-progress note has been acted on, or correct the outcome while it remains addressed. A code change can name its commit; an answered question has no commit. This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
+      "description": "Record the outcome after an open or in-progress note has been acted on, or correct the outcome while it remains addressed. A code change can name its commit; an answered question has no commit. This records completed work, not reviewer acceptance. Use resolve_note only when the reviewer explicitly asks to resolve it.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -757,6 +757,44 @@
             "description": "Why this work is waiting on the reviewer.",
             "type": "string",
             "minLength": 1
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "reopen_note",
+      "description": "Reopen a note only when the reviewer explicitly asks, returning it to open for further work. Accepts any current state; repeating the action succeeds. Preserves text, captured context, and outcome; clears the in-progress note. Does not change file checkoffs.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Global note id from get_review_notes, not its pull-request-scoped number."
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
+      "name": "resolve_note",
+      "description": "Resolve a note only when the reviewer explicitly asks. Addressed means work completed; resolved means the reviewer has accepted or closed it. Accepts any current state; repeating the action succeeds. Preserves text, captured context, and outcome; clears the in-progress note. Does not change file checkoffs.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Global note id from get_review_notes, not its pull-request-scoped number."
           }
         },
         "required": [

--- a/packages/service/src/mcp.test.ts
+++ b/packages/service/src/mcp.test.ts
@@ -49,10 +49,57 @@ afterEach(async () => {
 });
 
 describe("MCP endpoint", () => {
-  it("offers only the note pickup and completion tools", async () => {
+  it("offers the note workflow tools", async () => {
     const client = await connect();
     const names = (await client.listTools()).tools.map((t) => t.name).sort();
-    expect(names).toEqual(["get_review_notes", "mark_note_addressed", "mark_note_in_progress"]);
+    expect(names).toEqual(["get_review_notes", "mark_note_addressed", "mark_note_in_progress", "reopen_note", "resolve_note"]);
+    await client.close();
+  });
+
+  it.each(["open", "in_progress", "addressed", "resolved"] as const)(
+    "resolves and reopens a %s note by global id without losing authored content",
+    async (state) => {
+      const other = storage.addNote("acme/other", 8, { path: null, line: null, text: "Unrelated", headSha: null, sourceContext: null });
+      const note = storage.addNote("acme/atlas", 7, {
+        path: "a.ts", line: 2, text: "Why this choice?", headSha: "captured-sha",
+        sourceContext: { startLine: 1, lines: ["before", "selected", "after"] },
+      });
+      expect(note.id).not.toBe(note.number);
+      storage.markNoteAddressed(note.id, { summary: "The reviewer chose A", commitRef: "abc123" });
+      storage.updateNote("acme/atlas", 7, note.id, { state });
+      if (state === "in_progress") storage.markNoteInProgress(note.id, { note: "Decision needed" });
+      const before = storage.getNote(note.id)!;
+      const client = await connect();
+      for (const [tool, target, verb] of [
+        ["reopen_note", "open", "reopened"],
+        ["resolve_note", "resolved", "resolved"],
+        ["resolve_note", "resolved", "resolved"],
+        ["reopen_note", "open", "reopened"],
+        ["reopen_note", "open", "reopened"],
+      ] as const) {
+        // Restore the original state to cover resolve from every state as well.
+        if (tool === "resolve_note" && storage.getNote(note.id)?.state === "open") {
+          storage.updateNote("acme/atlas", 7, note.id, { state });
+        }
+        const result = await client.callTool({ name: tool, arguments: { id: note.id } });
+        expect(result.isError).not.toBe(true);
+        expect(textOf(result as { content?: unknown })).toBe(`Note ${note.number} ${verb}.`);
+        expect(storage.getNote(note.id)).toEqual({ ...before, state: target, inProgressNote: null });
+      }
+      expect(storage.getNote(other.id)).toEqual(other);
+      expect(storage.getReview("acme/atlas", 7).files).toEqual([]);
+      await client.close();
+    },
+  );
+
+  it.each(["resolve_note", "reopen_note"])("%s reports missing ids and rejects invalid ids", async (name) => {
+    const client = await connect();
+    const missing = await client.callTool({ name, arguments: { id: 999 } });
+    expect(missing.isError).toBe(true);
+    expect(textOf(missing as { content?: unknown })).toBe("Note id 999 does not exist.");
+    for (const id of [0, -1, 1.5, "1"]) {
+      expect((await client.callTool({ name, arguments: { id } })).isError).toBe(true);
+    }
     await client.close();
   });
 

--- a/packages/service/src/mcp.ts
+++ b/packages/service/src/mcp.ts
@@ -4,11 +4,9 @@ import { z } from "zod";
 import type { Storage } from "./storage.js";
 
 /**
- * The MCP contract is deliberately tiny: agents read the reviewer's notes, claim the
- * ones they start, and say when they have acted on one. Nothing here reads diffs, lists files, touches
- * checkoffs, or resolves a note — resolution is the reviewer's act alone, made in
- * the app by re-checking the file. Agents already have git and gh for code; this carries
- * only the reviewer's notes and their durable completion state.
+ * Agents read notes and record work outcomes. Explicit reviewer direction also lets
+ * them resolve or reopen notes. Git and gh remain the tools for reading code;
+ * MCP carries review notes and their durable state, without touching checkoffs.
  */
 export function buildMcpServer(storage: Storage, version: string): McpServer {
   const server = new McpServer({ name: "gander", version });
@@ -169,7 +167,7 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
       title: "Mark a review note addressed",
       description:
         "Record the outcome after an open or in-progress note has been acted on, or correct the outcome while it remains addressed. A code change can name its commit; an answered question has no commit. " +
-        "This does not resolve the note — the reviewer resolves it by re-reviewing the file.",
+        "This records completed work, not reviewer acceptance. Use resolve_note only when the reviewer explicitly asks to resolve it.",
       inputSchema: {
         id: z.number().int().positive().describe("Global note id from get_review_notes. Use its number when discussing the note with the reviewer."),
         commitRef: z.string().min(1).optional().describe("Commit that addressed it, when the outcome changed code."),
@@ -191,6 +189,27 @@ export function buildMcpServer(storage: Storage, version: string): McpServer {
       return { content: [{ type: "text", text: `Note ${marked.number} marked addressed.` }] };
     },
   );
+
+  for (const [name, state, title, description] of [
+    ["resolve_note", "resolved", "Resolve a review note",
+      "Resolve a note only when the reviewer explicitly asks. Addressed means work completed; resolved means the reviewer has accepted or closed it."],
+    ["reopen_note", "open", "Reopen a review note",
+      "Reopen a note only when the reviewer explicitly asks, returning it to open for further work."],
+  ] as const) {
+    server.registerTool(name, {
+      title,
+      description: description + " Accepts any current state; repeating the action succeeds. Preserves text, captured context, and outcome; clears the in-progress note. Does not change file checkoffs.",
+      inputSchema: {
+        id: z.number().int().positive().describe("Global note id from get_review_notes, not its pull-request-scoped number."),
+      },
+    }, async ({ id }) => {
+      const updated = storage.setNoteState(id, state);
+      if (updated === null) {
+        return { content: [{ type: "text", text: `Note id ${id} does not exist.` }], isError: true };
+      }
+      return { content: [{ type: "text", text: `Note ${updated.number} ${state === "open" ? "reopened" : "resolved"}.` }] };
+    });
+  }
 
   return server;
 }

--- a/packages/service/src/storage.ts
+++ b/packages/service/src/storage.ts
@@ -65,6 +65,7 @@ export interface Storage {
   listNotes(repoId: string, prNumber: number): Note[];
   addNote(repoId: string, prNumber: number, input: NewNote): Note;
   updateNote(repoId: string, prNumber: number, id: number, input: UpdateNote): Note | null;
+  setNoteState(id: number, state: "open" | "resolved"): Note | null;
   deleteNote(repoId: string, prNumber: number, id: number): boolean;
   close(): void;
 }
@@ -268,6 +269,15 @@ export function openStorage(dbPath: string): Storage {
         .run(...values, id, rid).changes;
       if (changed === 0) return null;
       return rowToNote(db.prepare(`SELECT ${NOTE_COLUMNS} FROM notes WHERE id = ?`).get(id) as NoteRow);
+    },
+
+    setNoteState(id, state) {
+      const review = db.prepare(`
+        SELECT reviews.repo_id, reviews.pr_number FROM reviews
+        JOIN notes ON notes.review_id = reviews.id WHERE notes.id = ?
+      `).get(id) as { repo_id: string; pr_number: number } | undefined;
+      if (review === undefined) return null;
+      return this.updateNote(review.repo_id, review.pr_number, id, { state });
     },
 
     deleteNote(repoId, prNumber, id) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
  *
  * Not the app's release version: releases happen far more often than the contract moves.
  */
-export const SERVICE_VERSION = "0.8.1";
+export const SERVICE_VERSION = "0.9.0";
 
 export const FileStatusSchema = z.enum(["A", "M", "D", "R"]);
 export type FileStatus = z.infer<typeof FileStatusSchema>;


### PR DESCRIPTION
Agents can now carry out an explicit reviewer decision to resolve or reopen a note through MCP, using its global id. The new `resolve_note` and `reopen_note` tools reuse the HTTP state-update behavior, preserve text, captured context and outcome, clear the in-progress note, and leave checkoffs unchanged. Repeated calls succeed. `mark_note_addressed` remains a separate work-completion action.

Updated tool descriptions, agent guidance, workflow docs, the local MCP checker, and the service contract (0.9.0). Reading notes and recording answers already work through MCP; note creation, text editing and deletion remain HTTP/app operations. There is no separate reply endpoint. Connection authentication is unchanged.

Validation: typecheck; 456 unit tests (the corrected CLI fixture was rerun after the full suite); all 25 Electron end-to-end tests; real MCP client against the checkout-local service exercised addressed → resolved → open, repeat resolve, missing id and outcome preservation. Disposable local QA notes were removed. `bin/mcp check` confirms all five tools. No hosted state or agent authentication configuration was changed.
